### PR TITLE
patch writes to .codeclimate.yml file to always set the file owner as the root directory user

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    codeclimate (0.0.5)
+    codeclimate (0.0.7)
       activesupport (~> 4.2, >= 4.2.1)
       codeclimate-yaml (~> 0.0, >= 0.0.2)
       faraday (~> 0.9.1)

--- a/lib/cc/analyzer/filesystem.rb
+++ b/lib/cc/analyzer/filesystem.rb
@@ -18,6 +18,11 @@ module CC
         File.read(path_for(path))
       end
 
+      def write_path(path, content)
+        File.write(path_for(path), content)
+        File.chown(root_uid, root_gid, path_for(path))
+      end
+
       def file_paths
         Dir.chdir(@root) do
           Dir["**/*.*"].select { |path| File.file?(path) }.sort
@@ -40,8 +45,22 @@ module CC
         end
       end
 
+      private
+
       def path_for(path)
         File.join(@root, path)
+      end
+
+      def root_uid
+        root_stat.uid
+      end
+
+      def root_gid
+        root_stat.gid
+      end
+
+      def root_stat
+        @root_stat ||= File.stat(@root)
       end
     end
   end

--- a/lib/cc/cli/engines/engine_command.rb
+++ b/lib/cc/cli/engines/engine_command.rb
@@ -17,13 +17,11 @@ module CC
         end
 
         def yaml_content
-          File.read(filesystem.path_for(CODECLIMATE_YAML)).freeze
+          filesystem.read_path(CODECLIMATE_YAML).freeze
         end
 
         def update_yaml
-          File.open(filesystem.path_for(CODECLIMATE_YAML), "w") do |f|
-            f.write(parsed_yaml.to_yaml)
-          end
+          filesystem.write_path(CODECLIMATE_YAML, parsed_yaml.to_yaml)
         end
 
         def engine_present_in_yaml?

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -30,7 +30,7 @@ module CC
 
         config["exclude_paths"] = exclude_paths(AUTO_EXCLUDE_PATHS)
 
-        File.write(filesystem.path_for(CODECLIMATE_YAML), config.to_yaml)
+        filesystem.write_path(CODECLIMATE_YAML, config.to_yaml)
       end
 
       def exclude_paths(paths)

--- a/spec/cc/analyzer/filesystem_spec.rb
+++ b/spec/cc/analyzer/filesystem_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 module CC::Analyzer
   describe Filesystem do
-    describe "#exists?" do
+    describe "#exist?" do
       it "returns true for files that exist" do
         root = Dir.mktmpdir
         File.write(File.join(root, "foo.rb"), "")
@@ -64,6 +64,17 @@ module CC::Analyzer
 
         filesystem.read_path("foo.rb").must_equal("Foo")
         filesystem.read_path("bar.rb").must_equal("Bar")
+      end
+    end
+
+    describe "#write_path" do
+      it "writes to the filesystem, given a path to a file and content" do
+        filesystem = Filesystem.new(Dir.mktmpdir)
+
+        filesystem.write_path("foo.js", "Hello world")
+
+        filesystem.exist?("foo.js").must_equal(true)
+        filesystem.read_path("foo.js").must_equal("Hello world")
       end
     end
 

--- a/spec/cc/cli/command_spec.rb
+++ b/spec/cc/cli/command_spec.rb
@@ -5,7 +5,7 @@ module CC::CLI
     describe "#require_codeclimate_yml" do
       it "exits if the file doesn't exist" do
         Dir.chdir(Dir.mktmpdir) do
-          stdoit, stderr = capture_io do
+          _, stderr = capture_io do
             lambda { Command.new.require_codeclimate_yml }.must_raise SystemExit
           end
 


### PR DESCRIPTION
@codeclimate/review This PR updates the `init` and `update_yaml` commands to set the `.codeclimate.yml` file `uid` and `gid` to match that of the root directory. 

After some experimenting, I found stubbing the `File.chown()` call in testing somewhat unfeasible. Meaningful tests seemed to require execution with `sudo` prefixed to `bundle exec rake`, which we probably would prefer to avoid. Happy to hear other thoughts though.