### PR TITLE
Extract Container class from Engine

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -2,6 +2,7 @@ module CC
   module Analyzer
     autoload :Accumulator,        "cc/analyzer/accumulator"
     autoload :Config,             "cc/analyzer/config"
+    autoload :Container,          "cc/analyzer/container"
     autoload :Engine,             "cc/analyzer/engine"
     autoload :EngineClient,       "cc/analyzer/engine_client"
     autoload :EngineOutputFilter, "cc/analyzer/engine_output_filter"

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -1,0 +1,98 @@
+require "posix/spawn"
+
+module CC
+  module Analyzer
+    class Container
+      DEFAULT_TIMEOUT = 15 * 60 # 15m
+
+      def initialize(
+        image:,
+        name:,
+        command: nil,
+        log: NullContainerLog.new,
+        timeout: DEFAULT_TIMEOUT
+      )
+        @image = image
+        @name = name
+        @command = command
+        @log = log
+        @timeout = timeout
+
+        @output_delimeter = "\n"
+        @on_output = ->(*) { }
+
+        @timed_out = false
+        @stderr_io = StringIO.new
+      end
+
+      def on_output(delimeter = "\n", &block)
+        @output_delimeter = delimeter
+        @on_output = block
+      end
+
+      def run(options = [])
+        @log.started(@image, @name)
+
+        pid, _, out, err = POSIX::Spawn.popen4(*docker_run_command(options))
+
+        t_out = read_stdout(out)
+        t_err = read_stderr(err)
+        t_timeout = timeout_thread(pid)
+
+        _, status = Process.waitpid2(pid)
+
+        @log.finished(status, @stderr_io.string)
+
+        t_timeout.kill
+      ensure
+        t_timeout.kill if t_timeout
+
+        if @timed_out
+          @log.timed_out(@timeout)
+          t_out.kill if t_out
+          t_err.kill if t_err
+        else
+          t_out.join if t_out
+          t_err.join if t_err
+        end
+      end
+
+      private
+
+      def docker_run_command(options)
+        [
+          "docker", "run",
+          "--rm",
+          "--name", @name,
+          options,
+          @image,
+          @command,
+        ].flatten.compact
+      end
+
+      def read_stdout(out)
+        Thread.new do
+          out.each_line(@output_delimeter) do |chunk|
+            output = chunk.chomp(@output_delimeter)
+
+            @on_output.call(output)
+          end
+        end
+      end
+
+      def read_stderr(err)
+        Thread.new do
+          err.each_line { |line| @stderr_io.write(line) }
+        end
+      end
+
+      def timeout_thread(pid)
+        Thread.new do
+          sleep @timeout
+          @timed_out = true
+          Process.kill("KILL", pid)
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -1,12 +1,11 @@
-require "posix/spawn"
 require "securerandom"
 
 module CC
   module Analyzer
     class Engine
-      attr_reader :name
+      autoload :ContainerLog, "cc/analyzer/engine/container_log"
 
-      TIMEOUT = 15 * 60 # 15m
+      attr_reader :name
 
       def initialize(name, metadata, code_path, config, label)
         @name = name
@@ -16,95 +15,40 @@ module CC
         @label = label.to_s
       end
 
-      def run(stdout_io:, stderr_io: StringIO.new, container_log: NullContainerLog.new)
-        container_log.started(@metadata["image"])
+      def run(stdout_io:, container_log: NullContainerLog.new)
+        container = Container.new(
+          image: @metadata["image"],
+          command: @metadata["command"],
+          name: container_name,
+          log: ContainerLog.new(name, container_log)
+        )
 
-        timed_out = false
-        pid, _, out, err = POSIX::Spawn.popen4(*docker_run_command)
-        Analyzer.statsd.increment("cli.engines.started")
-
-        t_out = Thread.new do
-          out.each_line("\0") do |chunk|
-            output = chunk.chomp("\0")
-
-            unless output_filter.filter?(output)
-              stdout_io.write(output)
-            end
+        container.on_output("\0") do |output|
+          unless output_filter.filter?(output)
+            stdout_io.write(output)
           end
         end
 
