### PR TITLE
Fix #108

### DIFF
--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -29,10 +29,10 @@ invalid_docker_host() {
 }
 
 if command -v docker-machine > /dev/null 2>&1; then
-  docker-machine ssh default -- \
+  docker-machine ssh $DOCKER_MACHINE_NAME -- \
     test -S /var/run/docker.sock > /dev/null 2>&1 || socket_missing
 
-  docker-machine ssh default -- \
+  docker-machine ssh $DOCKER_MACHINE_NAME -- \
     'test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock"' > /dev/null 2>&1 \
     && invalid_docker_host $(boot2docker ssh -- 'echo "$DOCKER_HOST"')
 elif command -v boot2docker > /dev/null 2>&1; then


### PR DESCRIPTION
Why:

* Docker Machine has support for many machines which results in
  codeclimate needing to know which machine to ssh.

This change addresses the need by:

* Use the `$DOCKER_MACHINE_NAME` environment variable that gets set by
* `docker-machine env`.