### PR TITLE
Update version of wget inside of container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY Gemfile.lock /usr/src/app/
 COPY VERSION /usr/src/app/
 COPY codeclimate.gemspec /usr/src/app/
 
-RUN apk --update add git openssh-client build-base && \
+RUN apk --update add git openssh-client wget build-base && \
     bundle install -j 4 && \
     apk del build-base && rm -fr /usr/share/ri
 


### PR DESCRIPTION
The version bundled with the base image is too old to handle whatever
SSL version get.docker.com requires. Updating wget when building the
container allows us to grab docker correctly.

This fixes the issue [building the image](https://circleci.com/gh/codeclimate/codeclimate/245)

@codeclimate/review 