### PR TITLE
Let users specify engines and paths as options to analyze command for easier debugging

### DIFF
--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -6,11 +6,12 @@ module CC
       InvalidEngineName = Class.new(StandardError)
       NoEnabledEngines = Class.new(StandardError)
 
-      def initialize(registry, formatter, source_dir, config, container_label = nil)
+      def initialize(registry, formatter, source_dir, config, requested_paths = [], container_label = nil)
         @registry = registry
         @formatter = formatter
         @source_dir = source_dir
         @config = config
+        @requested_paths = requested_paths
         @container_label = container_label
       end
 
@@ -27,6 +28,8 @@ module CC
       end
 
       private
+
+      attr_reader :requested_paths
 
       def run_engine(engine, container_listener)
         @formatter.engine_running(engine) do
@@ -72,12 +75,12 @@ module CC
         @registry[engine_name]
       end
 
-      def exclude_paths
-        PathPatterns.new(@config.exclude_paths || []).expanded + gitignore_paths
+      def include_paths
+        IncludePathsBuilder.new(@config.exclude_paths || [], requested_paths).build
       end
 
-      def include_paths
-        IncludePathsBuilder.new(@config.exclude_paths || []).build
+      def exclude_paths
+        @exclude_paths ||= PathPatterns.new(@config.exclude_paths || []).expanded + gitignore_paths
       end
 
       def gitignore_paths
@@ -87,6 +90,7 @@ module CC
           []
         end
       end
+
     end
   end
 end

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -80,7 +80,7 @@ module CC
       end
 
       def exclude_paths
-        @exclude_paths ||= PathPatterns.new(@config.exclude_paths || []).expanded + gitignore_paths
+        PathPatterns.new(@config.exclude_paths || []).expanded + gitignore_paths
       end
 
       def gitignore_paths
@@ -90,7 +90,6 @@ module CC
           []
         end
       end
-
     end
   end
 end

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -95,7 +95,7 @@ module CC::Analyzer
       end
 
       it "gets include_paths from IncludePathBuilder" do
-        IncludePathsBuilder.expects(:new).with([]).returns(mock(build: ['.']))
+        IncludePathsBuilder.expects(:new).with([], []).returns(mock(build: ['.']))
         expected_config = {
           "enabled" => true,
           :exclude_paths => [],

--- a/spec/cc/analyzer/include_paths_builder_spec.rb
+++ b/spec/cc/analyzer/include_paths_builder_spec.rb
@@ -8,7 +8,7 @@ module CC::Analyzer
       within_temp_dir { test.call }
     end
 
-    let(:builder) { CC::Analyzer::IncludePathsBuilder.new(cc_excludes) }
+    let(:builder) { CC::Analyzer::IncludePathsBuilder.new(cc_excludes, []) }
     let(:cc_excludes) { [] }
     let(:result) { builder.build }
 

--- a/spec/cc/analyzer/include_paths_builder_spec.rb
+++ b/spec/cc/analyzer/include_paths_builder_spec.rb
@@ -8,8 +8,9 @@ module CC::Analyzer
       within_temp_dir { test.call }
     end
 
-    let(:builder) { CC::Analyzer::IncludePathsBuilder.new(cc_excludes, []) }
+    let(:builder) { CC::Analyzer::IncludePathsBuilder.new(cc_excludes, cc_includes) }
     let(:cc_excludes) { [] }
+    let(:cc_includes) { [] }
     let(:result) { builder.build }
 
     before do
@@ -219,6 +220,27 @@ module CC::Analyzer
         Dir.expects(:entries).with("subdir/subdir").never
         result.include?("./").must_equal(true)
         result.include?("subdir/subdir/").must_equal(false)
+      end
+    end
+
+    describe "when cc_include_paths are passed in addition to excludes" do
+      let(:cc_excludes) { ["untrackable.rb"] }
+      let(:cc_includes) { ["untrackable.rb", "subdir"] }
+
+      before do
+        make_file("untrackable.rb")
+        make_file("trackable.rb")
+        make_file("subdir/subdir_trackable.rb")
+        make_file("subdir/foo.rb")
+        make_file("subdir/baz.rb")
+      end
+
+      it "includes requested paths" do
+        result.include?("subdir/").must_equal(true)
+      end
+
+      it "omits requested paths that are excluded by .codeclimate.yml" do
+        result.include?("untrackable.rb").must_equal(false)
       end
     end
   end


### PR DESCRIPTION
@codeclimate/review 

Caveat: At the moment, specifying the path part only works for `codeclimate-eslint` - which uses include paths instead of exclude paths internally.

 