### PR TITLE
Upgrade codeclimate-yaml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.8.0)
       activesupport (~> 4.2, >= 4.2.1)
-      codeclimate-yaml (~> 0.2.3)
+      codeclimate-yaml (~> 0.3.0)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.9.1)
       highline (~> 1.7, >= 1.7.2)
@@ -24,7 +24,7 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     builder (3.2.2)
-    codeclimate-yaml (0.2.3)
+    codeclimate-yaml (0.3.0)
       activesupport
       secure_string
     coderay (1.1.0)
@@ -76,6 +76,3 @@ DEPENDENCIES
   minitest-reporters
   mocha
   rack-test
-
-BUNDLED WITH
-   1.10.6

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.2.3"
+  s.add_dependency "codeclimate-yaml", "~> 0.3.0"
   s.add_dependency "faraday", "~> 0.9.1"
   s.add_dependency "faraday_middleware", "~> 0.9.1"
   s.add_dependency "highline",  "~> 1.7", ">= 1.7.2"


### PR DESCRIPTION
The `codeclimate-yaml` gem has to be upgraded for this gem to support
nested `config` for certain engines to work properly.