### PR TITLE
`init --upgrade`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,4 +10,5 @@ engines:
 ratings:
   paths:
   - "**.rb"
-exclude_paths: []
+exclude_paths:
+  - .bundle/**/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git
+.bundle

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,10 @@ Style/ClassAndModuleChildren:
   Exclude:
     - 'spec/**/*'
 
+Metrics/MethodLength:
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*'
@@ -32,6 +36,9 @@ Style/DotPosition:
   Enabled: false
 
 Style/SignalException:
+  Enabled: false
+
+Style/TrailingUnderscoreVariable:
   Enabled: false
 
 Metrics/AbcSize:

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -13,6 +13,8 @@ rubocop:
   image: codeclimate/codeclimate-rubocop
   description: A Ruby static code analyzer, based on the community Ruby style guide.
   community: false
+  upgrade_languages:
+   - Ruby
   enable_regexps:
     - \.rb$
   default_ratings_paths:
@@ -24,6 +26,8 @@ duplication:
   default_config:
     languages:
       - ruby
+  upgrade_languages:
+    - Ruby
   enable_regexps:
     - \.rb$
   default_ratings_paths:
@@ -64,6 +68,8 @@ eslint:
   image: codeclimate/codeclimate-eslint
   description: A JavaScript/JSX linting utility
   community: false
+  upgrade_languages:
+    - JavaScript
   enable_regexps:
     - \.js$
     - \.jsx$
@@ -96,6 +102,8 @@ bundler-audit:
   image: codeclimate/codeclimate-bundler-audit
   description: Patch-level verification for Bundler
   community: false
+  upgrade_languages:
+    - Ruby
   enable_patterns:
     - Gemfile.lock
   default_ratings_paths:
@@ -104,6 +112,8 @@ phpcodesniffer:
   image: codeclimate/codeclimate-phpcodesniffer
   description: PHP Code Sniffer
   community: false
+  upgrade_languages:
+    - PHP
   enable_regexps:
     - \.php$
     - \.module$
@@ -116,6 +126,8 @@ phpmd:
   image: codeclimate/codeclimate-phpmd
   description: PHP Mess Detector
   community: false
+  upgrade_languages:
+    - PHP
   enable_regexps:
     - \.php$
     - \.module$

--- a/lib/cc/cli/config.rb
+++ b/lib/cc/cli/config.rb
@@ -21,7 +21,13 @@ module CC
 
       def add_exclude_paths(paths)
         config["exclude_paths"] ||= []
-        config["exclude_paths"] += paths.map { |path| "#{path}/**/*" }
+        config["exclude_paths"] += paths.map do |path|
+          if path.ends_with?("/")
+            "#{path}**/*"
+          else
+            path
+          end
+        end
       end
 
       private

