### PR TITLE
Add -dev flag to analyze command

### DIFF
--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -72,7 +72,7 @@ module CC
         @engines ||= config.engine_names.map do |engine_name|
           Engine.new(
             engine_name,
-            @dev_mode ? make_registry_entry(engine_name) : engine_registry[engine_name],
+            registry_entry(engine_name),
             path,
             engine_config(engine_name),
             SecureRandom.uuid
@@ -88,7 +88,15 @@ module CC
         ENV['CODE_PATH']
       end
 
-      def make_registry_entry(engine_name)
+      def registry_entry(engine_name)
+        if @dev_mode
+          make_dev_registry_entry(engine_name)
+        else
+          engine_registry[engine_name]
+        end
+      end
+
+      def make_dev_registry_entry(engine_name)
         {
           "image_name"=>"codeclimate/codeclimate-#{engine_name}:latest"
         }

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -35,6 +35,8 @@ module CC
         when '-f'
           @args.shift # throw out the -f
           @formatter = Formatters.resolve(@args.shift)
+        when '-dev'
+          @dev_mode = true
         end
       rescue Formatters::Formatter::InvalidFormatterError => e
         fatal(e.message)
@@ -70,7 +72,7 @@ module CC
         @engines ||= config.engine_names.map do |engine_name|
           Engine.new(
             engine_name,
-            engine_registry[engine_name],
+            @dev_mode ? make_registry_entry(engine_name) : engine_registry[engine_name],
             path,
             engine_config(engine_name),
             SecureRandom.uuid
@@ -84,6 +86,12 @@ module CC
 
       def path
         ENV['CODE_PATH']
+      end
+
+      def make_registry_entry(engine_name)
+        {
+          "image_name"=>"codeclimate/codeclimate-#{engine_name}:latest"
+        }
       end
 
     end

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -35,7 +35,7 @@ module CC
         when '-f'
           @args.shift # throw out the -f
           @formatter = Formatters.resolve(@args.shift)
-        when '-dev'
+        when '--dev'
           @dev_mode = true
         end
       rescue Formatters::Formatter::InvalidFormatterError => e
@@ -90,13 +90,13 @@ module CC
 
       def registry_entry(engine_name)
         if @dev_mode
-          make_dev_registry_entry(engine_name)
+          dev_registry_entry(engine_name)
         else
           engine_registry[engine_name]
         end
       end
 
-      def make_dev_registry_entry(engine_name)
+      def dev_registry_entry(engine_name)
         {
           "image_name"=>"codeclimate/codeclimate-#{engine_name}:latest"
         }


### PR DESCRIPTION
Adds `-dev` flag to analyze command. Allows for easy local testing with CLI during engine hacking. Steps to test your in-progress engine locally with the CLI now become:

1. Add the engine name to the `.codeclimate.yml` file in the project you wish to analyze
2. Run `codeclimate analyze -dev` in that directory

The CLI will look for `codecliamte/codeclimate-YOUR_ENGINE_NAME:latest` in the Docker registry.

![screenshot 2015-06-25 16 37 13](https://cloud.githubusercontent.com/assets/2878/8365058/b92d974a-1b58-11e5-8076-991f123a67f9.png)