-        t_err = Thread.new do
-          err.each_line do |line|
-            if stderr_io
-              stderr_io.write(line)
-            end
-          end
-        end
-
-        t_timeout = Thread.new do
-          sleep TIMEOUT
-          run_command("docker kill #{container_name} || true")
-          timed_out = true
-        end
-
-        pid, status = Process.waitpid2(pid)
-        t_timeout.kill
-
-        Analyzer.statsd.increment("cli.engines.finished")
-
-        if timed_out
-          Analyzer.statsd.increment("cli.engines.result.error")
-          Analyzer.statsd.increment("cli.engines.result.error.timeout")
-          Analyzer.statsd.increment("cli.engines.names.#{name}.result.error")
-          Analyzer.statsd.increment("cli.engines.names.#{name}.result.error.timeout")
-          container_log.timed_out
-          raise EngineTimeout, "engine #{name} ran past #{TIMEOUT} seconds and was killed"
-        end
-
-        container_log.finished(status, stderr_io.string)
-
-        if status.success?
-          Analyzer.statsd.increment("cli.engines.names.#{name}.result.success")
-          Analyzer.statsd.increment("cli.engines.result.success")
-        else
-          Analyzer.statsd.increment("cli.engines.names.#{name}.result.error")
-          Analyzer.statsd.increment("cli.engines.result.error")
-          raise EngineFailure, "engine #{name} failed with status #{status.exitstatus} and stderr \n#{stderr_io.string}"
-        end
-      ensure
-        t_timeout.kill if t_timeout
-
-        if timed_out
-          t_out.kill if t_out
-          t_err.kill if t_err
-        else
-          t_out.join if t_out
-          t_err.join if t_err
-        end
+        container.run(container_options)
       end
 
       private
 
-      def container_name
-        @container_name ||= "cc-engines-#{name}-#{SecureRandom.uuid}"
-      end
-
-      def docker_run_command
+      def container_options
         [
-          "docker", "run",
-          "--rm",
           "--cap-drop", "all",
           "--label", "com.codeclimate.label=#{@label}",
-          "--name", container_name,
           "--memory", 512_000_000.to_s, # bytes
           "--memory-swap", "-1",
           "--net", "none",
           "--volume", "#{@code_path}:/code:ro",
           "--volume", "#{config_file}:/config.json:ro",
           "--user", "9000:9000",
-          @metadata["image"],
-          @metadata["command"], # String or Array
-        ].flatten.compact
+        ]
+      end
+
+      def container_name
+        @container_name ||= "cc-engines-#{name}-#{SecureRandom.uuid}"
       end
 
       def config_file
@@ -113,21 +57,9 @@ module CC
         path
       end
 
-      def run_command(command)
-        spawn = POSIX::Spawn::Child.new(command)
-
-        unless spawn.status.success?
-          raise CommandFailure, "command '#{command}' failed with status #{spawn.status.exitstatus} and output #{spawn.err}"
-        end
-      end
-
       def output_filter
         @output_filter ||= EngineOutputFilter.new(@config)
       end
-
-      CommandFailure = Class.new(StandardError)
-      EngineFailure = Class.new(StandardError)
-      EngineTimeout = Class.new(StandardError)
     end
   end
 end

