### PR TITLE
Do no run unregistered engines

### DIFF
--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -70,14 +70,19 @@ module CC
 
       def engines
         @engines ||= config.engine_names.map do |engine_name|
-          Engine.new(
-            engine_name,
-            registry_entry(engine_name),
-            path,
-            engine_config(engine_name),
-            SecureRandom.uuid
-          )
-        end
+          entry = registry_entry(engine_name)
+          if entry.nil?
+            fatal("unknown engine name: #{engine_name}")
+          else
+            Engine.new(
+              engine_name,
+              entry,
+              path,
+              engine_config(engine_name),
+              SecureRandom.uuid
+            )
+          end
+        end.compact
       end
 
       def formatter

--- a/spec/cc/cli/analyze_spec.rb
+++ b/spec/cc/cli/analyze_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+module CC::CLI
+  describe Analyze do
+    describe "#run" do
+      before { CC::Analyzer::Engine.any_instance.stubs(:run) }
+
+      describe "when no engines are specified" do
+        it "exits and reports no engines are enabled" do
+          within_temp_dir do
+            create_yaml(Factory.create_yaml_with_no_engines)
+
+            stdout, stderr = capture_io do
+              lambda { Analyze.new(args = []).run }.must_raise SystemExit
+            end
+
+            stderr.must_match("No engines enabled. Add some to your .codeclimate.yml file!")
+          end
+        end
+
+        describe "when engine is not in registry" do
+          it "reports that no engines are enabled" do
+            within_temp_dir do
+              create_yaml
+              stub_config(
+                engine_names: ["madeup", "rubocop"],
+                engine_config: {},
+                exclude_paths: {}
+              )
+
+              stdout, stderr = capture_io do
+                lambda { Analyze.new(args = []).run }.must_raise SystemExit
+              end
+
+              stderr.must_match("unknown engine name: madeup")
+            end
+          end
+        end
+      end
+    end
+
+    def within_temp_dir(&block)
+      temp = Dir.mktmpdir
+
+      Dir.chdir(temp) do
+        yield
+      end
+    end
+
+    def create_yaml(yaml_content = Factory.create_correct_yaml)
+      File.write(".codeclimate.yml", yaml_content)
+    end
+
+    def stub_config(stubs)
+      config = stub(stubs)
+      CC::Analyzer::Config.stubs(:new).returns(config)
+    end
+  end
+end

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -68,6 +68,12 @@ module Factory
     }
   end
 
+  def create_yaml_with_no_engines
+    %{
+      engines:
+    }
+  end
+
   def sample_issue
     {
       "type" => "issue",


### PR DESCRIPTION
I was taking a look at https://github.com/codeclimate/codeclimate-fixme and how I could create an engine. I noticed that it has a [`.codeclimate.yml`](https://github.com/codeclimate/codeclimate-fixme/blob/2bea75025808e35182cc574b3ef9672dbe9d2ff0/.codeclimate.yml) file so I attempted to run codeclimate on it. But I received the following error: 

```
codeclimate-fixme[master] $ codeclimate analyze
Starting analysis
Running fixme: Done!
error: (NoMethodError) undefined method `[]' for nil:NilClass
```

First, `codeclimate-fixme` isn't in `config/engines.yml` nor could I find it in the docker registry. Are there plans to add it? 

Second, I guess we should not try to run engines if they're not in `config/engines.yml`. I took a similar approach as [this command](https://github.com/codeclimate/codeclimate/blob/c341ccd457916a2b24a75f18f44bf64d6b8e42ad/lib/cc/cli/engines/install.rb#L24) in that we'll ignore unregistered engines and output a warning.

Let me know what you think!