### PR TITLE
Add codeclimate-init.

### DIFF
--- a/bin/codeclimate-init
+++ b/bin/codeclimate-init
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+$LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), "../lib")))
+
+require "cc/cli"
+
+ENV["FILESYSTEM_DIR"] ||= "."
+
+CC::CLI::Init.new(ARGV).execute

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files         = Dir["lib/**/*.rb"] + Dir["bin/*"] + Dir["config/*"]
   s.require_paths = ["lib"]
   s.bindir        = "bin"
-  s.executables   = %w(check codeclimate)
+  s.executables   = %w(check codeclimate-init)
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"


### PR DESCRIPTION
To eliminate collisions between `bin/codeclimate` here, and the `codeclimate` binstub we distribute with out Docker image, we:

* Create a new `bin/codeclimate-init` binary, which can be used in Platform and is included as an executable in the gemspec
* Remove `bin/codeclimate` from the gemspec. It's still in the repo and directly findable, just not installed anywhere by `gem install` or `bundle install`.