### PR TITLE
Add a Container#stop method to exit early and send a finished event

### DIFF
--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -42,13 +42,13 @@ module CC
         started = Time.now
         @listener.started(container_data)
 
-        pid, _, out, err = POSIX::Spawn.popen4(*docker_run_command(options))
+        @pid, _, out, err = POSIX::Spawn.popen4(*docker_run_command(options))
 
         t_out = read_stdout(out)
         t_err = read_stderr(err)
-        t_timeout = timeout_thread(pid)
+        t_timeout = timeout_thread(@pid)
 
-        _, status = Process.waitpid2(pid)
+        _, status = Process.waitpid2(@pid)
 
         duration = ((Time.now - started) * 1000).round
         @listener.finished(container_data(duration: duration, status: status))
@@ -65,6 +65,15 @@ module CC
           t_out.join if t_out
           t_err.join if t_err
         end
+      end
+
+      def stop
+        # Prevents the processing of more output after first error
+        @on_output = ->(*) { }
+
+        Process.kill("TERM", @pid) if @pid
+      rescue Errno::ESRCH
+        Analyzer.statsd.increment("container.kill_process_rescue")
       end
 
       private

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -33,7 +33,7 @@ module CC
 
         container.on_output("\0") do |output|
           unless output_filter.filter?(output)
-            stdout_io.write(output)
+            stdout_io.write(output) || container.stop
           end
         end
 


### PR DESCRIPTION
This PR allows the running container to stop analysis immediately in case of an output processing error.