### PR TITLE
always keep --interactive as arg in docker run command

### DIFF
--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -43,7 +43,7 @@ fi
 
 docker_run() {
   exec docker run \
-    --rm \
+    --interactive --rm \
     --env CODE_PATH="$PWD" \
     --volume "$PWD":/code \
     --volume /tmp/cc:/tmp/cc \
@@ -52,7 +52,7 @@ docker_run() {
 }
 
 if [ -t 1 ]; then
-  docker_run --interactive --tty codeclimate/codeclimate "$@"
+  docker_run --tty codeclimate/codeclimate "$@"
 else
   docker_run codeclimate/codeclimate "$@"
 fi


### PR DESCRIPTION
@codeclimate/review @brynary PR refactors wrapper script to keep `--interactive` as arg in docker run command no matter what. (Since it's related to `STDIN`, I shouldn't have made its inclusion conditional in recent update to wrapper script.)

Tested locally by running `./codeclimate-wrapper analyze` and `./codeclimate-wrapper analyze > test.txt`