### PR TITLE
WIP: Sketch for improving Engine

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -12,6 +12,7 @@ module CC
     autoload :IssueSorter,        "cc/analyzer/issue_sorter"
     autoload :LocationDescription,"cc/analyzer/location_description"
     autoload :NullConfig,         "cc/analyzer/null_config"
+    autoload :NullContainerLog,   "cc/analyzer/null_container_log"
     autoload :PathPatterns,       "cc/analyzer/path_patterns"
     autoload :SourceBuffer,       "cc/analyzer/source_buffer"
     autoload :UnitName,           "cc/analyzer/unit_name"

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -1,0 +1,70 @@
+module CC
+  module Analyzer
+    class Container
+      TIMEOUT = 15 * 60 # 15m
+
+      def initialize(image, command = nil, log = nil)
+        @image = image
+        @command = command
+        @log = log || NullContainerLog.new
+
+        @output_delimeter = "\n"
+        @on_output = ->(*)
+
+        @timed_out = false
+        @stderr_io = StringIO.new
+      end
+
+      def on_output(delimeter = "\n", &block)
+        @output_delimeter = delimeter
+        @on_output = block
+      end
+
+      def run(options)
+        @log.started(@image)
+
+        pid, _, out, err = POSIX::Spawn.popen4(*docker_run_command)
+
+        t_out = read_stdout(out)
+        t_err = read_stderr(err)
+        t_timeout = timeout_thread(pid)
+
+        _, status = Process.waitpid2(pid)
+
+        t_timeout.kill
+      ensure
+        t_timeout.kill if t_timeout
+
+        if @timed_out
+          t_out.kill if t_out
+          t_err.kill if t_err
+        else
+          t_out.join if t_out
+          t_err.join if t_err
+        end
+      end
+
+      private
+
+      def read_stdout(out)
+        Thread.new do
+          out.each_line(@output_delimeter, &@on_output)
+        end
+      end
+
+      def read_stderr(err)
+        Thread.new do
+          err.each_line { |line| stderr_io.write(line) }
+        end
+      end
+
+      def timeout_thread(pid)
+        Thread.new do
+          sleep TIMEOUT
+          Process.kill("KILL", pid)
+          @timed_out = true
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -4,9 +4,10 @@ require "securerandom"
 module CC
   module Analyzer
     class Engine
-      attr_reader :name
+      EngineFailure = Class.new(StandardError)
+      EngineTimeout = Class.new(StandardError)
 
-      TIMEOUT = 15 * 60 # 15m
+      attr_reader :name
 
       def initialize(name, metadata, code_path, config, label)
         @name = name
@@ -16,83 +17,28 @@ module CC
         @label = label.to_s
       end
 
-      def run(stdout_io, stderr_io = StringIO.new, container_log = NullContainerLog.new)
-        container_log.started(@metadata["image"])
+      def run(stdout_io, container_log = NullContainerLog.new)
+        container = Container.new(
+          @metadata["image"],
+          @metadata["command"],
+          ContainerLogLog.new(name, container_log)
+        )
 
-        timed_out = false
-        pid, _, out, err = POSIX::Spawn.popen4(*docker_run_command)
-        Analyzer.statsd.increment("cli.engines.started")
+        container.on_output("\0") do |chunk|
+          output = chunk.chomp("\0")
 
-        t_out = Thread.new do
-          out.each_line("\0") do |chunk|
-            output = chunk.chomp("\0")
-
-            unless output_filter.filter?(output)
-              stdout_io.write(output)
-            end
+          unless output_filter.filter?(output)
+            stdout_io.write(output)
           end
         end
 
