### PR TITLE
bump cc-yaml to 0.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.1.1)
       activesupport (~> 4.2, >= 4.2.1)
-      codeclimate-yaml (~> 0.0, >= 0.0.9)
+      codeclimate-yaml (~> 0.0, >= 0.0.10)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.9.1)
       highline (~> 1.7, >= 1.7.2)

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.0", ">= 0.0.9"
+  s.add_dependency "codeclimate-yaml", "~> 0.0", ">= 0.0.10"
   s.add_dependency "faraday", "~> 0.9.1"
   s.add_dependency "faraday_middleware", "~> 0.9.1"
   s.add_dependency "highline",  "~> 1.7", ">= 1.7.2"


### PR DESCRIPTION
@codeclimate/review Bumps `cc/yaml` gem from `v0.0.9` => `v0.0.10` (latest version).

Diff [here] (https://github.com/codeclimate/codeclimate-yaml/commit/c35f416bc072ab052edccd33b3a29628bc61d38a). Changes analysis key issues from being counted as `warnings` to `errors`.

In CLI, user-facing difference:

before:
```console
$ codeclimate validate-config
WARNING: No languages or engines key found. Must have analysis key.
$ codeclimate validate-config
WARNING: Use either a Languages key or an Engines key, but not both. They are mutually exclusive.
```
after:
```console
$ codeclimate validate-config 
ERROR: No languages or engines key found. Must have analysis key.
$ codeclimate validate-config
ERROR: Use either a Languages key or an Engines key, but not both. They are mutually exclusive.
```