### PR TITLE
Add raw engine data format option for developing

### DIFF
--- a/lib/cc/analyzer/formatters.rb
+++ b/lib/cc/analyzer/formatters.rb
@@ -4,11 +4,13 @@ module CC
       autoload :Formatter,  "cc/analyzer/formatters/formatter"
       autoload :JSONFormatter, "cc/analyzer/formatters/json_formatter"
       autoload :PlainTextFormatter,  "cc/analyzer/formatters/plain_text_formatter"
+      autoload :RawEngineDataFormatter, "cc/analyzer/formatters/raw_engine_data_formatter"
       autoload :Spinner, "cc/analyzer/formatters/spinner"
 
       FORMATTERS = {
         json: JSONFormatter,
         text: PlainTextFormatter,
+        raw: RawEngineDataFormatter,
       }.freeze
 
       def self.resolve(name)

--- a/lib/cc/analyzer/formatters/raw_engine_data_formatter.rb
+++ b/lib/cc/analyzer/formatters/raw_engine_data_formatter.rb
@@ -1,0 +1,42 @@
+module CC
+  module Analyzer
+    module Formatters
+      class RawEngineDataFormatter
+        def initialize(filesystem, output = $stdout)
+          @filesystem = filesystem
+          @output = output
+        end
+
+        def write(data)
+          puts data
+          puts
+        end
+
+        def started
+        end
+
+        def engine_running(engine)
+          @current_engine = engine
+          yield
+        ensure
+          @current_engine = nil
+        end
+
+        def finished
+        end
+
+        def close
+        end
+
+        def failed(output)
+        end
+
+        InvalidFormatterError = Class.new(StandardError)
+
+        private
+
+        attr_reader :current_engine
+      end
+    end
+  end
+end


### PR DESCRIPTION
@codeclimate/review @BlakeWilliams 

When developing an engine for the CLI spec, it can be
very useful to output raw engine data to better
understand what is getting passed to an engine and investigate
unexpected results.

Sample output:

```
$ codeclimate analyze -f raw
{"type":"Issue","check_name":"Rubocop/Style/ExtraSpacing","description":"Unnecessary spacing detected.","categories":["Style"],"remediation_points":50000,"location":{"path":"codeclimate.gemspec","positions":{"begin":{"column":31,"line":24},"end":{"column":32,"line":24}}}}

{"type":"Issue","check_name":"Rubocop/Style/WordArray","description":"Use `%w` or `%W` for array of words.","categories":["Style"],"remediation_points":50000,"location":{"path":"Rakefile","positions":{"begin":{"column":12,"line":6},"end":{"column":27,"line":6}}}}

{"type":"Issue","check_name":"Rubocop/Style/AccessModifierIndentation","description":"Indent access modifiers like `private`.","categories":["Style"],"remediation_points":50000,"location":{"path":"lib/cc/analyzer/config.rb","positions":{"begin":{"column":5,"line":62},"end":{"column":12,"line":62}}}}

{"type":"Issue","check_name":"Rubocop/Style/SpaceAroundOperators","description":"Surrounding space missing for operator `=\u003e`.","categories":["Style"],"remediation_points":50000,"location":{"path":"lib/cc/analyzer/config.rb","positions":{"begin":{"column":60,"line":8},"end":{"column":62,"line":8}}}}

{"type":"Issue","check_name":"Rubocop/Style/SpaceInsideHashLiteralBraces","description":"Space inside { missing.","categories":["Style"],"remediation_points":50000,"location":{"path":"lib/cc/analyzer/config.rb","positions":{"begin":{"column":50,"line":8},"end":{"column":51,"line":8}}}}

{"type":"Issue","check_name":"Rubocop/Metrics/CyclomaticComplexity","description":"Cyclomatic complexity for run is too high. [7/6]","categories":["Complexity"],"remediation_points":50000,"location":{"path":"lib/cc/analyzer/container.rb","positions":{"begin":{"column":7,"line":41},"end":{"column":10,"line":68}}}}

```