### PR TITLE
dont raise on invalid engine

### DIFF
--- a/lib/cc/analyzer/engine_registry.rb
+++ b/lib/cc/analyzer/engine_registry.rb
@@ -21,12 +21,12 @@ module CC
         @config
       end
 
-      def has_key?(engine_name)
+      def key?(engine_name)
         return true if dev_mode?
-        list.has_key?(engine_name)
+        list.key?(engine_name)
       end
 
-      alias exists? has_key?
+      alias_method :exists?, :key?
 
       private
 

--- a/lib/cc/analyzer/engine_registry.rb
+++ b/lib/cc/analyzer/engine_registry.rb
@@ -21,10 +21,12 @@ module CC
         @config
       end
 
-      def exists?(engine_name)
+      def has_key?(engine_name)
         return true if dev_mode?
-        list.keys.include?(engine_name)
+        list.has_key?(engine_name)
       end
+
+      alias exists? has_key?
 
       private
 

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -46,10 +46,9 @@ module CC
 
       def engines
         @engines ||= enabled_engines.map do |name, config|
-          metadata = registry_lookup(name)
           label = @container_label || SecureRandom.uuid
 
-          Engine.new(name, metadata, @source_dir, engine_config(config), label)
+          Engine.new(name, metadata(name), @source_dir, engine_config(config), label)
         end
       end
 
@@ -69,19 +68,15 @@ module CC
       def enabled_engines
         {}.tap do |ret|
           @config.engines.each do |name, config|
-            if config.enabled?
+            if config.enabled? && @registry.key?(name)
               ret[name] = config
             end
           end
         end
       end
 
-      def registry_lookup(engine_name)
-        if (metadata = @registry[engine_name])
-          metadata
-        else
-          raise InvalidEngineName, "unknown engine name: #{engine_name}"
-        end
+      def metadata(engine_name)
+        @registry[engine_name]
       end
 
       def exclude_paths

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -12,11 +12,11 @@ module CC::Analyzer
       EnginesRunner.new(registry, formatter, "/code", config).run
     end
 
-    it "raises for invalid engine names" do
+    it "does not raise for invalid engine names" do
       config = config_with_engine("an_engine")
       runner = EnginesRunner.new({}, null_formatter, "/code", config)
 
-      lambda { runner.run }.must_raise(EnginesRunner::InvalidEngineName)
+      lambda { runner.run }
     end
 
     it "raises for no enabled engines" do

--- a/spec/cc/cli/analyze_spec.rb
+++ b/spec/cc/cli/analyze_spec.rb
@@ -19,7 +19,7 @@ module CC::CLI
         end
 
         describe "when engine is not in registry" do
-          it "reports that no engines are enabled" do
+          it "ignores engine, without blowing up" do
             within_temp_dir do
               create_yaml(<<-EOYAML)
                 engines:
@@ -30,10 +30,10 @@ module CC::CLI
               EOYAML
 
               _, stderr = capture_io do
-                lambda { Analyze.new.run }.must_raise SystemExit
+                lambda { Analyze.new.run }
               end
 
-              stderr.must_match("unknown engine name: madeup")
+              stderr.must_match("")
             end
           end
         end


### PR DESCRIPTION
@codeclimate/review Now that `validate-config` provides information about invalid engines, we can let `EnginesRunner` silently skip invalid engines.