--- a/lib/cc/analyzer/engine/container_log.rb
+++ b/lib/cc/analyzer/engine/container_log.rb
@@ -1,0 +1,48 @@
+module CC
+  module Analyzer
+    class Engine
+      EngineFailure = Class.new(StandardError)
+      EngineTimeout = Class.new(StandardError)
+
+      class ContainerLog
+        def initialize(name, inner_log)
+          @name = name
+          @inner_log = inner_log
+        end
+
+        def started(image, name)
+          @inner_log.started(image, name)
+
+          Analyzer.statsd.increment("cli.engines.started")
+        end
+
+        def timed_out(timeout)
+          @inner_log.timed_out(timeout)
+
+          Analyzer.statsd.increment("cli.engines.result.error")
+          Analyzer.statsd.increment("cli.engines.result.error.timeout")
+          Analyzer.statsd.increment("cli.engines.names.#{@name}.result.error")
+          Analyzer.statsd.increment("cli.engines.names.#{@name}.result.error.timeout")
+
+          raise EngineTimeout, "engine #{@name} ran past #{timeout} seconds and was killed"
+        end
+
+        def finished(status, stderr)
+          @inner_log.finished(status, stderr)
+
+          Analyzer.statsd.increment("cli.engines.finished")
+
+          if status.success?
+            Analyzer.statsd.increment("cli.engines.result.success")
+            Analyzer.statsd.increment("cli.engines.names.#{@name}.result.success")
+          else
+            Analyzer.statsd.increment("cli.engines.result.error")
+            Analyzer.statsd.increment("cli.engines.names.#{@name}.result.error")
+
+            raise EngineFailure, "engine #{@name} failed with status #{status.exitstatus} and stderr \n#{stderr}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/null_container_log.rb
+++ b/lib/cc/analyzer/null_container_log.rb
@@ -1,10 +1,10 @@
 module CC
   module Analyzer
     class NullContainerLog
-      def started(_image)
+      def started(_image, _name)
       end
 
-      def timed_out
+      def timed_out(_seconds)
       end
 
       def finished(_status, _stderr)

--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -1,0 +1,117 @@
+require "spec_helper"
+
+module CC::Analyzer
+  describe Container do
+    describe "#run" do
+      it "spawns docker run with the image, name, and options given" do
+        container = Container.new(image: "codeclimate/foo", name: "name")
+
+        expect_spawn(%w[ docker run --rm --name name -i -t codeclimate/foo ])
+
+        container.run(%w[ -i -t ])
+      end
+
+      it "spawns the command if present" do
+        container = Container.new(image: "codeclimate/foo", command: "bar", name: "name")
+
+        expect_spawn(%w[ docker run --rm --name name codeclimate/foo bar ])
+
+        container.run
+      end
+
+      it "spawns an array command if given" do
+        container = Container.new(image: "codeclimate/foo", command: %w[ bar baz ], name: "name")
+
+        expect_spawn(%w[ docker run --rm --name name codeclimate/foo bar baz ])
+
+        container.run
+      end
+
+      it "spawns an array command with spaces" do
+        container = Container.new(
+          image: "codeclimate/foo",
+          command: %w[ bar baz\ bat ],
+          name: "name",
+        )
+
+        expect_spawn(%w[ docker run --rm --name name codeclimate/foo bar baz\ bat ])
+
+        container.run
+      end
+
+      it "sends output to the defined handler splitting on the defined delimiter" do
+        collected_output = []
+        container = Container.new(image: "codeclimate/foo", name: "name")
+        container.on_output("\0") { |output| collected_output << output }
+
+        out = StringIO.new
+        out.write("foo\0bar\0")
+        out.rewind
+        stub_spawn(out: out)
+
+        container.run
+
+        collected_output.must_equal %w[ foo bar ]
+      end
+
+      it "logs a start event to the given container log" do
+        stub_spawn
+        log = TestContainerLog.new
+        container = Container.new(image: "codeclimate/foo", name: "name", log: log)
+
+        container.run
+
+        log.started_image.must_equal "codeclimate/foo"
+        log.started_name.must_equal "name"
+      end
+
+      it "logs a finished event with status and stderr" do
+        log = TestContainerLog.new
+        container = Container.new(image: "codeclimate/foo", name: "name", log: log)
+
+        err = StringIO.new
+        err.puts("error one")
+        err.puts("error two")
+        err.rewind
+        stub_spawn(status: :failed, err: err)
+
+        container.run
+
+        log.finished_status.must_equal :failed
+        log.finished_stderr.must_equal "error one\nerror two\n"
+      end
+
+      it "times out slow containers" do
+        log = TestContainerLog.new
+        container = Container.new(image: "codeclimate/foo", name: "name", log: log, timeout: 0)
+
+        # N.B. stubbing a private method is a Bad Idea, but it's the best I can
+        # come up with here. Rather than invoke docker, we invoke a slow command
+        # in order to trigger the timeout logic.
+        container.stubs(:docker_run_command).returns(%w[ sleep 5 ])
+
+        container.run
+
+        log.timed_out?.must_equal true
+      end
+    end
+
+    def stub_spawn(status: nil, out: StringIO.new, err: StringIO.new)
+      pid = 42
+
+      POSIX::Spawn.stubs(:popen4).returns([pid, nil, out, err])
+      Process.stubs(:waitpid2).with(pid).returns([nil, status])
+
+      return [pid, out, err]
+    end
+
+    def expect_spawn(args, status: nil, out: StringIO.new, err: StringIO.new)
+      pid = 42
+
+      POSIX::Spawn.expects(:popen4).with(*args).returns([pid, nil, out, err])
+      Process.expects(:waitpid2).with(pid).returns([nil, status])
+
+      return [pid, out, err]
+    end
+  end
+end

