### PR TITLE
Support container logging within Engine

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -12,6 +12,7 @@ module CC
     autoload :IssueSorter,        "cc/analyzer/issue_sorter"
     autoload :LocationDescription,"cc/analyzer/location_description"
     autoload :NullConfig,         "cc/analyzer/null_config"
+    autoload :NullContainerLog,   "cc/analyzer/null_container_log"
     autoload :PathPatterns,       "cc/analyzer/path_patterns"
     autoload :SourceBuffer,       "cc/analyzer/source_buffer"
     autoload :UnitName,           "cc/analyzer/unit_name"

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -16,7 +16,9 @@ module CC
         @label = label.to_s
       end
 
-      def run(stdout_io, stderr_io = StringIO.new)
+      def run(stdout_io:, stderr_io: StringIO.new, container_log: NullContainerLog.new)
+        container_log.started(@metadata["image"])
+
         timed_out = false
         pid, _, out, err = POSIX::Spawn.popen4(*docker_run_command)
         Analyzer.statsd.increment("cli.engines.started")
@@ -55,8 +57,13 @@ module CC
           Analyzer.statsd.increment("cli.engines.result.error.timeout")
           Analyzer.statsd.increment("cli.engines.names.#{name}.result.error")
           Analyzer.statsd.increment("cli.engines.names.#{name}.result.error.timeout")
+          container_log.timed_out
           raise EngineTimeout, "engine #{name} ran past #{TIMEOUT} seconds and was killed"
-        elsif status.success?
+        end
+
+        container_log.finished(status, stderr_io.string)
+
+        if status.success?
           Analyzer.statsd.increment("cli.engines.names.#{name}.result.success")
           Analyzer.statsd.increment("cli.engines.result.success")
         else

--- a/lib/cc/analyzer/null_container_log.rb
+++ b/lib/cc/analyzer/null_container_log.rb
@@ -1,0 +1,14 @@
+module CC
+  module Analyzer
+    class NullContainerLog
+      def started(_image)
+      end
+
+      def timed_out
+      end
+
+      def finished(_status, _stderr)
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -77,7 +77,28 @@ module CC::Analyzer
         run_engine
       end
 
-      def run_engine(metadata = {}, config = {})
+      it "notifies the container log of start with the image name" do
+        container_log = TestContainerLog.new
+        expect_docker_run
+
+        run_engine({ "image" => "test/image" }, {}, container_log)
+
+        container_log.started_image.must_equal "test/image"
+      end
+
+      # N.B. test case for timed_out omitted because it's basically impossible
+
+      it "notifies the container log of finish with the status and stderr" do
+        container_log = TestContainerLog.new
+        expect_docker_run
+
+        run_engine({}, {}, container_log)
+
+        container_log.finished_status.exitstatus.must_equal 0
+        container_log.finished_stderr.must_equal ""
+      end
+
+      def run_engine(metadata = {}, config = {}, container_log = NullContainerLog.new)
         io = TestFormatter.new
         options = {
           "image" => "codeclimate/image-name",
@@ -86,7 +107,7 @@ module CC::Analyzer
         config.reverse_merge!(exclude_paths: ["foo.rb"])
 
         engine = Engine.new("rubocop", options, "/path", config, "sup")
-        engine.run(io)
+        engine.run(stdout_io: io, container_log: container_log)
 
         io
       end

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -90,7 +90,8 @@ module CC::Analyzer
 
     def expect_engine_run(name, source_dir, formatter, engine_config = nil)
       engine = stub(name: name)
-      engine.expects(:run).with(formatter)
+      engine.expects(:run).
+        with(has_entry(stdout_io: formatter))
 
       image = "codeclimate/codeclimate-#{name}"
       engine_config ||= { "enabled" => true, exclude_paths: [] }

--- a/spec/support/test_container_log.rb
+++ b/spec/support/test_container_log.rb
@@ -1,0 +1,16 @@
+class TestContainerLog
+  attr_reader :started_image, :timed_out, :finished_status, :finished_stderr
+
+  def started(image)
+    @started_image = image
+  end
+
+  def timed_out
+    @timed_out = true
+  end
+
+  def finished(status, stderr)
+    @finished_status = status
+    @finished_stderr = stderr
+  end
+end


### PR DESCRIPTION
We want to log the actions of starting, finishing, or timing out containers
into the database via Kafka/Wally. We will initially expose this information in
Admin and eventually to users via some kind of Builds dashboard.

Unfortunately, these actions occur very far away from the code that is actually
able to perform the logging:

    CC::Builder  |  CC::Analyzer
    =============|============================
    Runner      -|-> EnginesRunner -> Engine
      |                                 |
      V                                 V
    Kafka                           docker run

The approach implemented here passes a ContainerLogger object into
EnginesRunner and onto each Engine. This object responds to event methods which
the Engine invokes as it starts and stops containers.

Within this code base, the object is a NullContainerLogger and does nothing for
these events, but Builder will be able to pass a real ContainerLogger that
writes the information to the database through Kafka.

Other approaches considered and ruled out or deferred:

- Reifying a Container object to hold the docker run and (optionally) event
  logging logic

  This class could have been reusable for the (eventually container-based)
  Clone logic in Builder and taken advantage of the homogeneity that provides.
  Unfortunately, we would still be invoking Container from within Engine as
  it's very useful to share the EngineRunner and Engine objects between Builder
  and Analyzer, so it wouldn't help us in our immediate goal.

  When we do have the cloning performed in a container, creating such a class
  to hold the Posix::Spawn and timeout logic would make sense.

- Customizable life-cycle methods on Engine

  This would bloat Engine with new concerns and not be significantly more
  convenient for the objects that wanted to do logging.

  The object in charge of the actions to take only knows about EnginesRunner,
  so these actions would need to be passed through to Engine somehow.

  This would mean treating functions as values (setting and calling lambdas for
  the container life cycle events), and that is not idiomatic Ruby.

/cc @codeclimate/review 