### PR TITLE
enable bundler-audit when Gemfile.lock present

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -104,8 +104,8 @@ bundler-audit:
   community: false
   upgrade_languages:
     - Ruby
-  enable_patterns:
-    - Gemfile.lock
+  enable_regexps:
+    - Gemfile\.lock
   default_ratings_paths:
     - Gemfile.lock
 phpcodesniffer:

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -38,6 +38,15 @@ module CC::CLI
         end
         generator.eligible_engines.must_equal expected_engines
       end
+
+      it "returns brakeman when Gemfile.lock exists" do
+        File.write("Gemfile.lock", "gemfile-lock-content")
+
+        expected_engines = engine_registry.list.select do |name, _|
+          "bundler-audit" == name
+        end
+        generator.eligible_engines.must_equal expected_engines
+      end
     end
 
     describe "#exclude_paths" do


### PR DESCRIPTION
Looks like this was using the wrong yaml key: I don't see any reference
to `enable_patterns` in the code.