### PR TITLE
Add `default_config` key with nested values

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,11 +2,12 @@
 engines:
   rubocop:
     enabled: true
-  bundler-audit:
+  duplication:
     enabled: true
+    config:
+      languages:
+      - ruby
 ratings:
   paths:
   - "**.rb"
-exclude_paths:
-- config/**/*
-- spec/**/*
+exclude_paths: []

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    codeclimate (0.6.4)
+    codeclimate (0.6.3)
       activesupport (~> 4.2, >= 4.2.1)
       codeclimate-yaml (~> 0.2.3)
       faraday (~> 0.9.1)
@@ -49,7 +49,7 @@ GEM
       metaclass (~> 0.0.1)
     multipart-post (2.0.0)
     posix-spawn (0.3.11)
-    pry (0.10.1)
+    pry (0.10.2)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
@@ -76,6 +76,3 @@ DEPENDENCIES
   minitest-reporters
   mocha
   rack-test
-
-BUNDLED WITH
-   1.10.6

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -17,6 +17,17 @@ rubocop:
     - \.rb$
   default_ratings_paths:
     - "**.rb"
+duplication:
+  image: codeclimate/codeclimate-duplication
+  description: Find similar structures in your code
+  community: false
+  default_config:
+    languages:
+      - ruby
+  enable_regexps:
+    - \.rb$
+  default_ratings_paths:
+    - "**.rb"
 gofmt:
   image: codeclimate/codeclimate-gofmt
   description: gofmt

--- a/lib/cc/cli/config.rb
+++ b/lib/cc/cli/config.rb
@@ -1,0 +1,32 @@
+module CC
+  module CLI
+    class Config
+      delegate :to_yaml, to: :config
+      def initialize
+        @config = {
+          "engines" => {},
+          "ratings" => { "paths" => [] }
+        }
+      end
+
+      def add_engine(engine_name, engine_config)
+        config["engines"][engine_name] = { "enabled" => true }
+
+        if engine_config["default_config"].present?
+          config["engines"][engine_name]["config"] = engine_config["default_config"]
+        end
+
+        config["ratings"]["paths"] |= engine_config["default_ratings_paths"]
+      end
+
+      def add_exclude_paths(paths)
+        config["exclude_paths"] ||= []
+        config["exclude_paths"] += paths.map { |path| "#{path}/**/*" }
+      end
+
+      private
+
+      attr_reader :config
+    end
+  end
+end

--- a/spec/cc/cli/config_spec.rb
+++ b/spec/cc/cli/config_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+require "cc/cli/config"
+
+module CC::CLI
+  describe CC::CLI::Config do
+    describe "#add_engine" do
+      it "enables the passed in engine" do
+        config = CC::CLI::Config.new()
+        engine_config = {
+          "default_ratings_paths" => ["foo"]
+        }
+
+        config.add_engine("foo", engine_config)
+
+        engine = YAML.load(config.to_yaml)["engines"]["foo"]
+        engine.must_equal({ "enabled" => true })
+      end
+
+      it "copies over default configuration" do
+        config = CC::CLI::Config.new()
+        engine_config = {
+          "default_config" => { "awesome" => true },
+          "default_ratings_paths" => ["foo"]
+        }
+
+        config.add_engine("foo", engine_config)
+
+        engine = YAML.load(config.to_yaml)["engines"]["foo"]
+        engine.must_equal({
+          "enabled" => true,
+          "config" => {
+            "awesome" => true
+          }
+        })
+      end
+    end
+
+    describe "#add_exclude_paths" do
+      it "adds exclude paths to config with glob" do
+        config = CC::CLI::Config.new()
+        config.add_exclude_paths(["foo"])
+
+        exclude_paths = YAML.load(config.to_yaml)["exclude_paths"]
+        exclude_paths.must_equal(["foo/**/*"])
+      end
+    end
+  end
+end

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -36,7 +36,11 @@ module CC::CLI
               "engines" => {
                 "rubocop" => { "enabled"=>true },
                 "eslint" => { "enabled"=>true },
-                "csslint"=> { "enabled"=>true },
+                "csslint" => { "enabled"=>true },
+                "duplication" => {
+                  "enabled" => true,
+                  "config" => { "languages" => ["ruby"] }
+                }
               },
               "ratings" => { "paths" => ["**.rb", "**.js", "**.jsx", "**.css"] },
               "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],


### PR DESCRIPTION
This adds the `default_config` option which is used to add default
configuration options to an engine. This also marks the duplication
engine as a default engine when ruby files are present.