--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -1,0 +1,60 @@
+module CC
+  module CLI
+    class ConfigGenerator
+      CODECLIMATE_YAML = Command::CODECLIMATE_YAML
+      AUTO_EXCLUDE_PATHS = %w(config/ db/ features/ node_modules/ script/ spec/ test/ vendor/).freeze
+
+      def self.for(filesystem, engine_registry, upgrade_requested)
+        if upgrade_requested && upgrade_needed?(filesystem)
+          UpgradeConfigGenerator.new(filesystem, engine_registry)
+        else
+          ConfigGenerator.new(filesystem, engine_registry)
+        end
+      end
+
+      def initialize(filesystem, engine_registry)
+        @filesystem = filesystem
+        @engine_registry = engine_registry
+      end
+
+      def eligible_engines
+        return @eligible_engines if @eligible_engines
+
+        engines = engine_registry.list
+        @eligible_engines = engines.each_with_object({}) do |(name, config), result|
+          if engine_eligible?(config)
+            result[name] = config
+          end
+        end
+      end
+
+      def exclude_paths
+        AUTO_EXCLUDE_PATHS.select { |path| filesystem.exist?(path) }
+      end
+
+      def post_generation_verb
+        "generated"
+      end
+
+      private
+
+      attr_reader :engine_registry, :filesystem
+
+      def self.upgrade_needed?(filesystem)
+        if filesystem.exist?(CODECLIMATE_YAML)
+          YAML.safe_load(File.read(CODECLIMATE_YAML))["languages"].present?
+        end
+      end
+
+      def engine_eligible?(engine)
+        !engine["community"] && engine["enable_regexps"].present? && files_exist?(engine)
+      end
+
+      def files_exist?(engine)
+        filesystem.any? do |path|
+          engine["enable_regexps"].any? { |re| Regexp.new(re).match(path) }
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/cli/upgrade_config_generator.rb
+++ b/lib/cc/cli/upgrade_config_generator.rb
@@ -1,0 +1,34 @@
+require "cc/cli/config_generator"
+
+module CC
+  module CLI
+    class UpgradeConfigGenerator < ConfigGenerator
+      def exclude_paths
+        existing_yaml["exclude_paths"] || []
+      end
+
+      def post_generation_verb
+        "upgraded"
+      end
+
+      private
+
+      def engine_eligible?(engine)
+        base_eligble = super
+        if engine["upgrade_languages"].present?
+          base_eligble && (engine["upgrade_languages"] & classic_languages).any?
+        else
+          base_eligble
+        end
+      end
+
+      def classic_languages
+        @classic_languages ||= existing_yaml["languages"].reject { |_, v| !v }.map(&:first)
+      end
+
+      def existing_yaml
+        @existing_yml ||= YAML.safe_load(File.read(CODECLIMATE_YAML))
+      end
+    end
+  end
+end

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+require "cc/cli/config_generator"
+
+module CC::CLI
+  describe ConfigGenerator do
+    include Factory
+    include FileSystemHelpers
+
+    around do |test|
+      within_temp_dir { test.call }
+    end
+
+    describe "self.for" do
+      it "returns a standard generator when upgrade not requested" do
+        generator = ConfigGenerator.for(make_filesystem, engine_registry, false)
+        generator.class.must_equal ConfigGenerator
+      end
+
+      it "returns a standard generator when upgrade requested but .codeclimate.yml does not exist" do
+        generator = ConfigGenerator.for(make_filesystem, engine_registry, true)
+        generator.class.must_equal ConfigGenerator
+      end
+
+      it "returns an upgrade generator when requested" do
+        File.write(".codeclimate.yml", create_classic_yaml)
+        generator = ConfigGenerator.for(make_filesystem, engine_registry, true)
+        generator.class.must_equal UpgradeConfigGenerator
+      end
+    end
+
+    describe "#eligible_engines" do
+      it "calculates eligible_engines based on existing files" do
+        write_fixture_source_files
+
+        expected_engine_names = %w(rubocop duplication eslint csslint)
+        expected_engines = engine_registry.list.select do |name, _|
+          expected_engine_names.include?(name)
+        end
+        generator.eligible_engines.must_equal expected_engines
+      end
+    end
+
+    describe "#exclude_paths" do
+      it "uses AUTO_EXCLUDE_PATHS that exist locally" do
+        write_fixture_source_files
+
+        expected_paths = %w(config/ spec/ vendor/)
+        generator.exclude_paths.must_equal expected_paths
+      end
+    end
+
+    def generator
+      @generator ||= ConfigGenerator.new(make_filesystem, engine_registry)
+    end
+
+    def engine_registry
+      @engine_registry ||= CC::Analyzer::EngineRegistry.new
+    end
+  end
+end

--- a/spec/cc/cli/config_spec.rb
+++ b/spec/cc/cli/config_spec.rb
@@ -38,10 +38,18 @@ module CC::CLI
     describe "#add_exclude_paths" do
       it "adds exclude paths to config with glob" do
         config = CC::CLI::Config.new()
-        config.add_exclude_paths(["foo"])
+        config.add_exclude_paths(["foo/"])
 
         exclude_paths = YAML.load(config.to_yaml)["exclude_paths"]
         exclude_paths.must_equal(["foo/**/*"])
+      end
+
+      it "does not glob paths that aren't directories" do
+        config = CC::CLI::Config.new()
+        config.add_exclude_paths(["foo.rb"])
+
+        exclude_paths = YAML.load(config.to_yaml)["exclude_paths"]
+        exclude_paths.must_equal(["foo.rb"])
       end
     end
   end

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -3,146 +3,205 @@ require "cc/yaml"
 
 module CC::CLI
   describe Init do
+    include Factory
+    include FileSystemHelpers
+
+    around do |test|
+      within_temp_dir { test.call }
+    end
+
     describe "#run" do
       describe "when no .codeclimate.yml file is present in working directory" do
         it "creates a correct .codeclimate.yml file and reports successful creation" do
