### PR TITLE
bump to cc-yaml version 0.0.7 - fix languages key parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.0.24)
       activesupport (~> 4.2, >= 4.2.1)
-      codeclimate-yaml (~> 0.0, >= 0.0.6)
+      codeclimate-yaml (~> 0.0, >= 0.0.7)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.9.1)
       highline (~> 1.7, >= 1.7.2)
@@ -24,7 +24,7 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     builder (3.2.2)
-    codeclimate-yaml (0.0.6)
+    codeclimate-yaml (0.0.7)
       activesupport
       secure_string
     coderay (1.1.0)

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.0", ">= 0.0.6"
+  s.add_dependency "codeclimate-yaml", "~> 0.0", ">= 0.0.7"
   s.add_dependency "faraday", "~> 0.9.1"
   s.add_dependency "faraday_middleware", "~> 0.9.1"
   s.add_dependency "highline",  "~> 1.7", ">= 1.7.2"


### PR DESCRIPTION
@codeclimate/review bumps to `cc-yaml 0.0.7`, which fixes `languages` parsing to use traditional format:

```
languages:
  Ruby: true
  JavaScript: true
```
