### PR TITLE
invalid engines

### DIFF
--- a/lib/cc/cli/engines.rb
+++ b/lib/cc/cli/engines.rb
@@ -9,6 +9,7 @@ module CC
       autoload :Install, "cc/cli/engines/install"
       autoload :List, "cc/cli/engines/list"
       autoload :Remove, "cc/cli/engines/remove"
+      autoload :Validate, "cc/cli/engines/validate"
     end
   end
 end

--- a/lib/cc/cli/engines/validate.rb
+++ b/lib/cc/cli/engines/validate.rb
@@ -1,0 +1,36 @@
+require "cc/analyzer"
+
+module CC
+  module CLI
+    module Engines
+      class Validate < EngineCommand
+        def run
+          if invalid_engines.any?
+            warn
+            true
+          end
+        end
+
+        private
+
+        def warn
+          invalid_engines.each do |engine|
+            puts colorize("WARNING: unknown engine <#{engine}>", :red)
+          end
+        end
+
+        def invalid_engines
+          @invalid_engines ||= engine_names.reject { |engine_name| engine_exists? engine_name }
+        end
+
+        def engine_names
+          @engine_names ||= parsed_yaml.engine_names
+        end
+
+        def engine_exists?(engine_name)
+          engines_registry_list.keys.include?(engine_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/cli/validate_config.rb
+++ b/lib/cc/cli/validate_config.rb
@@ -17,7 +17,9 @@ module CC
         if any_issues?
           display_issues
         else
-          puts colorize("No errors or warnings found in .codeclimate.yml file.", :green)
+          unless validate_engines
+            puts colorize("No errors or warnings found in .codeclimate.yml file.", :green)
+          end
         end
       end
 
@@ -69,6 +71,10 @@ module CC
         warnings.each do |warning|
           puts colorize("WARNING: " + warning, :red)
         end
+      end
+
+      def validate_engines
+        Engines::Validate.new.run
       end
     end
   end

--- a/spec/cc/cli/validate_config_spec.rb
+++ b/spec/cc/cli/validate_config_spec.rb
@@ -111,7 +111,7 @@ module CC::CLI
                 engines:
                   rubocop:
                     enabled: true
-                  madeup
+                  madeup:
                     enabled: true
                 ratings:
                   paths:
@@ -125,7 +125,7 @@ module CC::CLI
                 ValidateConfig.new.run
               end
 
-              stdout.must_match("WARNING: unknown engine madeup")
+              stdout.must_include("WARNING: unknown engine <madeup>")
             end
           end
         end

--- a/spec/cc/cli/validate_config_spec.rb
+++ b/spec/cc/cli/validate_config_spec.rb
@@ -103,6 +103,32 @@ module CC::CLI
             end
           end
         end
+
+        describe "when there are invalid engines" do
+          it "reports that those engines are invalid" do
+            within_temp_dir do
+              yaml_content = <<-YAML
+                engines:
+                  rubocop:
+                    enabled: true
+                  madeup
+                    enabled: true
+                ratings:
+                  paths:
+                  - "**/*.rb"
+                  - "**/*.js"
+              YAML
+
+              File.write(".codeclimate.yml", yaml_content)
+
+              stdout, stderr = capture_io do
+                ValidateConfig.new.run
+              end
+
+              stdout.must_match("WARNING: unknown engine madeup")
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
@codeclimate/review 

This PR adds check for invalid engine names to `codeclimate validate-config`

Its implementation is to create a `validate` subcommand under `enges` (which means that users can also run `codeclimate engines:validate`) which I kind of like.

Feedback welcome.