### PR TITLE
Pass container image and name to all logged events

### DIFF
--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -41,14 +41,14 @@ module CC
 
         _, status = Process.waitpid2(pid)
 
-        @log.finished(status, @stderr_io.string)
+        @log.finished(@image, @name, status, @stderr_io.string)
 
         t_timeout.kill
       ensure
         t_timeout.kill if t_timeout
 
         if @timed_out
-          @log.timed_out(@timeout)
+          @log.timed_out(@image, @name, @timeout)
           t_out.kill if t_out
           t_err.kill if t_err
         else

--- a/lib/cc/analyzer/engine/container_log.rb
+++ b/lib/cc/analyzer/engine/container_log.rb
@@ -16,8 +16,8 @@ module CC
           Analyzer.statsd.increment("cli.engines.started")
         end
 
-        def timed_out(timeout)
-          @inner_log.timed_out(timeout)
+        def timed_out(image, name, timeout)
+          @inner_log.timed_out(image, name, timeout)
 
           Analyzer.statsd.increment("cli.engines.result.error")
           Analyzer.statsd.increment("cli.engines.result.error.timeout")
@@ -27,8 +27,8 @@ module CC
           raise EngineTimeout, "engine #{@name} ran past #{timeout} seconds and was killed"
         end
 
-        def finished(status, stderr)
-          @inner_log.finished(status, stderr)
+        def finished(image, name, status, stderr)
+          @inner_log.finished(image, name, status, stderr)
 
           Analyzer.statsd.increment("cli.engines.finished")
 

--- a/lib/cc/analyzer/null_container_log.rb
+++ b/lib/cc/analyzer/null_container_log.rb
@@ -4,10 +4,10 @@ module CC
       def started(_image, _name)
       end
 
-      def timed_out(_seconds)
+      def timed_out(_image, _name, _seconds)
       end
 
-      def finished(_status, _stderr)
+      def finished(_image, _name, _status, _stderr)
       end
     end
   end

--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -77,7 +77,8 @@ module CC::Analyzer
 
         container.run
 
-        log.finished_status.must_equal :failed
+        log.finished_image.must_equal "codeclimate/foo"
+        log.finished_name.must_equal "name"
         log.finished_stderr.must_equal "error one\nerror two\n"
       end
 
@@ -93,6 +94,9 @@ module CC::Analyzer
         container.run
 
         log.timed_out?.must_equal true
+        log.timed_out_image.must_equal "codeclimate/foo"
+        log.timed_out_name.must_equal "name"
+        log.timed_out_seconds.must_equal 0
       end
     end
 

--- a/spec/cc/analyzer/engine/container_log_spec.rb
+++ b/spec/cc/analyzer/engine/container_log_spec.rb
@@ -19,9 +19,11 @@ class CC::Analyzer::Engine
         inner_log = TestContainerLog.new
         container_log = ContainerLog.new("", inner_log)
 
-        container_log.timed_out(900) rescue nil
+        container_log.timed_out("image", "name", 900) rescue nil
 
         inner_log.timed_out?.must_equal true
+        inner_log.timed_out_image.must_equal "image"
+        inner_log.timed_out_name.must_equal "name"
         inner_log.timed_out_seconds.must_equal 900
       end
 
@@ -29,7 +31,7 @@ class CC::Analyzer::Engine
         inner_log = TestContainerLog.new
         container_log = ContainerLog.new("", inner_log)
 
-        action = ->() { container_log.timed_out(900) }
+        action = ->() { container_log.timed_out("image", "name", 900) }
         action.must_raise(EngineTimeout)
       end
     end
@@ -40,9 +42,10 @@ class CC::Analyzer::Engine
         inner_log = TestContainerLog.new
         container_log = ContainerLog.new("", inner_log)
 
-        container_log.finished(status, "stderr")
+        container_log.finished("image", "name", status, "stderr")
 
-        inner_log.finished_status.must_equal status
+        inner_log.finished_image.must_equal "image"
+        inner_log.finished_name.must_equal "name"
         inner_log.finished_stderr.must_equal "stderr"
       end
 
@@ -51,7 +54,7 @@ class CC::Analyzer::Engine
         inner_log = TestContainerLog.new
         container_log = ContainerLog.new("", inner_log)
 
-        action = ->() { container_log.finished(status, "stderr") }
+        action = ->() { container_log.finished("image", "name", status, "stderr") }
         action.must_raise(EngineFailure)
       end
     end

--- a/spec/support/test_container_log.rb
+++ b/spec/support/test_container_log.rb
@@ -1,12 +1,23 @@
 class TestContainerLog
-  attr_reader :started_image, :started_name, :timed_out_seconds, :finished_status, :finished_stderr
+  attr_reader \
+    :started_image,
+    :started_name,
+    :timed_out_image,
+    :timed_out_name,
+    :timed_out_seconds,
+    :finished_image,
+    :finished_name,
+    :finished_status,
+    :finished_stderr
 
   def started(image, name)
     @started_image = image
     @started_name = name
   end
 
-  def timed_out(seconds)
+  def timed_out(image, name, seconds)
+    @timed_out_image = image
+    @timed_out_name = name
     @timed_out_seconds = seconds
     @timed_out = true
   end
@@ -15,7 +26,9 @@ class TestContainerLog
     @timed_out
   end
 
-  def finished(status, stderr)
+  def finished(image, name, status, stderr)
+    @finished_image = image
+    @finished_name = name
     @finished_status = status
     @finished_stderr = stderr
   end


### PR DESCRIPTION
More than just the start event needs to know about container-specific
information (so far the container image and name). One solution to this would
be to instantiate a new log per container and pass in those values at
construction. This does not work for the following reasons:

- The object instantiating the log does not know these values
- The log also needs to know *build*-specific values (e.g. host and snapshot),
  so we really want to instantiate a single log for the build with these values
  passed in at construction (and the constructing object does know these)

The solution chosen is to pass in the container-specific values for every
life-cycle event, not just started.

/cc @codeclimate/review and h/t @noahd1 for spotting this originally