--- a/spec/cc/analyzer/engine/container_log_spec.rb
+++ b/spec/cc/analyzer/engine/container_log_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+class CC::Analyzer::Engine
+  describe ContainerLog do
+    describe "#started" do
+      it "forwards the call to the inner log" do
+        inner_log = TestContainerLog.new
+        container_log = ContainerLog.new("", inner_log)
+
+        container_log.started("image", "name")
+
+        inner_log.started_image.must_equal "image"
+        inner_log.started_name.must_equal "name"
+      end
+    end
+
+    describe "#timed_out" do
+      it "forwards the call to the inner log" do
+        inner_log = TestContainerLog.new
+        container_log = ContainerLog.new("", inner_log)
+
+        container_log.timed_out(900) rescue nil
+
+        inner_log.timed_out?.must_equal true
+        inner_log.timed_out_seconds.must_equal 900
+      end
+
+      it "raises Engine::EngineTimeout" do
+        inner_log = TestContainerLog.new
+        container_log = ContainerLog.new("", inner_log)
+
+        action = ->() { container_log.timed_out(900) }
+        action.must_raise(EngineTimeout)
+      end
+    end
+
+    describe "#finished" do
+      it "forwards the call to the inner log" do
+        status = stub(success?: true)
+        inner_log = TestContainerLog.new
+        container_log = ContainerLog.new("", inner_log)
+
+        container_log.finished(status, "stderr")
+
+        inner_log.finished_status.must_equal status
+        inner_log.finished_stderr.must_equal "stderr"
+      end
+
+      it "raises an Engine::EngineFailure if unsuccessful" do
+        status = stub(success?: false, exitstatus: 1)
+        inner_log = TestContainerLog.new
+        container_log = ContainerLog.new("", inner_log)
+
+        action = ->() { container_log.finished(status, "stderr") }
+        action.must_raise(EngineFailure)
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -7,136 +7,84 @@ module CC::Analyzer
     end
 
     describe "#run" do
-      it "uses the image and command in the metadata" do
-        expect_docker_run do |*args|
-          assert_within(["image", "command"], args)
-        end
+      it "passes the correct options to Container" do
+        container = stub
+        container.stubs(:on_output).yields("")
+        container.stubs(:run)
 
-        run_engine(
-          "image" => "image",
-          "command" => "command",
-        )
+        Container.expects(:new).with do |args|
+          args[:image].must_equal "codeclimate/foo"
+          args[:command].must_equal "bar"
+          args[:name].must_match /^cc-engines-foo/
+        end.returns(container)
+
+        metadata = { "image" => "codeclimate/foo", "command" => "bar" }
+        engine = Engine.new("foo", metadata, "", {}, "")
+        engine.run(stdout_io: StringIO.new)
       end
 
