### PR TITLE
Refactors during implementation of ignore-check

### DIFF
--- a/lib/cc/analyzer/formatters/formatter.rb
+++ b/lib/cc/analyzer/formatters/formatter.rb
@@ -2,7 +2,6 @@ module CC
   module Analyzer
     module Formatters
       class Formatter
-        attr_reader :current_engine
 
         def initialize(output = $stdout)
           @output = output
@@ -28,6 +27,10 @@ module CC
         end
 
         InvalidFormatterError = Class.new(StandardError)
+
+        private
+
+        attr_reader :current_engine
       end
     end
   end

--- a/lib/cc/analyzer/formatters/formatter.rb
+++ b/lib/cc/analyzer/formatters/formatter.rb
@@ -2,6 +2,8 @@ module CC
   module Analyzer
     module Formatters
       class Formatter
+        attr_reader :current_engine
+
         def initialize(output = $stdout)
           @output = output
         end
@@ -13,7 +15,10 @@ module CC
         end
 
         def engine_running(engine)
+          @current_engine = engine
           yield
+        ensure
+          @current_engine = nil
         end
 
         def finished

--- a/lib/cc/analyzer/formatters/formatter.rb
+++ b/lib/cc/analyzer/formatters/formatter.rb
@@ -2,7 +2,6 @@ module CC
   module Analyzer
     module Formatters
       class Formatter
-
         def initialize(output = $stdout)
           @output = output
         end

--- a/lib/cc/analyzer/formatters/json_formatter.rb
+++ b/lib/cc/analyzer/formatters/json_formatter.rb
@@ -14,11 +14,11 @@ module CC
         end
 
         def started
-          print "[ "
+          print "["
         end
 
         def finished
-          print " ]\n"
+          print "]\n"
         end
 
         def write(data)

--- a/lib/cc/analyzer/formatters/json_formatter.rb
+++ b/lib/cc/analyzer/formatters/json_formatter.rb
@@ -7,12 +7,6 @@ module CC
           @has_begun = false
         end
 
-        def engine_running(engine)
-          @active_engine = engine
-          yield
-          @active_engine = nil
-        end
-
         def started
           print "["
         end
@@ -25,7 +19,7 @@ module CC
           return unless data.present?
 
           document = JSON.parse(data)
-          document["engine_name"] = @active_engine.name
+          document["engine_name"] = current_engine.name
 
           if @has_begun
             print ",\n"

--- a/lib/cc/analyzer/formatters/plain_text_formatter.rb
+++ b/lib/cc/analyzer/formatters/plain_text_formatter.rb
@@ -14,8 +14,8 @@ module CC
         def write(data)
           if data.present?
             json = JSON.parse(data)
-            if @active_engine
-              json["engine_name"] = @active_engine.name
+            if current_engine
+              json["engine_name"] = current_engine.name
             end
 
             case json["type"].downcase
@@ -54,12 +54,10 @@ module CC
           puts(colorize(".", :green))
         end
 
-        def engine_running(engine)
-          @active_engine = engine
-          with_spinner("Running #{engine.name}: ") do
-            yield
+        def engine_running(engine, &block)
+          super(engine) do
+            with_spinner("Running #{current_engine.name}: ", &block)
           end
-          @active_engine = nil
         end
 
         def failed(output)

--- a/lib/cc/analyzer/formatters/plain_text_formatter.rb
+++ b/lib/cc/analyzer/formatters/plain_text_formatter.rb
@@ -14,9 +14,7 @@ module CC
         def write(data)
           if data.present?
             json = JSON.parse(data)
-            if current_engine
-              json["engine_name"] = current_engine.name
-            end
+            json["engine_name"] = current_engine.name
 
             case json["type"].downcase
             when "issue"

--- a/spec/cc/analyzer/formatters/json_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/json_formatter_spec.rb
@@ -56,7 +56,7 @@ module CC::Analyzer::Formatters
         stdout.first.must_match("[")
         last_two_characters.must_match("]\n")
 