-          within_temp_dir do
-            filesystem.exist?(".codeclimate.yml").must_equal(false)
-            File.write("cool.rb", "class Cool; end")
-            FileUtils.mkdir_p("js")
-            File.write("js/foo.js", "function() {}");
-            FileUtils.mkdir_p("stylesheets")
-            File.write("stylesheets/main.css", ".main {}")
-            FileUtils.mkdir_p("vendor/jquery")
-            File.write("vendor/foo.css", ".main {}")
-            File.write("vendor/jquery/jquery.css", ".main {}")
-            FileUtils.mkdir_p("spec/models")
-            File.write("spec/spec_helper.rb", ".main {}")
-            File.write("spec/models/foo.rb", ".main {}")
-            FileUtils.mkdir_p("config")
-            File.write("config/foo.rb", ".main {}")
+          filesystem.exist?(".codeclimate.yml").must_equal(false)
+          write_fixture_source_files
 
-            stdout, stderr = capture_io do
-              init = Init.new
-              init.run
-            end
-
-            new_content = File.read(".codeclimate.yml")
-
-            stdout.must_match "Config file .codeclimate.yml successfully generated."
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
-
-            YAML.safe_load(new_content).must_equal({
-              "engines" => {
-                "rubocop" => { "enabled"=>true },
-                "eslint" => { "enabled"=>true },
-                "csslint" => { "enabled"=>true },
-                "duplication" => {
-                  "enabled" => true,
-                  "config" => { "languages" => ["ruby"] }
-                }
-              },
-              "ratings" => { "paths" => ["**.rb", "**.js", "**.jsx", "**.css"] },
-              "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
-            })
-
-            CC::Yaml.parse(new_content).errors.must_be_empty
+          stdout, stderr = capture_io do
+            init = Init.new
+            init.run
           end
+
+          new_content = File.read(".codeclimate.yml")
+
+          stdout.must_match "Config file .codeclimate.yml successfully generated."
+          filesystem.exist?(".codeclimate.yml").must_equal(true)
+
+          YAML.safe_load(new_content).must_equal({
+            "engines" => {
+              "rubocop" => { "enabled"=>true },
+              "eslint" => { "enabled"=>true },
+              "csslint" => { "enabled"=>true },
+              "duplication" => {
+                "enabled" => true,
+                "config" => { "languages" => ["ruby"] }
+              }
+            },
+            "ratings" => { "paths" => ["**.rb", "**.js", "**.jsx", "**.css"] },
+            "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
+          })
+
+          CC::Yaml.parse(new_content).errors.must_be_empty
         end
 
         describe 'when default config for engine is available' do
           describe 'when no config file for this engine exists in working directory' do
             it 'creates .engine.yml with default config' do
-              within_temp_dir do
-                File.write('foo.rb', 'class Foo; end')
+              File.write('foo.rb', 'class Foo; end')
 
-                stdout, stderr = capture_io do
-                  init = Init.new
-                  init.run
-                end
-
-                new_content = File.read('.rubocop.yml')
-
-                stdout.must_match 'Config file .rubocop.yml successfully generated.'
-                filesystem.exist?('.rubocop.yml').must_equal(true)
-                YAML.safe_load(new_content).keys.must_include('AllCops')
+              stdout, stderr = capture_io do
+                init = Init.new
+                init.run
               end
+
+              new_content = File.read('.rubocop.yml')
+
+              stdout.must_match 'Config file .rubocop.yml successfully generated.'
+              filesystem.exist?('.rubocop.yml').must_equal(true)
+              YAML.safe_load(new_content).keys.must_include('AllCops')
             end
           end
 
           describe 'when config file for this engine already exists in working directory' do
             it 'skips engine config file generation' do
-              within_temp_dir do
-                File.write('foo.rb', 'class Foo; end')
+              File.write('foo.rb', 'class Foo; end')
 
-                content_before = 'test content'
-                File.write('.rubocop.yml', content_before)
+              content_before = 'test content'
+              File.write('.rubocop.yml', content_before)
 
-                stdout, stderr = capture_io do
-                  init = Init.new
-                  init.run
-                end
-
-                content_after = File.read('.rubocop.yml')
-
-                stdout.must_match 'Skipping generating .rubocop.yml file (already exists).'
-                filesystem.exist?('.rubocop.yml').must_equal(true)
-                content_after.must_equal(content_before)
+              stdout, stderr = capture_io do
+                init = Init.new
+                init.run
               end
+
+              content_after = File.read('.rubocop.yml')
+
+              stdout.must_match 'Skipping generating .rubocop.yml file (already exists).'
+              filesystem.exist?('.rubocop.yml').must_equal(true)
+              content_after.must_equal(content_before)
             end
           end
         end
       end
 
-      describe "when a .codeclimate.yml file is already present in working directory" do
+      describe "when a platform .codeclimate.yml file is already present in working directory" do
         it "does not create a new file or overwrite the old" do
