### PR TITLE
Abh update wrapper script

### DIFF
--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -41,10 +41,18 @@ else
     && invalid_docker_host "$DOCKER_HOST"
 fi
 
-exec docker run \
-  --interactive --tty --rm \
-  --env CODE_PATH="$PWD" \
-  --volume "$PWD":/code \
-  --volume /tmp/cc:/tmp/cc \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
-  codeclimate/codeclimate "$@"
+docker_run() {
+  exec docker run \
+    --rm \
+    --env CODE_PATH="$PWD" \
+    --volume "$PWD":/code \
+    --volume /tmp/cc:/tmp/cc \
+    --volume /var/run/docker.sock:/var/run/docker.sock \
+    "$@"
+}
+
+if [ -t 1 ]; then
+  docker_run --interactive --tty codeclimate/codeclimate "$@"
+else
+  docker_run codeclimate/codeclimate "$@"
+fi

--- a/lib/cc/analyzer/formatters/spinner.rb
+++ b/lib/cc/analyzer/formatters/spinner.rb
@@ -7,6 +7,7 @@ module CC
         end
 
         def start
+          return unless $stdout.tty?
           @thread = Thread.new do
             loop do
               @spinning = true


### PR DESCRIPTION
@codeclimate/review This PR updates the codeclimate-wrapper script to run `docker --tty` only if stdout is a `tty`.

Impact: piping to a file with `codeclimate analyze` will result in plain text. Running `codeclimate analyze` will still produce normal colorful output and spinner.

Sample output post `codeclimate analyze > test.txt`:

terminal: nothing

file: 
![screen shot 2015-07-08 at 4 25 59 pm](https://cloud.githubusercontent.com/assets/8718443/8581344/26ae8560-258e-11e5-9686-4f1f51318917.png)