-        t_err = Thread.new do
-          err.each_line do |line|
-            if stderr_io
-              stderr_io.write(line)
-            end
-          end
-        end
-
-        t_timeout = Thread.new do
-          sleep TIMEOUT
-          run_command("docker kill #{container_name} || true")
-          timed_out = true
-        end
-
-        pid, status = Process.waitpid2(pid)
-        t_timeout.kill
-
-        Analyzer.statsd.increment("cli.engines.finished")
-
-        if timed_out
-          Analyzer.statsd.increment("cli.engines.result.error")
-          Analyzer.statsd.increment("cli.engines.result.error.timeout")
-          Analyzer.statsd.increment("cli.engines.names.#{name}.result.error")
-          Analyzer.statsd.increment("cli.engines.names.#{name}.result.error.timeout")
-          container_log.timed_out
-          raise EngineTimeout, "engine #{name} ran past #{TIMEOUT} seconds and was killed"
-        end
-
-        container_log.finished(status, stderr_io.string)
-
-        if status.success?
-          Analyzer.statsd.increment("cli.engines.names.#{name}.result.success")
-          Analyzer.statsd.increment("cli.engines.result.success")
-        else
-          Analyzer.statsd.increment("cli.engines.names.#{name}.result.error")
-          Analyzer.statsd.increment("cli.engines.result.error")
-          raise EngineFailure, "engine #{name} failed with status #{status.exitstatus} and stderr \n#{stderr_io.string}"
-        end
-      ensure
-        t_timeout.kill if t_timeout
-
-        if timed_out
-          t_out.kill if t_out
-          t_err.kill if t_err
-        else
-          t_out.join if t_out
-          t_err.join if t_err
-        end
+        container.run(container_options)
       end
 
       private
 
-      def container_name
-        @container_name ||= "cc-engines-#{name}-#{SecureRandom.uuid}"
-      end
-
-      def docker_run_command
+      def container_options
         [
-          "docker", "run",
-          "--rm",
           "--cap-drop", "all",
           "--label", "com.codeclimate.label=#{@label}",
           "--name", container_name,
@@ -102,9 +48,11 @@ module CC
           "--volume", "#{@code_path}:/code:ro",
           "--volume", "#{config_file}:/config.json:ro",
           "--user", "9000:9000",
-          @metadata["image"],
-          @metadata["command"], # String or Array
-        ].flatten.compact
+        ]
+      end
+
+      def container_name
+        @container_name ||= "cc-engines-#{name}-#{SecureRandom.uuid}"
       end
 
       def config_file
@@ -113,21 +61,48 @@ module CC
         path
       end
 
-      def run_command(command)
-        spawn = POSIX::Spawn::Child.new(command)
-
-        unless spawn.status.success?
-          raise CommandFailure, "command '#{command}' failed with status #{spawn.status.exitstatus} and output #{spawn.err}"
-        end
-      end
-
       def output_filter
         @output_filter ||= EngineOutputFilter.new(@config)
       end
 
-      CommandFailure = Class.new(StandardError)
-      EngineFailure = Class.new(StandardError)
-      EngineTimeout = Class.new(StandardError)
+      class ContainerLog
+        def initialize(name, inner_log)
+          @name = name
+          @inner_log = inner_log
+        end
+
+        def started(image)
+          @inner_log.started(image)
+
+          Analyzer.statsd.increment("cli.engines.started")
+        end
+
+        def timed_out
+          @inner_log.timed_out
+
+          Analyzer.statsd.increment("cli.engines.result.error")
+          Analyzer.statsd.increment("cli.engines.result.error.timeout")
+          Analyzer.statsd.increment("cli.engines.names.#{@name}.result.error")
+          Analyzer.statsd.increment("cli.engines.names.#{@name}.result.error.timeout")
+
+          raise EngineTimeout, "engine #{@name} ran past #{TIMEOUT} seconds and was killed"
+        end
+
+        def finished(status, stderr)
+          @inner_log.finished(status, stderr)
+
+          Analyzer.statsd.increment("cli.engines.finished")
+
+          if status.success?
+            Analyzer.statsd.increment("cli.engines.result.success")
+            Analyzer.statsd.increment("cli.engines.names.#{@name}.result.success")
+          else
+            Analyzer.statsd.increment("cli.engines.result.error")
+            Analyzer.statsd.increment("cli.engines.names.#{@name}.result.error")
+            raise EngineFailure, "engine #{@name} failed with status #{status.exitstatus} and stderr \n#{stderr}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -21,7 +21,7 @@ module CC
         container = Container.new(
           @metadata["image"],
           @metadata["command"],
-          ContainerLogLog.new(name, container_log)
+          ContainerLog.new(name, container_log)
         )
 
         container.on_output("\0") do |chunk|

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -14,14 +14,14 @@ module CC
         @container_label = container_label
       end
 