-          within_temp_dir do
-            filesystem.exist?(".codeclimate.yml").must_equal(false)
+          filesystem.exist?(".codeclimate.yml").must_equal(false)
 
-            yaml_content_before = "This is a test yaml!"
-            File.write(".codeclimate.yml", yaml_content_before)
+          yaml_content_before = "---\nlanguages:\n  Ruby: true\n"
+          File.write(".codeclimate.yml", yaml_content_before)
 
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
+          filesystem.exist?(".codeclimate.yml").must_equal(true)
 
-            capture_io do
-              Init.new.run
-            end
-
-            content_after = File.read(".codeclimate.yml")
-
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
-            content_after.must_equal(yaml_content_before)
+          capture_io do
+            Init.new.run
           end
+
+          content_after = File.read(".codeclimate.yml")
+
+          filesystem.exist?(".codeclimate.yml").must_equal(true)
+          content_after.must_equal(yaml_content_before)
         end
 
         it "reports that there is a .codeclimate.yml file already present" do
-          within_temp_dir do
-            filesystem.exist?(".codeclimate.yml").must_equal(false)
+          filesystem.exist?(".codeclimate.yml").must_equal(false)
 
-            File.new(".codeclimate.yml", "w")
+          File.new(".codeclimate.yml", "w")
 
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
+          filesystem.exist?(".codeclimate.yml").must_equal(true)
 
-            stdout, stderr = capture_io do
-              Init.new.run
-            end
-
-            stdout.must_match("Config file .codeclimate.yml already present.")
+          stdout, stderr = capture_io do
+            Init.new.run
           end
+
+          stdout.must_match("Config file .codeclimate.yml already present.")
+        end
+      end
+
+      describe "when --upgrade flag is on" do
+        it "refuses to upgrade a platform config" do
+          filesystem.exist?(".codeclimate.yml").must_equal(false)
+
+          yaml_content_before = yaml_with_rubocop_enabled
+          File.write(".codeclimate.yml", yaml_content_before)
+
+          filesystem.exist?(".codeclimate.yml").must_equal(true)
+
+          stdout, _ = capture_io do
+            Init.new(["--upgrade"]).run
+          end
+
+          content_after = File.read(".codeclimate.yml")
+
+          filesystem.exist?(".codeclimate.yml").must_equal(true)
+          content_after.must_equal(yaml_content_before)
+
+          stdout.must_match "--upgrade should not be used on a .codeclimate.yml configured for the Platform"
+        end
+
+        it "behaves normally if no .codeclimate.yml present" do
+          filesystem.exist?(".codeclimate.yml").must_equal(false)
+          write_fixture_source_files
+
+          stdout, _ = capture_io do
+            Init.new(["--upgrade"]).run
+          end
+
+          stdout.must_match "Config file .codeclimate.yml successfully generated."
+
+          new_content = File.read(".codeclimate.yml")
+          YAML.safe_load(new_content).must_equal({
+            "engines" => {
+              "rubocop" => { "enabled"=>true },
+              "eslint" => { "enabled"=>true },
+              "csslint" => { "enabled"=>true },
+              "duplication" => {
+                "enabled" => true,
+                "config" => { "languages" => ["ruby"] }
+              }
+            },
+            "ratings" => { "paths" => ["**.rb", "**.js", "**.jsx", "**.css"] },
+            "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
+          })
+
+          CC::Yaml.parse(new_content).errors.must_be_empty
+        end
+
+        it "upgrades if classic config is present" do
+          filesystem.exist?(".codeclimate.yml").must_equal(false)
+
+          File.write(".codeclimate.yml", create_classic_yaml)
+
+          filesystem.exist?(".codeclimate.yml").must_equal(true)
+
+          write_fixture_source_files
+
+          stdout, _ = capture_io do
+            Init.new(["--upgrade"]).run
+          end
+
+          stdout.must_match "Config file .codeclimate.yml successfully upgraded."
+
+          new_content = File.read(".codeclimate.yml")
+          YAML.safe_load(new_content).must_equal({
+            "engines" => {
+              "rubocop" => { "enabled"=>true },
+              "csslint" => { "enabled"=>true },
+              "duplication" => {
+                "enabled" => true,
+                "config" => { "languages" => ["ruby"] }
+              }
+            },
+            "ratings" => { "paths" => ["**.rb", "**.css"] },
+            "exclude_paths" => ["excluded.rb"],
+          })
+
+          CC::Yaml.parse(new_content).errors.must_be_empty
         end
       end
     end
 
     def filesystem
