### PR TITLE
Test checking formatter for failure before sending finished event

### DIFF
--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -18,13 +18,15 @@ module CC
         name:,
         command: nil,
         listener: ContainerListener.new,
-        timeout: DEFAULT_TIMEOUT
+        timeout: DEFAULT_TIMEOUT,
+        stdout_io: StringIO.new
       )
         @image = image
         @name = name
         @command = command
         @listener = listener
         @timeout = timeout
+        @stdout_io = stdout_io
 
         @output_delimeter = "\n"
         @on_output = ->(*) { }
@@ -50,8 +52,10 @@ module CC
 
         _, status = Process.waitpid2(pid)
 
-        duration = ((Time.now - started) * 1000).round
-        @listener.finished(container_data(duration: duration, status: status))
+        unless @stdout_io.respond_to?(:failed) && @stdout_io.failed
+          duration = ((Time.now - started) * 1000).round
+          @listener.finished(container_data(duration: duration, status: status))
+        end
 
         t_timeout.kill
       ensure

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -29,6 +29,7 @@ module CC
           command: @metadata["command"],
           name: container_name,
           listener: composite_listener,
+          stdout_io: stdout_io,
         )
 
         container.on_output("\0") do |output|


### PR DESCRIPTION
This PR prevents the running engine from sending off a second container `finished` event after the formatter has already handled an engine output failure.

Depends upon the `#failed` formatter method added in codeclimate/builder#168 to block correctly.