### PR TITLE
bump to v0.0.9 of cc-yaml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.0.25)
       activesupport (~> 4.2, >= 4.2.1)
-      codeclimate-yaml (~> 0.0, >= 0.0.7)
+      codeclimate-yaml (~> 0.0, >= 0.0.9)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.9.1)
       highline (~> 1.7, >= 1.7.2)
@@ -24,7 +24,7 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     builder (3.2.2)
-    codeclimate-yaml (0.0.7)
+    codeclimate-yaml (0.0.9)
       activesupport
       secure_string
     coderay (1.1.0)

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.0", ">= 0.0.7"
+  s.add_dependency "codeclimate-yaml", "~> 0.0", ">= 0.0.9"
   s.add_dependency "faraday", "~> 0.9.1"
   s.add_dependency "faraday_middleware", "~> 0.9.1"
   s.add_dependency "highline",  "~> 1.7", ">= 1.7.2"


### PR DESCRIPTION
@codeclimate/review bump `cc-yaml` from `v0.0.7` to `v0.0.9`, which [fixes bug] (https://github.com/codeclimate/codeclimate-yaml/commit/4f7111b8607c86cf07632a347e4530a1ce2bd746#diff-db2eff17b198a77ecc2de173e25cf913R90) in `v0.0.8` and [keeps v0.0.8 new functionality] (https://github.com/codeclimate/codeclimate-yaml/commit/03b144bfd1b49b17ba4049b5957c93dbd773beb6):

1) Adds warning if no `engines` or `languages` key is found.
```
$ codeclimate validate-config
WARNING: No languages or engines key found. Must have analysis key. 
```
2) Updates language in warning for when both `engines` and `languages` keys are present.

old warning:
```
$ codeclimate validate-config
WARNING: engines key already found, dropping key: languages. Analysis settings for Languages and 
Engines are both valid but mutually exclusive. Note: command line analysis requires an Engines 
configuration.
```
new warning:
```
$ codeclimate validate-config
WARNING: Use either a Languages key or an Engines key, but not both. They are mutually exclusive.
```