### PR TITLE
Tweak plain text formatter

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -1,6 +1,5 @@
 module CC
   module Analyzer
-    autoload :Accumulator,        "cc/analyzer/accumulator"
     autoload :Config,             "cc/analyzer/config"
     autoload :Engine,             "cc/analyzer/engine"
     autoload :EngineClient,       "cc/analyzer/engine_client"

--- a/lib/cc/analyzer/formatters/formatter.rb
+++ b/lib/cc/analyzer/formatters/formatter.rb
@@ -2,7 +2,8 @@ module CC
   module Analyzer
     module Formatters
       class Formatter
-        def initialize(output = $stdout)
+        def initialize(filesystem, output = $stdout)
+          @filesystem = filesystem
           @output = output
         end
 

--- a/lib/cc/analyzer/formatters/plain_text_formatter.rb
+++ b/lib/cc/analyzer/formatters/plain_text_formatter.rb
@@ -37,7 +37,8 @@ module CC
 
             IssueSorter.new(file_issues).by_location.each do |issue|
               if location = issue["location"]
-                print(colorize(LocationDescription.new(location, ": "), :cyan))
+                source_buffer = @filesystem.source_buffer_for(location["path"])
+                print(colorize(LocationDescription.new(source_buffer, location, ": "), :cyan))
               end
 
               print(issue["description"])

--- a/lib/cc/analyzer/location_description.rb
+++ b/lib/cc/analyzer/location_description.rb
@@ -1,27 +1,23 @@
 module CC
   module Analyzer
     class LocationDescription
-      def initialize(location, suffix = "")
+      def initialize(source_buffer, location, suffix = "")
+        @source_buffer = source_buffer
         @location = location
         @suffix = suffix
       end
 
       def to_s
-        str = ""
-
         if location["lines"]
-          str << render_lines
-        elsif (positions = location["positions"])
-          str << render_position(positions["begin"])
-
-          if positions["end"]
-            str << "-"
-            str << render_position(positions["end"])
-          end
+          begin_line = location["lines"]["begin"]
+          end_line = location["lines"]["end"]
+        elsif location["positions"]
+          begin_line = position_to_line(location["positions"]["begin"])
+          end_line = position_to_line(location["positions"]["end"])
         end
 
+        str = render_lines(begin_line, end_line)
         str << suffix unless str.blank?
-
         str
       end
 
@@ -29,27 +25,20 @@ module CC
 
       attr_reader :location, :suffix
 
-      def render_lines
-        str = location["lines"]["begin"].to_s
-
-        if location["lines"]["end"] && location["lines"]["end"] != location["lines"]["begin"]
-          str << "-#{location["lines"]["end"]}"
+      def render_lines(begin_line, end_line)
+        if end_line != begin_line
+          "#{begin_line}-#{end_line}"
+        else
+          begin_line.to_s
         end
-
-        str
       end
 
-      def render_position(position)
-        str = ""
-
+      def position_to_line(position)
         if position["line"]
-          str << position["line"].to_s
-          str << ":#{position["column"]}" if position["column"]
-        elsif position["offset"]
-          str << position["offset"].to_s
+          position["line"]
+        else
+          @source_buffer.decompose_position(position["offset"]).first
         end
-
-        str
       end
     end
   end

--- a/lib/cc/analyzer/location_description.rb
+++ b/lib/cc/analyzer/location_description.rb
@@ -8,9 +8,10 @@ module CC
 
       def to_s
         str = ""
+
         if location["lines"]
           str << render_lines
-        elsif positions = location["positions"]
+        elsif (positions = location["positions"])
           str << render_position(positions["begin"])
 
           if positions["end"]
@@ -30,7 +31,11 @@ module CC
 
       def render_lines
         str = location["lines"]["begin"].to_s
