### PR TITLE
add confidence reporting

### DIFF
--- a/lib/cc/analyzer/formatters/plain_text_formatter.rb
+++ b/lib/cc/analyzer/formatters/plain_text_formatter.rb
@@ -7,6 +7,17 @@ module CC
     module Formatters
       class PlainTextFormatter < Formatter
 
+        SEVERITY_LEVELS = [
+          INFO = "info",
+          NORMAL = "normal",
+          CRITICAL = "critical",
+        ].freeze
+
+        SEVERITY_HUES = {
+          INFO => "#1a0dab",
+          CRITICAL => "#FF4500",
+        }.freeze
+
         def started
           puts colorize("Starting analysis", :green)
         end
@@ -40,7 +51,13 @@ module CC
               end
 
               print(issue["description"])
+
+              if issue["severity"] && issue["severity"] != NORMAL
+                report(issue["severity"])
+              end
+
               print(colorize(" [#{issue["engine_name"]}]", "#333333"))
+
               puts
             end
             puts
@@ -67,6 +84,14 @@ module CC
         end
 
         private
+
+        def report(severity)
+          color = SEVERITY_HUES[severity] || "#333333"
+          str = colorize(" [", "#333333")
+          str += colorize("#{severity}", color)
+          str += colorize("]", "#333333")
+          print str
+        end
 
         def spinner(text = nil)
           @spinner ||= Spinner.new(text)

--- a/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
@@ -36,6 +36,39 @@ module CC::Analyzer::Formatters
         stdout.must_match("Missing top-level class documentation comment")
         stdout.must_match("[cool_engine]")
       end
+
+      it "reports issue severity when info" do
+        engine = stub(name: "cool_engine")
+
+        stdout, _ = capture_io do
+          write_from_engine(formatter, engine, sample_issue_with_severity("info"))
+          formatter.finished
+        end
+
+        stdout.must_match("[info]")
+      end
+
+      it "reports issue severity when critical" do
+        engine = stub(name: "cool_engine")
+
+        stdout, _ = capture_io do
+          write_from_engine(formatter, engine, sample_issue_with_severity("critical"))
+          formatter.finished
+        end
+
+        stdout.must_match("[critical]")
+      end
+
+      it "does not report severity when normal" do
+        engine = stub(name: "cool_engine")
+
+        stdout, _ = capture_io do
+          write_from_engine(formatter, engine, sample_issue_with_severity("normal"))
+          formatter.finished
+        end
+
+        stdout.wont_match("[normal]")
+      end
     end
 
     def write_from_engine(formatter, engine, issue)

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -99,4 +99,22 @@ module Factory
       }
     }
   end
+
+  def sample_issue_with_severity(severity)
+    {
+      "type" => "issue",
+      "check" => "Rubocop/Style/Documentation",
+      "description" => "Missing top-level class documentation comment.",
+      "categories" => ["Style"],
+      "remediation_points" => 10,
+      "severity" => severity,
+      "location"=> {
+        "path" => "lib/cc/analyzer/config.rb",
+        "lines" => {
+          "begin" => 32,
+          "end" => 40
+        }
+      }
+    }
+  end
 end


### PR DESCRIPTION
@codeclimate/review @mrb 

Experiment with having Code Climate CLI accept a confidence key on issue.

Only applicable type of analysis that I'm aware of is Brakeman, so it may not be clean design idea to make a custom key for that quality yet. 

<img width="915" alt="screen shot 2015-10-02 at 8 18 47 pm" src="https://cloud.githubusercontent.com/assets/8718443/10260395/09369484-6943-11e5-98b1-dcd6e7e6ed1d.png">