-        stdout.must_match("[ {\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"},\n{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"} ]\n")
+        stdout.must_match("[{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"},\n{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"}]\n")
       end
     end
   end

--- a/spec/cc/analyzer/formatters/json_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/json_formatter_spec.rb
@@ -2,30 +2,31 @@ require 'spec_helper'
 
 module CC::Analyzer::Formatters
   describe JSONFormatter do
+    include Factory
+
     describe "#write" do
       it "returns when no data is present" do
         formatter = JSONFormatter.new
-        issue = Factory.sample_issue
         stdout, stderr = capture_io do
-          formatter.engine_running(OpenStruct.new(name: "cool_engine")) do
-            formatter.write(issue.to_json)
+          formatter.engine_running(engine_double("cool_engine")) do
+            formatter.write("")
           end
         end
 
-        stdout.must_match("")
+        stdout.must_equal("")
       end
     end
 
     describe "#start, write, finished" do
       it "outputs a string that can be parsed as JSON" do
-        issue1 = Factory.sample_issue
-        issue2 = Factory.sample_issue
+        issue1 = sample_issue
+        issue2 = sample_issue
 
         formatter = JSONFormatter.new
 
         stdout, stderr = capture_io do
           formatter.started
-          formatter.engine_running(OpenStruct.new(name: "cool_engine")) do
+          formatter.engine_running(engine_double("cool_engine")) do
             formatter.write(issue1.to_json)
             formatter.write(issue2.to_json)
           end
@@ -37,14 +38,14 @@ module CC::Analyzer::Formatters
       end
 
       it "prints a correctly formatted array of comma separated JSON issues" do
-        issue1 = Factory.sample_issue
-        issue2 = Factory.sample_issue
+        issue1 = sample_issue
+        issue2 = sample_issue
 
         formatter = JSONFormatter.new
 
         stdout, stderr = capture_io do
           formatter.started
-          formatter.engine_running(OpenStruct.new(name: "cool_engine")) do
+          formatter.engine_running(engine_double("cool_engine")) do
             formatter.write(issue1.to_json)
             formatter.write(issue2.to_json)
           end
@@ -56,8 +57,12 @@ module CC::Analyzer::Formatters
         stdout.first.must_match("[")
         last_two_characters.must_match("]\n")
 
-        stdout.must_match("[{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"},\n{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"}]\n")
+        stdout.must_equal("[{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"},\n{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/accumulator.rb\",\"begin\":{\"pos\":32,\"line\":3},\"end\":{\"pos\":37,\"line\":3}},\"engine_name\":\"cool_engine\"}]\n")
       end
+    end
+
+    def engine_double(name)
+      stub(name: name, ignore_issue?: false)
     end
   end
 end

--- a/spec/cc/analyzer/formatters/json_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/json_formatter_spec.rb
@@ -62,7 +62,7 @@ module CC::Analyzer::Formatters
     end
 
     def engine_double(name)
-      stub(name: name, ignore_issue?: false)
+      stub(name: name)
     end
   end
 end


### PR DESCRIPTION
These are some behavior-neutral changes I have in my branch for ignoring
checks. I'm opening this separately so the eventual diff for the feature is
clearer.

- Change whitespace in JSONFormatter

  The document itself doesn't use spaces between tokens, so we shouldn't have
  whitespace after/before the overall brackets.

- Fix JSONFormatter spec
  - Include Factory to cut down on noise
  - Actually send in empty data for empty data spec
  - Use must_equal not must_match which always succeeds if given the empty
    string (causing pass-by-coincidence)

- Centralize engine_running behavior into superclass
  - Sub classes shouldn't need to duplicate this
  - Ensures a consistent instance variable (current_engine) is used
  - Provide an attr_reader for it
  - Paves the way for formatter-centralized issue exlusion based on engine
    configuration

/cc @codeclimate/review