-        str << "-#{location["lines"]["end"]}" if location["lines"]["end"]
+
+        if location["lines"]["end"] && location["lines"]["end"] != location["lines"]["begin"]
+          str << "-#{location["lines"]["end"]}"
+        end
+
         str
       end
 

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -79,7 +79,7 @@ module CC
       end
 
       def formatter
-        @formatter ||= Formatters::PlainTextFormatter.new
+        @formatter ||= Formatters::PlainTextFormatter.new(filesystem)
       end
 
       def path

--- a/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
@@ -4,7 +4,7 @@ module CC::Analyzer::Formatters
   describe PlainTextFormatter do
     describe "#write" do
       it "raises an error" do
-        formatter = PlainTextFormatter.new
+        formatter = PlainTextFormatter.new(Object.new)
         data = {"type" => "thing"}.to_json
 
         lambda { formatter.write(data) }.must_raise(RuntimeError, "Invalid type found: thing")
@@ -14,7 +14,7 @@ module CC::Analyzer::Formatters
     describe "#finished" do
       it "outputs a breakdown" do
         issue = Factory.sample_issue
-        formatter = PlainTextFormatter.new
+        formatter = PlainTextFormatter.new(::CC::Analyzer::Filesystem.new("."))
 
         stdout, stderr = capture_io do
           formatter.engine_running(OpenStruct.new(name: "cool_engine")) do
@@ -24,7 +24,7 @@ module CC::Analyzer::Formatters
           formatter.finished
         end
 
-        stdout.must_match("accumulator.rb (1 issue)")
+        stdout.must_match("config.rb (1 issue)")
         stdout.must_match("Missing top-level class documentation comment")
         stdout.must_match("[cool_engine]")
       end

--- a/spec/cc/analyzer/location_description_spec.rb
+++ b/spec/cc/analyzer/location_description_spec.rb
@@ -6,13 +6,13 @@ module CC::Analyzer
       it "adds the suffix" do
         location = { "lines" => { "begin" => 1, "end" => 3 } }
 
-        LocationDescription.new(location, "!").to_s.must_equal("1-3!")
+        LocationDescription.new(Object.new, location, "!").to_s.must_equal("1-3!")
       end
 
       it "with lines" do
         location = {"lines" => {"begin" => 1, "end" => 3}}
 
-        LocationDescription.new(location).to_s.must_equal("1-3")
+        LocationDescription.new(Object.new, location).to_s.must_equal("1-3")
       end
 
       it "with linecols" do
@@ -29,22 +29,23 @@ module CC::Analyzer
           }
         }
 
-        LocationDescription.new(location).to_s.must_equal("1:2-3:4")
+        LocationDescription.new(Object.new, location).to_s.must_equal("1-3")
       end
 
       it "with offsets" do
         location = {
           "positions" => {
             "begin" => {
-              "offset" => 111
+              "offset" => 1
             },
             "end" => {
-              "offset" => 122
+              "offset" => 5
             }
           }
         }
 
-        LocationDescription.new(location).to_s.must_equal("111-122")
+        source_buffer = SourceBuffer.new("foo.rb", "foo\nbar")
+        LocationDescription.new(source_buffer, location).to_s.must_equal("1-2")
       end
     end
   end

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -76,14 +76,10 @@ module Factory
       "categories" => ["Style"],
       "remediation_points" => 10,
       "location"=> {
-        "path" => "lib/cc/analyzer/accumulator.rb",
-        "begin" => {
-          "pos" => 32,
-          "line" => 3
-        },
-        "end"=> {
-          "pos" => 37,
-          "line" => 3
+        "path" => "lib/cc/analyzer/config.rb",
+        "lines" => {
+          "begin" => 32,
+          "end" => 40
         }
       }
     }


### PR DESCRIPTION
* Always display line numbers, not offsets in plain text formatter (offsets are incomprehensible to humans)
* Don't display the end line if same as the start line
* Various updates to conform with the SPEC

/c @codeclimate/review @GordonDiggs 