### PR TITLE
Update check message to use sudo when appropriate

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -10,7 +10,11 @@ docker version | grep -q "Server version\|Server:" || {
   if command -v boot2docker > /dev/null 2>&1; then
     echo "Please ensure \`boot2docker up\` succeeds and you've run \`eval \$(boot2docker shellinit)\` in this shell" >&2
   else
-    echo "Please ensure \`docker version' succeeds and try again"
+    if [ $UID -eq 0 ]; then
+      echo "Please ensure \`sudo docker version' succeeds and try again" >&2
+    else
+      echo "Please ensure \`docker version' succeeds and try again" >&2
+    fi
   fi
 
   exit 1


### PR DESCRIPTION
If bin/check is run as root (i.e. via sudo make install), and the user is
unable to connect to docker (as root), the error message is confusing since it
instructs them to ensure docker version succeeds (which it likely does). In
fact, *sudo* docker version is the failing command that must succeed before
sudo make install would.

To address this confusion, we include sudo in the example command if the check
script is being run as root (UID=0).

Note: we're purposely ignoring the edge case where a user is running the check
script as root but not via sudo (e.g. su root) and our example command
incorrectly instructs them to try sudo docker version.

/cc @codeclimate/review @brynary