-      it "supports array commands" do
-        expect_docker_run do |*args|
-          assert_within(["foo", "bar"], args)
-        end
+      it "runs a Container in a constrained environment" do
+        container = stub
+        container.stubs(:on_output).yields("")
 
-        run_engine("command" => %w[foo bar])
+        container.expects(:run).with(includes(
+          "--cap-drop", "all",
+          "--label", "com.codeclimate.label=a-label",
+          "--memory", "512000000",
+          "--memory-swap", "-1",
+          "--net", "none",
+          "--volume", "/code:/code:ro",
+          "--user", "9000:9000",
+        ))
+
+        Container.expects(:new).returns(container)
+        engine = Engine.new("", {}, "/code", {}, "a-label")
+        engine.run(stdout_io: StringIO.new)
       end
 
-      it "runs the container in a constrained environment" do
-        expect_docker_run do |*args|
-          assert_within(["--cap-drop", "all"], args)
-          assert_within(["--memory", 512_000_000.to_s], args)
-          assert_within(["--memory-swap", "-1"], args)
-          assert_within(["--net", "none"], args)
-        end
+      it "passes its container log wrapping the given one" do
+        container = stub
+        container.stubs(:on_output).yields("")
+        container.stubs(:run)
 
-        run_engine
+        given_log = stub
+        container_log = stub
+        Engine::ContainerLog.expects(:new).with("foo", given_log).returns(container_log)
+        Container.expects(:new).with(has_entry(log: container_log)).returns(container)
+
+        engine = Engine.new("foo", {}, "", {}, "")
+        engine.run(stdout_io: StringIO.new, container_log: given_log)
       end
 
       it "parses stdout for null-delimited issues" do
+        container = TestContainer.new([
+          "issue one",
+          "issue two",
+          "issue three",
+        ])
+        Container.expects(:new).returns(container)
+
         stdout = StringIO.new
-        stdout.write("issue one\0")
-        stdout.write("issue two\0")
-        stdout.write("issue three")
-        stdout.rewind
+        engine = Engine.new("", {}, "", {}, "")
+        engine.run(stdout_io: stdout)
 
-        expect_docker_run(stdout)
-
-        io = run_engine
-        io.string.must_equal("issue oneissue twoissue three")
+        stdout.string.must_equal "issue oneissue twoissue three"
       end
 
       it "supports issue filtering by check name" do
+        container = TestContainer.new([
+          %{{"type":"issue","check":"foo"}},
+          %{{"type":"issue","check":"bar"}},
+          %{{"type":"issue","check":"baz"}},
+        ])
+        Container.expects(:new).returns(container)
+
         stdout = StringIO.new
-        stdout.write(%{{"type":"issue","check":"foo"}\0})
-        stdout.write(%{{"type":"issue","check":"bar"}\0})
-        stdout.write(%{{"type":"issue","check":"baz"}})
-        stdout.rewind
+        config = { "checks" => { "bar" => { "enabled" => false } } }
+        engine = Engine.new("", {}, "", config, "")
+        engine.run(stdout_io: stdout)
 