-      @filesystem ||= CC::Analyzer::Filesystem.new(".")
-    end
-
-    def within_temp_dir(&block)
-      temp = Dir.mktmpdir
-
-      Dir.chdir(temp) do
-        yield
-      end
+      @filesystem ||= make_filesystem
     end
   end
 end

--- a/spec/cc/cli/upgrade_config_generator_spec.rb
+++ b/spec/cc/cli/upgrade_config_generator_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+require "cc/cli/upgrade_config_generator"
+
+module CC::CLI
+  describe UpgradeConfigGenerator do
+    include Factory
+    include FileSystemHelpers
+
+    around do |test|
+      within_temp_dir { test.call }
+    end
+
+    describe "#eligible_engines" do
+      it "calculates eligible_engines based on classic languages & source files" do
+        File.write(".codeclimate.yml", create_classic_yaml)
+        write_fixture_source_files
+
+        expected_engine_names = %w(rubocop csslint duplication)
+        expected_engines = engine_registry.list.select do |name, _|
+          expected_engine_names.include?(name)
+        end
+        generator.eligible_engines.must_equal expected_engines
+      end
+    end
+
+    describe "#exclude_paths" do
+      it "uses existing exclude_paths from yaml" do
+        File.write(".codeclimate.yml", create_classic_yaml)
+        write_fixture_source_files
+
+        expected_paths = %w(excluded.rb)
+        generator.exclude_paths.must_equal expected_paths
+      end
+    end
+
+    def generator
+      @generator ||= UpgradeConfigGenerator.new(make_filesystem, engine_registry)
+    end
+
+    def engine_registry
+      @engine_registry ||= CC::Analyzer::EngineRegistry.new
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,13 @@ require "minitest/autorun"
 require "minitest/reporters"
 require "minitest/around/spec"
 require "mocha/mini_test"
+require "safe_yaml"
 require "cc/cli"
 require "cc/yaml"
 
 Dir.glob("spec/support/**/*.rb").each(&method(:load))
+
+SafeYAML::OPTIONS[:default_mode] = :safe
 
 Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new
 

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -74,6 +74,15 @@ module Factory
     }
   end
 
+  def create_classic_yaml
+    %{
+      languages:
+        Ruby: true
+      exclude_paths:
+        - excluded.rb
+    }
+  end
+
   def sample_issue
     {
       "type" => "issue",

--- a/spec/support/file_system_helpers.rb
+++ b/spec/support/file_system_helpers.rb
@@ -3,6 +3,10 @@ module FileSystemHelpers
     Dir.chdir(Dir.mktmpdir, &block)
   end
 
+  def make_filesystem
+    CC::Analyzer::Filesystem.new(".")
+  end
+
   def make_tree(spec)
     paths = spec.split(/\s+/).select(&:present?)
     paths.each { |path| make_file(path, "") }
@@ -13,5 +17,21 @@ module FileSystemHelpers
 
     FileUtils.mkdir_p(directory)
     File.write(path, content)
+  end
+
+  def write_fixture_source_files
+    File.write("cool.rb", "class Cool; end")
+    FileUtils.mkdir_p("js")
+    File.write("js/foo.js", "function() {}")
+    FileUtils.mkdir_p("stylesheets")
+    File.write("stylesheets/main.css", ".main {}")
+    FileUtils.mkdir_p("vendor/jquery")
+    File.write("vendor/foo.css", ".main {}")
+    File.write("vendor/jquery/jquery.css", ".main {}")
+    FileUtils.mkdir_p("spec/models")
+    File.write("spec/spec_helper.rb", ".main {}")
+    File.write("spec/models/foo.rb", ".main {}")
+    FileUtils.mkdir_p("config")
+    File.write("config/foo.rb", ".main {}")
   end
 end


### PR DESCRIPTION
This adds an `--upgrade` flag the `init` command will recognize to upgrade classic configuration.

In the upgrade case, the logic for each individual engine should be:

* Enable it if its language was supported by the classic platform & was enabled in the user's existing classic config.
* Enable it if its language was not supported by classic platform, but it meets the normal criteria for inclusion.
* Do not enable it if its language was supported by the classic platform but it was not enabled in the user's classic config.

Additionally, if upgrading a classic config, do not alter `exclude_paths`, since this key existed for classic config & should be respected.

Basically, do what we would normally do unless it contradicts existing config.

There's definitely still opportunity for me clean this up some, but I'm going to open this for review now since I think the cleaning will make the diff harder to read. cc @codeclimate/review 