### PR TITLE
Add a more comprehensive pre-install check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ release:
 	git push --tags
 
 install:
-	which docker
+	bin/check
 	docker pull codeclimate/codeclimate:latest
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	install -m 0755 codeclimate-wrapper $(DESTDIR)$(PREFIX)/bin/codeclimate

--- a/bin/check
+++ b/bin/check
@@ -1,0 +1,17 @@
+#!/bin/sh
+command -v docker > /dev/null 2>&1 || {
+  echo "Unable to find \`docker' on your \$PATH, is it installed?" >&2
+  exit 1
+}
+
+docker version | grep -Fq "Server version" || {
+  echo "Unable to run \`docker version', the docker daemon may not be running" >&2
+
+  if command -v boot2docker > /dev/null 2>&1; then
+    echo "Please ensure \`boot2docker up' succeeds and you've run \`boot2docker shellinit' in this shell" >&2
+  else
+    echo "Please ensure \`docker version' succeeds and try again"
+  fi
+
+  exit 1
+}


### PR DESCRIPTION
This extends our pre-install check (formerly just `which docker`) to also check
for an inability to talk to the docker server and output a more informative
error including boot2docker-specific instructions in that case.

/cc @codeclimate/review