### PR TITLE
Remove image_id, rename image_name to image

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -1,6 +1,8 @@
 # This file lists all the engines available to be run for analysis.
 #
-# Each engine must have an `image_name` and `description`.
+# Each engine must have an `image` and `description`. The value in `image` will
+# be passed to `docker run` and so may be any value appropriate for that
+# (repo/name:tag, image id, etc).
 #
 # When a repo has files that match the `enable_regexps`, that engine will be
 # enabled by default in the codeclimate.yml file. That file will also have in it
@@ -8,8 +10,7 @@
 # which files should be rated.
 #
 rubocop:
-  image_name: codeclimate/codeclimate-rubocop
-  image_id: 41273519bce24e59685106ff3f4519abc20233fdaf46093576cefecc093b795f
+  image: codeclimate/codeclimate-rubocop
   description: A Ruby static code analyzer, based on the community Ruby style guide.
   community: false
   enable_regexps:
@@ -17,8 +18,7 @@ rubocop:
   default_ratings_paths:
     - "**.rb"
 gofmt:
-  image_name: codeclimate/codeclimate-gofmt
-  image_id: fe7b20a9eda6e0bd154fbbb289f0d18ff3ffc41d891cd3b2e5dbe7e015180396
+  image: codeclimate/codeclimate-gofmt
   description: gofmt
   community: true
   enable_regexps:
@@ -26,8 +26,7 @@ gofmt:
   default_ratings_paths:
     - "**.go"
 golint:
-  image_name: codeclimate/codeclimate-golint
-  image_id: cfde0099114d8b18bec8419d9ed359efac03069821cb967144b807d02ada1412
+  image: codeclimate/codeclimate-golint
   description: golint
   community: true
   enable_regexps:
@@ -35,8 +34,7 @@ golint:
   default_ratings_paths:
     - "**.go"
 govet:
-  image_name: codeclimate/codeclimate-govet
-  image_id: fe7690da7198c569a28b69189909eb4c1199d2987bf50ab5d3bbd20d83139489
+  image: codeclimate/codeclimate-govet
   description: govet
   community: true
   enable_regexps:
@@ -44,7 +42,7 @@ govet:
   default_ratings_paths:
     - "**.go"
 coffeelint:
-  image_name: codeclimate/codeclimate-coffeelint
+  image: codeclimate/codeclimate-coffeelint
   description: A style checker for CoffeeScript
   community: false
   enable_regexps:
@@ -52,8 +50,7 @@ coffeelint:
   default_ratings_paths:
     - "**.coffee"
 eslint:
-  image_name: codeclimate/codeclimate-eslint
-  image_id: 28a9ec7c5fc88a67317b6193c3ddc72f1402ba2500e8ed3c6feab6d06ca91f65
+  image: codeclimate/codeclimate-eslint
   description: A JavaScript/JSX linting utility
   community: false
   enable_regexps:
@@ -63,8 +60,7 @@ eslint:
     - "**.js"
     - "**.jsx"
 csslint:
-  image_name: codeclimate/codeclimate-csslint
-  image_id: 3d5aea2e5f241ff1daff33bd86cc5a819a34c81471e31ca70992f6de5e8edf43
+  image: codeclimate/codeclimate-csslint
   description: Automated linting of Cascading Stylesheets
   community: false
   enable_regexps:
@@ -72,21 +68,21 @@ csslint:
   default_ratings_paths:
     - "**.css"
 watson:
-  image_name: codeclimate/codeclimate-watson
+  image: codeclimate/codeclimate-watson
   description: A young Ember Doctor to help you fix your code.
   community: true
   enable_regexps:
   default_ratings_paths:
     - "app/**"
 rubymotion:
-  image_name: codeclimate/codeclimate-rubymotion
+  image: codeclimate/codeclimate-rubymotion
   description: Rubymotion-specific rubocop checks
   community: true
   enable_regexps:
   default_ratings_paths:
     - "**.rb"
 bundler-audit:
-  image_name: codeclimate/codeclimate-bundler-audit
+  image: codeclimate/codeclimate-bundler-audit
   description: Patch-level verification for Bundler
   community: false
   enable_patterns:
@@ -94,7 +90,7 @@ bundler-audit:
   default_ratings_paths:
     - Gemfile.lock
 phpcodesniffer:
-  image_name: codeclimate/codeclimate-phpcodesniffer
+  image: codeclimate/codeclimate-phpcodesniffer
   description: PHP Linting
   community: false
   enable_regexps:

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -86,7 +86,7 @@ module CC
           "--volume", "#{@code_path}:/code:ro",
           "--env-file", env_file,
           "--user", "9000:9000",
-          @metadata["image_name"],
+          @metadata["image"],
           @metadata["command"], # String or Array
         ].flatten.compact
       end

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -98,7 +98,7 @@ module CC
 
       def dev_registry_entry(engine_name)
         {
-          "image_name"=>"codeclimate/codeclimate-#{engine_name}:latest"
+          "image"=>"codeclimate/codeclimate-#{engine_name}:latest"
         }
       end
 

--- a/lib/cc/cli/engines/install.rb
+++ b/lib/cc/cli/engines/install.rb
@@ -35,7 +35,7 @@ module CC
         end
 
         def engine_image(engine_name)
-          engines_registry_list[engine_name]["image_name"]
+          engines_registry_list[engine_name]["image"]
         end
 
         def pull_engine_image(engine_image)

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -14,7 +14,7 @@ describe CC::Analyzer::Engine do
       end
 
       run_engine(
-        "image_name" => "image",
+        "image" => "image",
         "command" => "command",
       )
     end
@@ -68,7 +68,7 @@ describe CC::Analyzer::Engine do
     def run_engine(metadata = {})
       io = TestFormatter.new
       options = {
-        "image_name" => "codeclimate/image-name",
+        "image" => "codeclimate/image-name",
         "command" => "run",
       }.merge(metadata)
 

--- a/spec/cc/cli/engines/install_spec.rb
+++ b/spec/cc/cli/engines/install_spec.rb
@@ -6,7 +6,7 @@ module CC::CLI::Engines
       it "pulls uninstalled images using docker" do
         stub_config(engine_names: ["madeup"])
         stub_engine_registry(list: {
-          "madeup" => { "image_name" => "madeup_img" }
+          "madeup" => { "image" => "madeup_img" }
         })
 
         expect_system("docker pull madeup_img")
@@ -28,7 +28,7 @@ module CC::CLI::Engines
       it "errors if an image is unable to be pulled" do
         stub_config(engine_names: ["madeup"])
         stub_engine_registry(list: {
-          "madeup" => { "image_name" => "madeup_img" }
+          "madeup" => { "image" => "madeup_img" }
         })
 
         expect_system("docker pull madeup_img", false)


### PR DESCRIPTION
The image key represents the argument given to `docker run` to run the 
engine's image. It is equally valid to use a name, an id, or any other 
identifier that `docker run` supports.

This change will allow Builder to pass exact image IDs and coordinate a 
version bump along with any change in the engine images that are run.