### PR TITLE
composition

### DIFF
--- a/lib/cc/analyzer/engine_registry.rb
+++ b/lib/cc/analyzer/engine_registry.rb
@@ -21,6 +21,11 @@ module CC
         @config
       end
 
+      def exists?(engine_name)
+        return true if dev_mode?
+        list.keys.include?(engine_name)
+      end
+
       private
 
       def dev_mode?

--- a/lib/cc/cli/command.rb
+++ b/lib/cc/cli/command.rb
@@ -60,6 +60,10 @@ module CC
       def terminal
         @terminal ||= HighLine.new($stdin, $stdout)
       end
+
+      def engine_registry
+        @engine_registry ||= CC::Analyzer::EngineRegistry.new
+      end
     end
   end
 end

--- a/lib/cc/cli/console.rb
+++ b/lib/cc/cli/console.rb
@@ -1,12 +1,10 @@
 module CC
   module CLI
     class Console < Command
-
       def run
         require "pry"
         binding.pry(quiet: true, prompt: Pry::SIMPLE_PROMPT, output: $stdout)
       end
-
     end
   end
 end

--- a/lib/cc/cli/engines/engine_command.rb
+++ b/lib/cc/cli/engines/engine_command.rb
@@ -33,11 +33,11 @@ module CC
         end
 
         def engine_exists?
-          engines_registry_list.keys.include?(engine_name)
+          engine_registry.exists?(engine_name)
         end
 
-        def engines_registry_list
-          @engines_registry_list ||= CC::Analyzer::EngineRegistry.new.list
+        def engine_registry_list
+          engine_registry.list
         end
       end
     end

--- a/lib/cc/cli/engines/install.rb
+++ b/lib/cc/cli/engines/install.rb
@@ -1,5 +1,3 @@
-require "cc/analyzer"
-
 module CC
   module CLI
     module Engines
@@ -17,7 +15,7 @@ module CC
 
         def pull_docker_images
           engine_names.each do |name|
-            if engine_exists?(name)
+            if engine_registry.exists?(name)
               image = engine_image(name)
               pull_engine_image(image)
             else
@@ -30,12 +28,8 @@ module CC
           @engine_names ||= parsed_yaml.engine_names
         end
 
-        def engine_exists?(engine_name)
-          engines_registry_list.keys.include?(engine_name)
-        end
-
         def engine_image(engine_name)
-          engines_registry_list[engine_name]["image"]
+          engine_registry_list[engine_name]["image"]
         end
 
         def pull_engine_image(engine_image)

--- a/lib/cc/cli/engines/list.rb
+++ b/lib/cc/cli/engines/list.rb
@@ -4,7 +4,7 @@ module CC
       class List < EngineCommand
         def run
           say "Available engines:"
-          engines_registry_list.sort_by { |name, _| name }.each do |name, attributes|
+          engine_registry_list.sort_by { |name, _| name }.each do |name, attributes|
             say "- #{name}: #{attributes["description"]}"
           end
         end

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -52,7 +52,7 @@ module CC
       end
 
       def eligible_engines
-        CC::Analyzer::EngineRegistry.new.list.each_with_object({}) do |(engine_name, config), result|
+        engine_registry.list.each_with_object({}) do |(engine_name, config), result|
           if engine_eligible?(config)
             result[engine_name] = config
           end

--- a/lib/cc/cli/validate_config.rb
+++ b/lib/cc/cli/validate_config.rb
@@ -6,6 +6,8 @@ module CC
       include CC::Analyzer
       include CC::Yaml
 
+      VALID_CONFIG_MESSAGE = "No errors or warnings found in .codeclimate.yml file.".freeze
+
       def run
         require_codeclimate_yml
         verify_yaml
@@ -17,12 +19,12 @@ module CC
         if any_issues?
           display_issues
         else
-          puts colorize("No errors or warnings found in .codeclimate.yml file.", :green)
+          puts colorize(VALID_CONFIG_MESSAGE, :green)
         end
       end
 
       def any_issues?
-        parsed_yaml.errors? || parsed_yaml.nested_warnings.any? || parsed_yaml.warnings?
+        parsed_yaml.errors? || parsed_yaml.nested_warnings.any? || parsed_yaml.warnings? || invalid_engines.any?
       end
 
       def yaml_content
@@ -48,27 +50,46 @@ module CC
       def display_issues
         display_errors
         display_warnings
+        display_invalid_engines
         display_nested_warnings
       end
 
       def display_errors
         errors.each do |error|
-          puts colorize("ERROR: " + error, :red)
+          puts colorize("ERROR: #{error}", :red)
         end
       end
 
       def display_nested_warnings
         nested_warnings.each do |nested_warning|
           if nested_warning[0][0]
-            puts colorize("WARNING in " + nested_warning[0][0] + ": " + nested_warning[1], :red)
+            puts colorize("WARNING in #{nested_warning[0][0]}: #{nested_warning[1]}", :red)
           end
         end
       end
 
       def display_warnings
         warnings.each do |warning|
-          puts colorize("WARNING: " + warning, :red)
+          puts colorize("WARNING: #{warning}", :red)
         end
+      end
+
+      def display_invalid_engines
+        invalid_engines.each do |engine_name|
+          puts colorize("WARNING: unknown engine <#{engine_name}>", :red)
+        end
+      end
+
+      def invalid_engines
+        @invalid_engines ||= engine_names.reject { |engine_name| engine_registry.exists? engine_name }
+      end
+
+      def engine_names
+        @engine_names ||= engines.keys
+      end
+
+      def engines
+        @engines ||= parsed_yaml.engines || {}
       end
     end
   end

--- a/spec/cc/cli/validate_config_spec.rb
+++ b/spec/cc/cli/validate_config_spec.rb
@@ -103,6 +103,32 @@ module CC::CLI
             end
           end
         end
+
+        describe "when there are invalid engines" do
+          it "reports that those engines are invalid" do
+            within_temp_dir do
+              yaml_content = <<-YAML
+                engines:
+                  rubocop:
+                    enabled: true
+                  madeup:
+                    enabled: true
+                ratings:
+                  paths:
+                  - "**/*.rb"
+                  - "**/*.js"
+              YAML
+
+              File.write(".codeclimate.yml", yaml_content)
+
+              stdout, stderr = capture_io do
+                ValidateConfig.new.run
+              end
+
+              stdout.must_include("WARNING: unknown engine <madeup>")
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
@codeclimate/review This PR:

1) adds warning for invalid engines to the `validate-config` command
2) makes `engine_exists?` and `engine_registry_list` accessible via the `Engines` module through composition.
