### PR TITLE
Skip .gitignore if it's a directory.

### DIFF
--- a/lib/cc/analyzer/include_paths_builder.rb
+++ b/lib/cc/analyzer/include_paths_builder.rb
@@ -46,7 +46,7 @@ module CC
 
       def ignored_files
         Tempfile.open(".cc_gitignore") do |tmp|
-          tmp.write(File.read(".gitignore")) if File.exist?(".gitignore")
+          tmp.write(File.read(".gitignore")) if File.file?(".gitignore")
           tmp << @cc_exclude_paths.join("\n")
           tmp.close
           tracked_and_ignored = `git ls-files -zi -X #{tmp.path}`.split("\0")

--- a/spec/cc/analyzer/include_paths_builder_spec.rb
+++ b/spec/cc/analyzer/include_paths_builder_spec.rb
@@ -243,5 +243,15 @@ module CC::Analyzer
         result.include?("untrackable.rb").must_equal(false)
       end
     end
+
+    describe "when .gitignore is a directory" do
+      before do
+        FileUtils.mkdir(".gitignore")
+      end
+
+      it "skips it entirely" do
+        result.include?("./").must_equal(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
IncludePathsBuilder was erroring on repos where .gitignore was a
directory (most likely due to developer error). Now it just skips
.gitignore instead.