-        expect_docker_run(stdout)
-
-        io = run_engine({}, { "checks" => { "bar" => { "enabled" => false } } })
-        io.string.wont_match(%{"check":"bar"})
-      end
-
-      it "passes stderr to a formatter" do
-        expect_docker_run(StringIO.new, StringIO.new, failed_status)
-
-        lambda { run_engine }.must_raise(Engine::EngineFailure)
-      end
-
-      it "ensures the container is cleaned up" do
-        expect_docker_run do |*args|
-          assert_within(["--rm"], args)
-        end
-
-        run_engine
-      end
-
-      it "notifies the container log of start with the image name" do
-        container_log = TestContainerLog.new
-        expect_docker_run
-
-        run_engine({ "image" => "test/image" }, {}, container_log)
-
-        container_log.started_image.must_equal "test/image"
-      end
-
-      # N.B. test case for timed_out omitted because it's basically impossible
-
-      it "notifies the container log of finish with the status and stderr" do
-        container_log = TestContainerLog.new
-        expect_docker_run
-
-        run_engine({}, {}, container_log)
-
-        container_log.finished_status.exitstatus.must_equal 0
-        container_log.finished_stderr.must_equal ""
-      end
-
-      def run_engine(metadata = {}, config = {}, container_log = NullContainerLog.new)
-        io = TestFormatter.new
-        options = {
-          "image" => "codeclimate/image-name",
-          "command" => "run",
-        }.merge(metadata)
-        config.reverse_merge!(exclude_paths: ["foo.rb"])
-
-        engine = Engine.new("rubocop", options, "/path", config, "sup")
-        engine.run(stdout_io: io, container_log: container_log)
-
-        io
-      end
-
-      def expect_docker_run(stdout = StringIO.new, stderr = StringIO.new, status = success_status, &block)
-        block ||= ->(*) { :unused }
-
-        Process.expects(:waitpid2).returns([1, status])
-        POSIX::Spawn.expects(:popen4).
-          with(&block).returns([1, nil, stdout, stderr])
-      end
-
-      # Assert that +a+ is included in full, in order within +b+.
-      def assert_within(a, b)
-        msg = "#{a.inspect} expected to appear within #{b.inspect}"
-
-        if idx = b.index(a.first)
-          assert(b[idx, a.length] == a, msg)
-        else
-          assert(false, msg)
-        end
-      end
-
-      def success_status
-        stub(exitstatus: 0, success?: true)
-      end
-
-      def failed_status
-        stub(exitstatus: 1, success?: false)
+        stdout.string.wont_match(%{"check":"bar"})
       end
     end
   end

--- a/spec/support/test_container.rb
+++ b/spec/support/test_container.rb
@@ -1,0 +1,14 @@
+class TestContainer
+  def initialize(outputs)
+    @outputs = outputs
+    @on_output = ->(*) { }
+  end
+
+  def on_output(*, &block)
+    @on_output = block
+  end
+
+  def run(*)
+    @outputs.each { |output| @on_output.call(output) }
+  end
+end

--- a/spec/support/test_container_log.rb
+++ b/spec/support/test_container_log.rb
@@ -1,12 +1,18 @@
 class TestContainerLog
-  attr_reader :started_image, :timed_out, :finished_status, :finished_stderr
+  attr_reader :started_image, :started_name, :timed_out_seconds, :finished_status, :finished_stderr
 
-  def started(image)
+  def started(image, name)
     @started_image = image
+    @started_name = name
   end
 
-  def timed_out
+  def timed_out(seconds)
+    @timed_out_seconds = seconds
     @timed_out = true
+  end
+
+  def timed_out?
+    @timed_out
   end
 
   def finished(status, stderr)


### PR DESCRIPTION
New responsibility breakdown:

**Container**: launch a docker container, give its stdout to the caller,
capture its stderr, monitor its process, handle timeouts, call life-cycle
events on the container-log given.

**Engine::ContainerLog**: perform the statsd calls on container life-cycle
events and then forward those events to the log its been given; sort of a
ContainerLog middleware stack idea.

**Engine**: launch and run a Container for the engine, specify how to shuttle
null-delimited stdout to the formatter, compose its container-log with the one
given.

Benefits:

- Engine is smaller
- Engine#run is smaller
- Container is singly-responsible and reusable for Clone in builder
- Easier to reason about (complex timeout logic is clearer IMO)
- Better tested

Notable change:

Rather than spawning `docker kill` I'm using Ruby's `Process.kill`, the two
should be equivalent and this was more convenient with the way the code is now
(no need to track container-name).