### PR TITLE
remove executables

### DIFF
--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.files         = Dir["lib/**/*.rb"] + Dir["bin/*"] + Dir["config/*"]
   s.require_paths = ["lib"]
   s.bindir        = "bin"
-  s.executables   = %w(check codeclimate)
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"


### PR DESCRIPTION
@codeclimate/review 

Reverts install of gem executables, which undesirably take precedence over the docker CC wrapper when installed. 

(These executables were installed for use in `Builder` to run `codeclimate init` and generate config file).

Not sure if removing it is the correct step, but having it installed breaks local CLI analysis for CC devs. 