### PR TITLE
Add empty output to engine output filter rules

### DIFF
--- a/lib/cc/analyzer/engine_output_filter.rb
+++ b/lib/cc/analyzer/engine_output_filter.rb
@@ -8,6 +8,8 @@ module CC
       end
 
       def filter?(output)
+        return true unless output.present?
+
         if (json = parse_as_json(output))
           issue?(json) && ignore_issue?(json)
         else

--- a/lib/cc/analyzer/formatters/json_formatter.rb
+++ b/lib/cc/analyzer/formatters/json_formatter.rb
@@ -17,8 +17,6 @@ module CC
         end
 
         def write(data)
-          return unless data.present?
-
           document = JSON.parse(data)
           document["engine_name"] = current_engine.name
 

--- a/lib/cc/analyzer/formatters/plain_text_formatter.rb
+++ b/lib/cc/analyzer/formatters/plain_text_formatter.rb
@@ -12,18 +12,16 @@ module CC
         end
 
         def write(data)
-          if data.present?
-            json = JSON.parse(data)
-            json["engine_name"] = current_engine.name
+          json = JSON.parse(data)
+          json["engine_name"] = current_engine.name
 
-            case json["type"].downcase
-            when "issue"
-              issues << json
-            when "warning"
-              warnings << json
-            else
-              raise "Invalid type found: #{json["type"]}"
-            end
+          case json["type"].downcase
+          when "issue"
+            issues << json
+          when "warning"
+            warnings << json
+          else
+            raise "Invalid type found: #{json["type"]}"
           end
         end
 

--- a/spec/cc/analyzer/engine_output_filter_spec.rb
+++ b/spec/cc/analyzer/engine_output_filter_spec.rb
@@ -2,6 +2,14 @@ require "spec_helper"
 
 module CC::Analyzer
   describe EngineOutputFilter do
+    it "filters empty output" do
+      filter = EngineOutputFilter.new
+
+      filter.filter?("").must_equal true
+      filter.filter?(" ").must_equal true
+      filter.filter?("\n").must_equal true
+    end
+
     it "does not filter arbitrary output" do
       filter = EngineOutputFilter.new
 

--- a/spec/cc/analyzer/formatters/json_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/json_formatter_spec.rb
@@ -9,18 +9,6 @@ module CC::Analyzer::Formatters
       JSONFormatter.new(filesystem)
     end
 
-    describe "#write" do
-      it "returns when no data is present" do
-        stdout, stderr = capture_io do
-          formatter.engine_running(engine_double("cool_engine")) do
-            formatter.write("")
-          end
-        end
-
-        stdout.must_equal("")
-      end
-    end
-
     describe "#start, write, finished" do
       it "outputs a string that can be parsed as JSON" do
         issue1 = sample_issue


### PR DESCRIPTION
This prevents processing errors when the engine output is parsed into another structure by adding empty output to the `EngineOutputFilter` filter rules.