### PR TITLE
Raise error if config json is too big

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -92,12 +92,14 @@ module CC
       end
 
       def env_file
-        if @config_json.size > 64 * 1024
+        contents = "ENGINE_CONFIG=#{@config_json}"
+
+        if contents.size > 64 * 1024
           raise EngineFailure, "Config for engine #{name} exceeds 64k character limit"
         end
 
         path = File.join("/tmp/cc", SecureRandom.uuid)
-        File.write(path, "ENGINE_CONFIG=#{@config_json}")
+        File.write(path, contents)
         path
       end
 

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -92,6 +92,10 @@ module CC
       end
 
       def env_file
+        if @config_json.size > 64 * 1024
+          raise EngineFailure, "Config for engine #{name} exceeds 64k character limit"
+        end
+
         path = File.join("/tmp/cc", SecureRandom.uuid)
         File.write(path, "ENGINE_CONFIG=#{@config_json}")
         path

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -65,6 +65,14 @@ describe CC::Analyzer::Engine do
       run_engine
     end
 
+    it "raises an error if the config is too big" do
+      json = "a" * (64 * 1024 + 1)
+      engine = CC::Analyzer::Engine.new("rubocop", {}, "/path", json, "label")
+
+      error = lambda { engine.run(StringIO.new) }.must_raise(CC::Analyzer::Engine::EngineFailure)
+      error.message.must_match "exceeds 64k character limit"
+    end
+
     def run_engine(metadata = {})
       io = TestFormatter.new
       options = {


### PR DESCRIPTION
/cc @codeclimate/review 

Example output:

```console
~/git_repos/codeclimate_test (master) 🐖  codeclimate analyze -f json
error: (CC::Analyzer::Engine::EngineFailure) Config for engine rubocop exceeds 64k character limit
```