### PR TITLE
Fix formatter instantiation

### DIFF
--- a/lib/cc/analyzer/formatters.rb
+++ b/lib/cc/analyzer/formatters.rb
@@ -12,7 +12,7 @@ module CC
       }.freeze
 
       def self.resolve(name)
-        FORMATTERS[name.to_sym].new(ENV['FILESYSTEM_DIR']) or raise InvalidFormatterError, "'#{name}' is not a valid formatter. Valid options are: #{FORMATTERS.keys.join(", ")}"
+        FORMATTERS[name.to_sym] or raise InvalidFormatterError, "'#{name}' is not a valid formatter. Valid options are: #{FORMATTERS.keys.join(", ")}"
       end
     end
   end

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -35,7 +35,7 @@ module CC
         while arg = @args.shift
           case arg
           when '-f'
-            @formatter = Formatters.resolve(@args.shift)
+            @formatter = Formatters.resolve(@args.shift).new(filesystem)
           when '-e', '--engine'
             @engine_options << @args.shift
           when '--dev'

--- a/spec/cc/cli/analyze_spec.rb
+++ b/spec/cc/cli/analyze_spec.rb
@@ -17,89 +17,98 @@ module CC::CLI
             stderr.must_match("No enabled engines. Add some to your .codeclimate.yml file!")
           end
         end
+      end
 
-        describe "when engine is not in registry" do
-          it "ignores engine, without blowing up" do
-            within_temp_dir do
-              create_yaml(<<-EOYAML)
-                engines:
-                  madeup:
-                    enabled: true
-                  rubocop:
-                    enabled: true
-              EOYAML
+      describe "when engine is not in registry" do
+        it "ignores engine, without blowing up" do
+          within_temp_dir do
+            create_yaml(<<-EOYAML)
+              engines:
+                madeup:
+                  enabled: true
+                rubocop:
+                  enabled: true
+            EOYAML
 
-              _, stderr = capture_io do
-                Analyze.new.run
-              end
-
-              stderr.must_match("")
+            _, stderr = capture_io do
+              Analyze.new.run
             end
+
+            stderr.must_match("")
           end
         end
+      end
 
-        describe "when user passes engine options to command" do
-          it "uses only the engines provided" do
-            within_temp_dir do
-              create_yaml(<<-EOYAML)
-                engines:
-                  rubocop:
-                    enabled: true
-              EOYAML
+      describe "when user passes engine options to command" do
+        it "uses only the engines provided" do
+          within_temp_dir do
+            create_yaml(<<-EOYAML)
+              engines:
+                rubocop:
+                  enabled: true
+            EOYAML
 
-              args = ["-e", "eslint"]
+            args = ["-e", "eslint"]
 
-              analyze = Analyze.new(args)
-              qualified_config = analyze.send(:config)
+            analyze = Analyze.new(args)
+            qualified_config = analyze.send(:config)
 
-              qualified_config.engines.must_equal("eslint" => { "enabled" => true })
-            end
+            qualified_config.engines.must_equal("eslint" => { "enabled" => true })
           end
         end
+      end
 
-        describe "when user passes path args to command" do
-          it "captures the paths provided as path_options" do
-            within_temp_dir do
-              create_yaml(<<-EOYAML)
-                engines:
-                  rubocop:
-                    enabled: true
-                  eslint:
-                    enabled: true
-              EOYAML
+      describe "when user passes path args to command" do
+        it "captures the paths provided as path_options" do
+          within_temp_dir do
+            create_yaml(<<-EOYAML)
+              engines:
+                rubocop:
+                  enabled: true
+                eslint:
+                  enabled: true
+            EOYAML
 
-              args = ["-e", "eslint", "foo.rb"]
-              paths = ["foo.rb"]
+            args = ["-e", "eslint", "foo.rb"]
+            paths = ["foo.rb"]
 
-              analyze = Analyze.new(args)
+            analyze = Analyze.new(args)
 
-              analyze.send(:path_options).must_equal(paths)
-            end
+            analyze.send(:path_options).must_equal(paths)
           end
         end
+      end
 
-        describe "when user passes path args to command" do
-          it "passes the paths provided" do
-            within_temp_dir do
-              create_yaml(<<-EOYAML)
-                engines:
-                  rubocop:
-                    enabled: true
-                  eslint:
-                    enabled: true
-              EOYAML
+      describe "when user passes path args to command" do
+        it "passes the paths provided" do
+          within_temp_dir do
+            create_yaml(<<-EOYAML)
+              engines:
+                rubocop:
+                  enabled: true
+                eslint:
+                  enabled: true
+            EOYAML
 
-              args = ["-e", "eslint", "foo.rb"]
-              paths = ["foo.rb"]
+            args = ["-e", "eslint", "foo.rb"]
+            paths = ["foo.rb"]
 
-              analyze = Analyze.new(args)
-              engines_runner = stub(run: "peace")
+            analyze = Analyze.new(args)
+            engines_runner = stub(run: "peace")
 
-              CC::Analyzer::EnginesRunner.expects(:new).with(anything, anything, anything, anything, paths).returns(engines_runner)
+            CC::Analyzer::EnginesRunner.expects(:new).with(anything, anything, anything, anything, paths).returns(engines_runner)
 
-              analyze.run
-            end
+            analyze.run
           end
+        end
+      end
+
+      describe "when a formatter argument is passed" do
+        it "instantiates the correct formatter with a proper Filesystem argument" do
+          CC::Analyzer::Formatters::JSONFormatter.expects(:new).
+            with(kind_of(CC::Analyzer::Filesystem))
+
+          Analyze.new(%w[-f json])
         end
       end
     end


### PR DESCRIPTION
Formatters are meant to be instantiated with an instance of FileSystem,
however when handling the -f option we were instantiating it with the raw
directory. To fix this, Formatters.resolve now returns the class itself and
the caller instantiates it with the FileSystem instance it holds already.

Fixes #111

/cc @codeclimate/review

Note: my initial attempts at getting a meaningful failing spec around this
before implementing the fix were not successful, but I should probably figure
something out along those lines before merging.