### PR TITLE
Abh update json formatter

### DIFF
--- a/lib/cc/analyzer/formatters/json_formatter.rb
+++ b/lib/cc/analyzer/formatters/json_formatter.rb
@@ -28,11 +28,11 @@ module CC
           document["engine_name"] = @active_engine.name
 
           if @has_begun
-            print ",\n" + document.to_json
-          else
-            print document.to_json
-            @has_begun = true
+            print ",\n"
           end
+
+          print document.to_json
+          @has_begun = true
         end
 
         def failed(output)

--- a/lib/cc/analyzer/formatters/json_formatter.rb
+++ b/lib/cc/analyzer/formatters/json_formatter.rb
@@ -3,6 +3,10 @@ module CC
     module Formatters
       class JSONFormatter < Formatter
 
+        def initialize
+          @has_begun = false
+        end
+
         def engine_running(engine)
           @active_engine = engine
           yield
@@ -10,11 +14,11 @@ module CC
         end
 
         def started
-          puts "[ "
+          print "[ "
         end
 
         def finished
-          puts "\b\b ]"
+          print " ]\n"
         end
 
         def write(data)
@@ -22,7 +26,13 @@ module CC
 
           document = JSON.parse(data)
           document["engine_name"] = @active_engine.name
-          puts document.to_json + ","
+
+          if @has_begun
+            print ",\n" + document.to_json
+          else
+            print document.to_json
+            @has_begun = true
+          end
         end
 
         def failed(output)

--- a/lib/cc/analyzer/formatters/json_formatter.rb
+++ b/lib/cc/analyzer/formatters/json_formatter.rb
@@ -9,12 +9,20 @@ module CC
           @active_engine = nil
         end
 
+        def started
+          puts "[ "
+        end
+
+        def finished
+          puts "\b\b ]"
+        end
+
         def write(data)
           return unless data.present?
 
           document = JSON.parse(data)
           document["engine_name"] = @active_engine.name
-          puts document.to_json
+          puts document.to_json + ","
         end
 
         def failed(output)

--- a/spec/cc/analyzer/formatters/json_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/json_formatter_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+module CC::Analyzer::Formatters
+  describe JSONFormatter do
+    describe "#write" do
+      it "returns when no data is present" do
+        formatter = JSONFormatter.new
+        issue = Factory.sample_issue
+        stdout, stderr = capture_io do
+          formatter.engine_running(OpenStruct.new(name: "cool_engine")) do
+            formatter.write(issue.to_json)
+          end
+        end
+
+        stdout.must_match("")
+      end
+    end
+
+    describe "#start, write, finished" do
+      it "outputs a string that can be parsed as JSON" do
+        issue1 = Factory.sample_issue
+        issue2 = Factory.sample_issue
+
+        formatter = JSONFormatter.new
+
+        stdout, stderr = capture_io do
+          formatter.started
+          formatter.engine_running(OpenStruct.new(name: "cool_engine")) do
+            formatter.write(issue1.to_json)
+            formatter.write(issue2.to_json)
+          end
+          formatter.finished
+        end
+
+        parsed_json = JSON.parse(stdout)
+        parsed_json.must_equal([{"type"=>"issue", "check"=>"Rubocop/Style/Documentation", "description"=>"Missing top-level class documentation comment.", "categories"=>["Style"], "remediation_points"=>10, "location"=>{"path"=>"lib/cc/analyzer/accumulator.rb", "begin"=>{"pos"=>32, "line"=>3}, "end"=>{"pos"=>37, "line"=>3}}, "engine_name"=>"cool_engine"}, {"type"=>"issue", "check"=>"Rubocop/Style/Documentation", "description"=>"Missing top-level class documentation comment.", "categories"=>["Style"], "remediation_points"=>10, "location"=>{"path"=>"lib/cc/analyzer/accumulator.rb", "begin"=>{"pos"=>32, "line"=>3}, "end"=>{"pos"=>37, "line"=>3}}, "engine_name"=>"cool_engine"}])
+      end
+
+      it "prints a correctly formatted array of comma separated JSON issues" do
+        issue1 = Factory.sample_issue
+        issue2 = Factory.sample_issue
+
+        formatter = JSONFormatter.new
+
+        stdout, stderr = capture_io do
+          formatter.started
+          formatter.engine_running(OpenStruct.new(name: "cool_engine")) do
+            formatter.write(issue1.to_json)
+            formatter.write(issue2.to_json)
+          end
+          formatter.finished
+        end
+
+        last_two_characters = stdout[stdout.length-2..stdout.length-1]
+
+        stdout.first.must_match("[")
+        last_two_characters.must_match("]\n")
+
+        stdout.must_match("[ {\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"},\n{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"} ]\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
@codeclimate/review This PR updates output of `JSONFormatter` to print a valid json object - an array of json issue documents.

I updated the `started` and `finished` methods on JSONFormatter to print brackets (previously only parent class `Formatter` used these. They called in `anlayze` but they're empty methods).

I also added a `@has_begun` instance variable to keep track of started state. I investigated using `"\r "` and `"\b"` characters to remove the last `", "` when printing `document.json + ", "` but didn't get those strategies to work. Happy to hear feedback. 

```
Ashleys-MacBook-Pro:codeclimate ashleybaldwin-hunter$ codeclimate analyze -f json
[ {"type":"Issue","check_name":"Rubocop/Style/StringLiterals","description":"Prefer single-quoted strings 
when you don't need string interpolation or special symbols.","categories":
["Style"],"remediation_points":50000,"location":{"path":"codeclimate.gemspec","positions":{"begin": 
{"column":40,"line":1},"end":{"column":48,"line":1}}},"engine_name":"rubocop"},
...
{"type":"Issue","check_name":"Rubocop/Style/StringLiterals","description":"Prefer single-quoted strings 
when you don't need string interpolation or special symbols.","categories":
["Style"],"remediation_points":50000,"location":{"path":"spec/support/test_formatter.rb","positions":
{"begin":{"column":15,"line":5},"end":{"column":17,"line":5}}},"engine_name":"rubocop"} ]
```