-      def run
+      def run(container_log = NullContainerLog.new)
         raise NoEnabledEngines if engines.empty?
 
         Analyzer.logger.info("running #{engines.size} engines")
 
         @formatter.started
 
-        engines.each { |engine| run_engine(engine) }
+        engines.each { |engine| run_engine(engine, container_log) }
 
         @formatter.finished
       ensure
@@ -30,13 +30,13 @@ module CC
 
       private
 
-      def run_engine(engine)
+      def run_engine(engine, container_log)
         Analyzer.logger.info("starting engine #{engine.name}")
 
         Analyzer.statsd.time("engines.time") do
           Analyzer.statsd.time("engines.names.#{engine.name}.time") do
             @formatter.engine_running(engine) do
-              engine.run(@formatter)
+              engine.run(@formatter, StringIO.new, container_log)
             end
           end
         end

--- a/lib/cc/analyzer/null_container_log.rb
+++ b/lib/cc/analyzer/null_container_log.rb
@@ -1,0 +1,14 @@
+module CC
+  module Analyzer
+    class NullContainerLog
+      def started(_image)
+      end
+
+      def timed_out
+      end
+
+      def finished(_status, _stderr)
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -90,7 +90,7 @@ module CC::Analyzer
 
     def expect_engine_run(name, source_dir, formatter, engine_config = nil)
       engine = stub(name: name)
-      engine.expects(:run).with(formatter)
+      engine.expects(:run).with(formatter, kind_of(StringIO), kind_of(NullContainerLog))
 
       image = "codeclimate/codeclimate-#{name}"
       engine_config ||= { "enabled" => true, exclude_paths: [] }

--- a/spec/support/test_container_log.rb
+++ b/spec/support/test_container_log.rb
@@ -1,0 +1,16 @@
+class TestContainerLog
+  attr_reader :started_image, :timed_out, :finished_status, :finished_stderr
+
+  def started(image)
+    @started_image = image
+  end
+
+  def timed_out
+    @timed_out = true
+  end
+
+  def finished(status, stderr)
+    @finished_status = status
+    @finished_stderr = stderr
+  end
+end


### PR DESCRIPTION
/cc @codeclimate/review

This is as sketch. It's built on top of pb-container-log. If we think this is a
good direction, I'll wait for that to merge and open a new PR from this branch
after rebasing, adding/fixing tests etc.

---

New responsibility breakdown:

**Container**: launch a docker container, give its stdout to the caller,
capture its stderr, monitor its process, handle timeouts, call life-cycle
events on the container-log given.

**Engine::ContainerLog**: perform the statsd calls on container life-cycle
events and then forward those events to the log its been given; sort of a
ContainerLog middleware stack idea.

**Engine**: launch and run a Container for the engine, specify how to shuttle
null-delimited stdout to the formatter, compose its container-log with the one
given.

Benefits:

- Engine is smaller, more focused
- Container is reusable for Clone in builder
- Container is easier to reason about (i.e. the complex timeout logic is
  clearer IMO)

Notable change:

Rather than spawning `docker kill` I'm using Ruby's `Process.kill`, the two
should be equivalent and this was more convenient with the way the code is now
(e.g. no need to track container-name).