### PR TITLE
Add EngineOutputFilter, filter by check name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,35 @@
+Style/StringLiterals:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Style/TrailingComma:
+  Enabled: false
+
+Style/FileName:
+  Exclude:
+    - 'bin/**/*'
+
+Style/ClassAndModuleChildren:
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*'
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/DotPosition:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: false

--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -4,6 +4,7 @@ module CC
     autoload :Config,             "cc/analyzer/config"
     autoload :Engine,             "cc/analyzer/engine"
     autoload :EngineClient,       "cc/analyzer/engine_client"
+    autoload :EngineOutputFilter, "cc/analyzer/engine_output_filter"
     autoload :EngineProcess,      "cc/analyzer/engine_process"
     autoload :EngineRegistry,     "cc/analyzer/engine_registry"
     autoload :Filesystem,         "cc/analyzer/filesystem"

--- a/lib/cc/analyzer/engine_output_filter.rb
+++ b/lib/cc/analyzer/engine_output_filter.rb
@@ -24,7 +24,7 @@ module CC
       end
 
       def issue?(json)
-        json.is_a?(Hash) && json["type"] == ISSUE_TYPE
+        json["type"] == ISSUE_TYPE
       end
 
       def ignore_issue?(json)

--- a/lib/cc/analyzer/engine_output_filter.rb
+++ b/lib/cc/analyzer/engine_output_filter.rb
@@ -32,8 +32,8 @@ module CC
       end
 
       def check_config(check_name)
-        checks = @config.fetch("checks", {})
-        checks.fetch(check_name, {})
+        @checks ||= @config.fetch("checks", {})
+        @checks.fetch(check_name, {})
       end
     end
   end

--- a/lib/cc/analyzer/engine_output_filter.rb
+++ b/lib/cc/analyzer/engine_output_filter.rb
@@ -1,0 +1,40 @@
+module CC
+  module Analyzer
+    class EngineOutputFilter
+      ISSUE_TYPE = "issue".freeze
+
+      def initialize(config = {})
+        @config = config
+      end
+
+      def filter?(output)
+        if (json = parse_as_json(output))
+          issue?(json) && ignore_issue?(json)
+        else
+          false
+        end
+      end
+
+      private
+
+      def parse_as_json(output)
+        JSON.parse(output)
+      rescue JSON::ParserError
+        nil
+      end
+
+      def issue?(json)
+        json.is_a?(Hash) && json["type"] == ISSUE_TYPE
+      end
+
+      def ignore_issue?(json)
+        !check_config(json["check"]).fetch("enabled", true)
+      end
+
+      def check_config(check_name)
+        checks = @config.fetch("checks", {})
+        checks.fetch(check_name, {})
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engine_output_filter_spec.rb
+++ b/spec/cc/analyzer/engine_output_filter_spec.rb
@@ -12,7 +12,6 @@ module CC::Analyzer
       filter = EngineOutputFilter.new
 
       filter.filter?(%{{"arbitrary":"json"}}).must_equal false
-      filter.filter?(%{[{"arbitrary":"json"}]}).must_equal false
     end
 
     it "does not filter issues missing or enabled in the config" do

--- a/spec/cc/analyzer/engine_output_filter_spec.rb
+++ b/spec/cc/analyzer/engine_output_filter_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+module CC::Analyzer
+  describe EngineOutputFilter do
+    it "does not filter arbitrary output" do
+      filter = EngineOutputFilter.new
+
+      filter.filter?("abritrary output").must_equal false
+    end
+
+    it "does not filter arbitrary json" do
+      filter = EngineOutputFilter.new
+
+      filter.filter?(%{{"arbitrary":"json"}}).must_equal false
+      filter.filter?(%{[{"arbitrary":"json"}]}).must_equal false
+    end
+
+    it "does not filter issues missing or enabled in the config" do
+      foo_issue = build_issue("foo")
+      bar_issue = build_issue("bar")
+
+      filter = EngineOutputFilter.new(
+        "checks" => {
+          "foo" => { "enabled" => true },
+        }
+      )
+
+      filter.filter?(foo_issue.to_json).must_equal false
+      filter.filter?(bar_issue.to_json).must_equal false
+    end
+
+    it "filters issues ignored in the config" do
+      issue = build_issue("foo")
+
+      filter = EngineOutputFilter.new(
+        "checks" => {
+          "foo" => { "enabled" => false },
+        }
+      )
+
+      filter.filter?(issue.to_json).must_equal true
+    end
+
+    def build_issue(check_name)
+      {
+        "type" => EngineOutputFilter::ISSUE_TYPE,
+        "check" => check_name,
+      }
+    end
+  end
+end


### PR DESCRIPTION
Engines are instantiated with a string a json that corresponds to a modified
version of the YAML object under the engines key for the given engine. Within
this object, we'll now support a "checks" key that can hold check-specific
configuration including an enabled boolean.

This commit introduces an EngineOutputFilter that accepts this engine 
configuration and decides if the output of the engine should be written to the
formatter.

There is a lot of JSON generation and re-parsing going on that can seem 
redundant; I'm leaving this in place for now because orchestrating the various
parts that would need to change to address that is difficult.

One possible approach would be to enrich the interfaces involved and not pass
strings around so much. Engine would take a Hash of configuration and
stringify it only for the purposes of writing the config.json file. Formatter
could lose it's IO-like write interface and receive more structured data
centralizing the output parsing and filtering further upstream.

/cc @codeclimate/review

Note: the refactor PR from earlier was actually in support of an alternative
approach that I didn't end up going with. Oh well, I still think it was
valuable.