### PR TITLE
update gemfile - unless we intentionally switched back to 0.6.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    codeclimate (0.6.3)
+    codeclimate (0.6.4)
       activesupport (~> 4.2, >= 4.2.1)
       codeclimate-yaml (~> 0.2.3)
       faraday (~> 0.9.1)
@@ -76,3 +76,6 @@ DEPENDENCIES
   minitest-reporters
   mocha
   rack-test
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
@codeclimate/review 

Not sure what's best protocol for handling bundler differences. 

I think we want `0.6.4` for CC in gemfile.lock though. Looks like the last update might not have used a bundle.