### PR TITLE
Improve Engine spec

### DIFF
--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -1,122 +1,122 @@
 require "spec_helper"
-require "ostruct"
-require 'support/test_formatter'
 
-describe CC::Analyzer::Engine do
-  before do
-    FileUtils.mkdir_p("/tmp/cc")
-  end
+module CC::Analyzer
+  describe Engine do
+    before do
+      FileUtils.mkdir_p("/tmp/cc")
+    end
 
-  describe "#run" do
-    it "uses the image and command in the metadata" do
-      expect_docker_run do |*args|
-        assert_within(["image", "command"], args)
+    describe "#run" do
+      it "uses the image and command in the metadata" do
+        expect_docker_run do |*args|
+          assert_within(["image", "command"], args)
+        end
+
+        run_engine(
+          "image" => "image",
+          "command" => "command",
+        )
       end
 
-      run_engine(
-        "image" => "image",
-        "command" => "command",
-      )
-    end
+      it "supports array commands" do
+        expect_docker_run do |*args|
+          assert_within(["foo", "bar"], args)
+        end
 
-    it "supports array commands" do
-      expect_docker_run do |*args|
-        assert_within(["foo", "bar"], args)
+        run_engine("command" => %w[foo bar])
       end
 
-      run_engine("command" => %w[foo bar])
-    end
+      it "runs the container in a constrained environment" do
+        expect_docker_run do |*args|
+          assert_within(["--cap-drop", "all"], args)
+          assert_within(["--memory", 512_000_000.to_s], args)
+          assert_within(["--memory-swap", "-1"], args)
+          assert_within(["--net", "none"], args)
+        end
 
-    it "runs the container in a constrained environment" do
-      expect_docker_run do |*args|
-        assert_within(["--cap-drop", "all"], args)
-        assert_within(["--memory", 512_000_000.to_s], args)
-        assert_within(["--memory-swap", "-1"], args)
-        assert_within(["--net", "none"], args)
+        run_engine
       end
 
-      run_engine
-    end
+      it "parses stdout for null-delimited issues" do
+        stdout = StringIO.new
+        stdout.write("issue one\0")
+        stdout.write("issue two\0")
+        stdout.write("issue three")
+        stdout.rewind
 
-    it "parses stdout for null-delimited issues" do
-      stdout = StringIO.new
-      stdout.write("issue one\0")
-      stdout.write("issue two\0")
-      stdout.write("issue three")
-      stdout.rewind
+        expect_docker_run(stdout)
 
-      expect_docker_run(stdout)
-
-      io = run_engine
-      io.string.must_equal("issue oneissue twoissue three")
-    end
-
-    it "supports issue filtering by check name" do
-      stdout = StringIO.new
-      stdout.write(%{{"type":"issue","check":"foo"}\0})
-      stdout.write(%{{"type":"issue","check":"bar"}\0})
-      stdout.write(%{{"type":"issue","check":"baz"}})
-      stdout.rewind
-
-      expect_docker_run(stdout)
-
-      io = run_engine({}, { "checks" => { "bar" => { "enabled" => false } } })
-      io.string.wont_match(%{"check":"bar"})
-    end
-
-    it "passes stderr to a formatter" do
-      expect_docker_run(StringIO.new, StringIO.new, failed_status)
-
-      lambda { run_engine }.must_raise(CC::Analyzer::Engine::EngineFailure)
-    end
-
-    it "ensures the container is cleaned up" do
-      expect_docker_run do |*args|
-        assert_within(["--rm"], args)
+        io = run_engine
+        io.string.must_equal("issue oneissue twoissue three")
       end
 
-      run_engine
-    end
+      it "supports issue filtering by check name" do
+        stdout = StringIO.new
+        stdout.write(%{{"type":"issue","check":"foo"}\0})
+        stdout.write(%{{"type":"issue","check":"bar"}\0})
+        stdout.write(%{{"type":"issue","check":"baz"}})
+        stdout.rewind
 
-    def run_engine(metadata = {}, config = {})
-      io = TestFormatter.new
-      options = {
-        "image" => "codeclimate/image-name",
-        "command" => "run",
-      }.merge(metadata)
-      config.reverse_merge!(exclude_paths: ["foo.rb"])
+        expect_docker_run(stdout)
 
-      engine = CC::Analyzer::Engine.new("rubocop", options, "/path", config, "sup")
-      engine.run(io)
-
-      io
-    end
-
-    def expect_docker_run(stdout = StringIO.new, stderr = StringIO.new, status = success_status, &block)
-      block ||= ->(*) { :unused }
-
-      Process.expects(:waitpid2).returns([1, status])
-      POSIX::Spawn.expects(:popen4).
-        with(&block).returns([1, nil, stdout, stderr])
-    end
-
-    # Assert that +a+ is included in full, in order within +b+.
-    def assert_within(a, b)
-      msg = "#{a.inspect} expected to appear within #{b.inspect}"
-
-      if idx = b.index(a.first)
-        assert(b[idx, a.length] == a, msg)
-      else
-        assert(false, msg)
+        io = run_engine({}, { "checks" => { "bar" => { "enabled" => false } } })
+        io.string.wont_match(%{"check":"bar"})
       end
-    end
 
-    def success_status
-      OpenStruct.new(exitstatus: 0, success?: true)
-    end
+      it "passes stderr to a formatter" do
+        expect_docker_run(StringIO.new, StringIO.new, failed_status)
 
-    def failed_status
-      OpenStruct.new(exitstatus: 1, success?: false)
+        lambda { run_engine }.must_raise(Engine::EngineFailure)
+      end
+
+      it "ensures the container is cleaned up" do
+        expect_docker_run do |*args|
+          assert_within(["--rm"], args)
+        end
+
+        run_engine
+      end
+
+      def run_engine(metadata = {}, config = {})
+        io = TestFormatter.new
+        options = {
+          "image" => "codeclimate/image-name",
+          "command" => "run",
+        }.merge(metadata)
+        config.reverse_merge!(exclude_paths: ["foo.rb"])
+
+        engine = Engine.new("rubocop", options, "/path", config, "sup")
+        engine.run(io)
+
+        io
+      end
+
+      def expect_docker_run(stdout = StringIO.new, stderr = StringIO.new, status = success_status, &block)
+        block ||= ->(*) { :unused }
+
+        Process.expects(:waitpid2).returns([1, status])
+        POSIX::Spawn.expects(:popen4).
+          with(&block).returns([1, nil, stdout, stderr])
+      end
+
+      # Assert that +a+ is included in full, in order within +b+.
+      def assert_within(a, b)
+        msg = "#{a.inspect} expected to appear within #{b.inspect}"
+
+        if idx = b.index(a.first)
+          assert(b[idx, a.length] == a, msg)
+        else
+          assert(false, msg)
+        end
+      end
+
+      def success_status
+        stub(exitstatus: 0, success?: true)
+      end
+
+      def failed_status
+        stub(exitstatus: 1, success?: false)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,10 @@ require "minitest/spec"
 require "minitest/autorun"
 require "minitest/reporters"
 require "mocha/mini_test"
-require "support/factory"
 require "cc/cli"
 require "cc/yaml"
+
+Dir.glob("spec/support/**/*.rb").each(&method(:load))
 
 Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new
 


### PR DESCRIPTION
- Replace OpenStruct with mocha stub
- Load anything in spec/support
- Nested describe to avoid namespacing

/cc @codeclimate/review

These are just some zero-impact improvements to the spec that I find useful in
another branch I'm working on (specifically the namespacing), and I'd like to
merge it first here to keep that eventual diff easier to review.