### PR TITLE
Displaying error when engine raises exception

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -58,7 +58,7 @@ module CC
         else
           Analyzer.statsd.increment("cli.engines.names.#{name}.result.error")
           Analyzer.statsd.increment("cli.engines.result.error")
-          raise EngineFailure, "engine #{name} failed with status #{status.exitstatus} and stderr #{stderr_io.string.inspect}"
+          raise EngineFailure, "engine #{name} failed with status #{status.exitstatus} and stderr \n#{stderr_io.string}"
         end
       ensure
         t_timeout.kill if t_timeout


### PR DESCRIPTION
I was trying to get an engine up for scss-lint and ran into this behavior:

```
Starting analysis
Running rubocop: Done!
Running scss-lint: Done!
error: (CC::Analyzer::Engine::EngineFailure) engine scss-lint failed with status 1 and stderr "/usr/lib/ruby/gems/2.2.0/gems/scss_lint-0.40.1/lib/scss_lint/file_finder.rb:33:in `find': All files matched by the patterns [nested/test2.scss, test.scss] were excluded by the patterns: [/code/nested/test2.scss, /code/test.scss, /code/vendor/bundle, /code/vendor/bundle/ruby, /code/vendor/bundle/ruby/2.1.0] (SCSSLint::Exceptions::AllFilesFilteredError)\n\tfrom /usr/lib/ruby/gems/2.2.0/gems/scss_lint-0.40.1/lib/scss_lint/cli.rb:58:in `scan_for_lints'\n\tfrom /usr/lib/ruby/gems/2.2.0/gems/scss_lint-0.40.1/lib/scss_lint/cli.rb:51:in `act_on_options'\n\tfrom /usr/src/app/lib/cc/engine/scss-lint.rb:19:in `block in run'\n\tfrom /usr/src/app/lib/cc/engine/scss-lint.rb:18:in `chdir'\n\tfrom /usr/src/app/lib/cc/engine/scss-lint.rb:18:in `run'\n\tfrom /usr/src/app/bin/codeclimate-scss-lint:9:in `<main>'\n"
```

Would it be better if this stacktrace was formatted with new lines and tabs instead of printing the inspect value? This is the line where this behavior is coming from: https://github.com/codeclimate/codeclimate/blob/c341ccd457916a2b24a75f18f44bf64d6b8e42ad/lib/cc/analyzer/engine.rb#L61