### PR TITLE
Use find to walk directories in init

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,10 @@
+---
 engines:
   rubocop:
     enabled: true
 ratings:
   paths:
   - "**.rb"
+exclude_paths:
+- config/**/*
+- spec/**/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,3 @@ DEPENDENCIES
   minitest-reporters
   mocha
   rack-test
-
-BUNDLED WITH
-   1.10.3

--- a/lib/cc/analyzer/filesystem.rb
+++ b/lib/cc/analyzer/filesystem.rb
@@ -23,18 +23,8 @@ module CC
         File.chown(root_uid, root_gid, path_for(path))
       end
 
-      def file_paths
-        Dir.chdir(@root) do
-          Dir["**/*.*"].select { |path| File.file?(path) }.sort
-        end
-      end
-
-      def all
-        @files ||= Dir.chdir(@root) { Dir.glob("**/*") }
-      end
-
       def any?(&block)
-        all.any?(&block)
+        file_paths.any?(&block)
       end
 
       def files_matching(globs)
@@ -46,6 +36,12 @@ module CC
       end
 
       private
+
+      def file_paths
+        @file_paths ||= Dir.chdir(@root) do
+          `find . -type f`.strip.split("\n")
+        end
+      end
 
       def path_for(path)
         File.join(@root, path)

--- a/lib/cc/analyzer/filesystem.rb
+++ b/lib/cc/analyzer/filesystem.rb
@@ -40,7 +40,7 @@ module CC
       def file_paths
         @file_paths ||= Dir.chdir(@root) do
           `find . -type f -print0`.strip.split("\0").map do |path|
-            path.sub(/^\.//, "")
+            path.sub(/^\.\//, "")
           end
         end
       end

--- a/lib/cc/analyzer/filesystem.rb
+++ b/lib/cc/analyzer/filesystem.rb
@@ -39,7 +39,9 @@ module CC
 
       def file_paths
         @file_paths ||= Dir.chdir(@root) do
-          `find . -type f`.strip.split("\n")
+          `find . -type f -print0`.strip.split("\0").map do |path|
+            path.sub(/^\.//, "")
+          end
         end
       end
 

--- a/spec/cc/analyzer/filesystem_spec.rb
+++ b/spec/cc/analyzer/filesystem_spec.rb
@@ -77,28 +77,5 @@ module CC::Analyzer
         filesystem.read_path("foo.js").must_equal("Hello world")
       end
     end
-
-    describe "#file_paths" do
-      it "returns all regular files in the root" do
-        root = Dir.mktmpdir
-        Dir.mkdir(File.join(root, "foo"))
-        Dir.mkdir(File.join(root, "bar"))
-        File.write(File.join(root, "foo.rb"), "")
-        File.write(File.join(root, "foo", "foo.rb"), "")
-        File.write(File.join(root, "foo", "bar.rb"), "")
-        File.write(File.join(root, "bar", "foo.rb"), "")
-        File.write(File.join(root, "bar", "bar.rb"), "")
-
-        filesystem = Filesystem.new(root)
-
-        filesystem.file_paths.sort.must_equal([
-          "foo.rb",
-          "foo/foo.rb",
-          "foo/bar.rb",
-          "bar/foo.rb",
-          "bar/bar.rb",
-        ].sort)
-      end
-    end
   end
 end


### PR DESCRIPTION
* Existing `file_paths` method was unused... Removed it.
* Renamed `all` as `file_paths` and made it only emit files (not dirs)
* Shell out to `find` instead of using `Dir.glob`... Fixes issue where CTRL+C won't kill an in-process init.
* Exclude `config` and `spec` from analysis

/c @codeclimate/review 