### PR TITLE
Extract Analyzer::Engines from Analyzer::EnginesRunner.

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -5,6 +5,7 @@ module CC
     autoload :Container, "cc/analyzer/container"
     autoload :ContainerListener, "cc/analyzer/container_listener"
     autoload :Engine, "cc/analyzer/engine"
+    autoload :Engines, "cc/analyzer/engines"
     autoload :EngineOutputFilter, "cc/analyzer/engine_output_filter"
     autoload :EngineRegistry, "cc/analyzer/engine_registry"
     autoload :EnginesRunner, "cc/analyzer/engines_runner"

--- a/lib/cc/analyzer/engines.rb
+++ b/lib/cc/analyzer/engines.rb
@@ -7,17 +7,23 @@ module CC
         super()
         @registry = registry
         @config = config
+        @container_label = container_label
         @requested_paths = requested_paths
+        @source_dir = source_dir
         names_and_raw_engine_configs.each do |name, raw_engine_config|
-          label = container_label || SecureRandom.uuid
-          engine_config = engine_config(raw_engine_config)
-          self << Engine.new(
-            name, registry[name], source_dir, engine_config, label
-          )
+          self << build_engine(name, raw_engine_config)
         end
       end
 
       private
+
+      def build_engine(name, raw_engine_config)
+        label = @container_label || SecureRandom.uuid
+        engine_config = engine_config(raw_engine_config)
+        Engine.new(
+          name, @registry[name], @source_dir, engine_config, label
+        )
+      end
 
       def engine_config(raw_engine_config)
         config = raw_engine_config.merge(
@@ -51,7 +57,7 @@ module CC
       end
 
       def exclude_paths
-        PathPatterns.new(@config.exclude_paths || []).expanded + 
+        PathPatterns.new(@config.exclude_paths || []).expanded +
           gitignore_paths
       end
 

--- a/lib/cc/analyzer/engines.rb
+++ b/lib/cc/analyzer/engines.rb
@@ -1,0 +1,67 @@
+require "securerandom"
+
+module CC
+  module Analyzer
+    class Engines < Array
+      def initialize(registry:, config:, container_label:, source_dir:, requested_paths:)
+        super()
+        @registry = registry
+        @config = config
+        @requested_paths = requested_paths
+        names_and_raw_engine_configs.each do |name, raw_engine_config|
+          label = container_label || SecureRandom.uuid
+          engine_config = engine_config(raw_engine_config)
+          self << Engine.new(
+            name, registry[name], source_dir, engine_config, label
+          )
+        end
+      end
+
+      private
+
+      def engine_config(raw_engine_config)
+        config = raw_engine_config.merge(
+          exclude_paths: exclude_paths,
+          include_paths: include_paths
+        )
+        # The yaml gem turns a config file string into a hash, but engines
+        # expect the string. So we (for now) need to turn it into a string in
+        # that one scenario.
+        # TODO: update the engines to expect the hash and then remove this.
+        if config.fetch("config", {}).keys.size == 1 && config["config"].key?("file")
+          config["config"] = config["config"]["file"]
+        end
+        config
+      end
+
+      def names_and_raw_engine_configs
+        {}.tap do |ret|
+          @config.engines.each do |name, raw_engine_config|
+            if raw_engine_config.enabled? && @registry.key?(name)
+              ret[name] = raw_engine_config
+            end
+          end
+        end
+      end
+
+      def include_paths
+        IncludePathsBuilder.new(
+          @config.exclude_paths || [], @requested_paths
+        ).build
+      end
+
+      def exclude_paths
+        PathPatterns.new(@config.exclude_paths || []).expanded + 
+          gitignore_paths
+      end
+
+      def gitignore_paths
+        if File.exist?(".gitignore")
+          `git ls-files --others -i -z --exclude-from .gitignore`.split("\0")
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -13,21 +13,14 @@ module CC
         @config = config
         @requested_paths = requested_paths
         @container_label = container_label
-        @engines = Engines.new(
-          registry: registry,
-          config: config,
-          container_label: container_label,
-          source_dir: source_dir,
-          requested_paths: requested_paths
-        )
       end
 
       def run(container_listener = ContainerListener.new)
-        raise NoEnabledEngines if @engines.empty?
+        raise NoEnabledEngines if engines.empty?
 
         @formatter.started
 
-        @engines.each { |engine| run_engine(engine, container_listener) }
+        engines.each { |engine| run_engine(engine, container_listener) }
 
         @formatter.finished
       ensure
@@ -37,6 +30,16 @@ module CC
       private
 
       attr_reader :requested_paths
+
+      def engines
+        @engines ||= Engines.new(
+          registry: @registry,
+          config: @config,
+          container_label: @container_label,
+          source_dir: @source_dir,
+          requested_paths: @requested_paths
+        )
+      end
 
       def run_engine(engine, container_listener)
         @formatter.engine_running(engine) do

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -13,14 +13,21 @@ module CC
         @config = config
         @requested_paths = requested_paths
         @container_label = container_label
+        @engines = Engines.new(
+          registry: registry,
+          config: config,
+          container_label: container_label,
+          source_dir: source_dir,
+          requested_paths: requested_paths
+        )
       end
 
       def run(container_listener = ContainerListener.new)
-        raise NoEnabledEngines if engines.empty?
+        raise NoEnabledEngines if @engines.empty?
 
         @formatter.started
 
-        engines.each { |engine| run_engine(engine, container_listener) }
+        @engines.each { |engine| run_engine(engine, container_listener) }
 
         @formatter.finished
       ensure
@@ -34,60 +41,6 @@ module CC
       def run_engine(engine, container_listener)
         @formatter.engine_running(engine) do
           engine.run(@formatter, container_listener)
-        end
-      end
-
-      def engines
-        @engines ||= enabled_engines.map do |name, config|
-          label = @container_label || SecureRandom.uuid
-
-          Engine.new(name, metadata(name), @source_dir, engine_config(config), label)
-        end
-      end
-
-      def engine_config(config)
-        config = config.merge(
-          exclude_paths: exclude_paths,
-          include_paths: include_paths
-        )
-
-        # The yaml gem turns a config file string into a hash, but engines expect the string
-        # So we (for now) need to turn it into a string in that one scenario.
-        # TODO: update the engines to expect the hash and then remove this.
-        if config.fetch("config", {}).keys.size == 1 && config["config"].key?("file")
-          config["config"] = config["config"]["file"]
-        end
-
-        config
-      end
-
-      def enabled_engines
-        {}.tap do |ret|
-          @config.engines.each do |name, config|
-            if config.enabled? && @registry.key?(name)
-              ret[name] = config
-            end
-          end
-        end
-      end
-
-      def metadata(engine_name)
-        @registry[engine_name]
-      end
-
-      def include_paths
-        IncludePathsBuilder.new(@config.exclude_paths || [], requested_paths).build
-      end
-
-      def exclude_paths
-        PathPatterns.new(@config.exclude_paths || []).expanded + gitignore_paths
-      end
-
-      def gitignore_paths
-        if File.exist?(".gitignore")
-          `git ls-files --others -i -z --exclude-from .gitignore`.split("\0")
-        else
-          []
         end
       end
     end

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -24,87 +24,11 @@ module CC::Analyzer
       EnginesRunner.new(registry, formatter, "/code", config).run
     end
 
-    it "does not raise for invalid engine names" do
-      config = config_with_engine("an_engine")
-      runner = EnginesRunner.new({}, null_formatter, "/code", config)
-
-      lambda { runner.run }
-    end
-
     it "raises for no enabled engines" do
       config = stub(engines: {})
       runner = EnginesRunner.new({}, null_formatter, "/code", config)
 
       lambda { runner.run }.must_raise(EnginesRunner::NoEnabledEngines)
-    end
-
-    it "massages data for the config" do
-      config = CC::Yaml.parse <<-EOYAML
-        engines:
-          rubocop:
-            enabled: true
-            config:
-              file: rubocop.yml
-      EOYAML
-      registry = registry_with_engine("rubocop")
-      formatter = null_formatter
-
-      FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
-      expected_config = {
-        "enabled" => true,
-        "config" => "rubocop.yml",
-        :exclude_paths => [],
-        :include_paths => ["./"]
-      }
-
-      expect_engine_run("rubocop", "/code", formatter, expected_config)
-
-      EnginesRunner.new(registry, formatter, "/code", config).run
-    end
-
-    it "respects .gitignore paths" do
-      make_file(".ignorethis")
-      make_file(".gitignore", ".ignorethis\n")
-      config = CC::Yaml.parse <<-EOYAML
-        engines:
-          rubocop:
-            enabled: true
-      EOYAML
-      registry = registry_with_engine("rubocop")
-      formatter = null_formatter
-
-      FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
-      expected_config = {
-        "enabled" => true,
-        :exclude_paths => %w[.ignorethis],
-        :include_paths => %w[.gitignore]
-      }
-
-      expect_engine_run("rubocop", "/code", formatter, expected_config)
-
-      EnginesRunner.new(registry, formatter, "/code", config).run
-    end
-
-    describe "when the source directory contains all readable files, and there are no ignored files" do
-      let(:engines_config) { config_with_engine("an_engine") }
-      let(:formatter) { null_formatter }
-      let(:registry) { registry_with_engine("an_engine") }
-
-      before do
-        make_file("root_file.rb")
-        make_file("subdir/subdir_file.rb")
-      end
-
-      it "gets include_paths from IncludePathBuilder" do
-        IncludePathsBuilder.expects(:new).with([], []).returns(mock(build: ['.']))
-        expected_config = {
-          "enabled" => true,
-          :exclude_paths => [],
-          :include_paths => ['.']
-        }
-        expect_engine_run("an_engine", "/code", formatter, expected_config)
-        EnginesRunner.new(registry, formatter, "/code", engines_config).run
-      end
     end
 
     describe "when the formatter does not respond to #close" do

--- a/spec/cc/analyzer/engines_spec.rb
+++ b/spec/cc/analyzer/engines_spec.rb
@@ -1,0 +1,167 @@
+require "spec_helper"
+require "file_utils_ext"
+
+module CC::Analyzer
+  describe EnginesRunner do
+    include FileSystemHelpers
+
+    let(:engines) do
+      Engines.new(
+        registry: registry,
+        config: config,
+        container_label: container_label,
+        source_dir: source_dir,
+        requested_paths: requested_paths
+      )
+    end
+    let(:container_label) { nil }
+    let(:requested_paths) { [] }
+    let(:source_dir) { "/code" }
+
+    around do |test|
+      within_temp_dir { test.call }
+    end
+
+    before do
+      system("git init > /dev/null")
+    end
+
+    describe "with one engine" do
+      let(:config) { config_with_engine("an_engine") }
+      let(:registry) { registry_with_engine("an_engine") }
+
+      before do
+        FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
+      end
+
+      it "contains that engine" do
+        engines.size.must_equal(1)
+        engines.first.name.must_equal("an_engine")
+      end
+    end
+
+    describe "with an invalid engine name" do
+      let(:config) { config_with_engine("an_engine") }
+      let(:registry) { {} }
+
+      it "does not raise" do
+        lambda { engines }
+      end
+    end
+
+    describe "with engine-specific config" do
+      let(:config) do
+        CC::Yaml.parse <<-EOYAML
+          engines:
+            rubocop:
+              enabled: true
+              config:
+                file: rubocop.yml
+        EOYAML
+      end
+      let(:registry) { registry_with_engine("rubocop") }
+
+      before do
+        FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
+      end
+
+      it "keeps that config and adds some entries" do
+        expected_config = {
+          "enabled" => true,
+          "config" => "rubocop.yml",
+          :exclude_paths => [],
+          :include_paths => ["./"]
+        }
+        Engine.expects(:new).with(
+          "rubocop",
+          registry["rubocop"],
+          source_dir,
+          expected_config,
+          anything
+        )
+        engines
+      end
+    end
+
+    describe "with a .gitignore file" do
+      let(:config) do
+        CC::Yaml.parse <<-EOYAML
+          engines:
+            rubocop:
+              enabled: true
+        EOYAML
+      end
+      let(:registry) { registry_with_engine("rubocop") }
+
+      before do
+        make_file(".ignorethis")
+        make_file(".gitignore", ".ignorethis\n")
+      end
+
+      before do
+        FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
+      end
+
+      it "respects those paths" do
+        expected_config = {
+          "enabled" => true,
+          :exclude_paths => %w[.ignorethis],
+          :include_paths => %w[.gitignore]
+        }
+        Engine.expects(:new).with(
+          "rubocop",
+          registry["rubocop"],
+          source_dir,
+          expected_config,
+          anything
+        )
+        engines
+      end
+    end
+
+    describe "when the source directory contains all readable files, and there are no ignored files" do
+      let(:config) { config_with_engine("an_engine") }
+      let(:registry) { registry_with_engine("an_engine") }
+
+      before do
+        make_file("root_file.rb")
+        make_file("subdir/subdir_file.rb")
+      end
+
+      it "gets include_paths from IncludePathBuilder" do
+        IncludePathsBuilder.stubs(:new).with([], []).returns(mock(build: ['.']))
+        expected_config = {
+          "enabled" => true,
+          :exclude_paths => [],
+          :include_paths => ['.']
+        }
+        Engine.expects(:new).with(
+          "an_engine",
+          registry["an_engine"],
+          source_dir,
+          expected_config,
+          anything
+        )
+        engines
+      end
+    end
+
+    def registry_with_engine(name)
+      { name => { "image" => "codeclimate/codeclimate-#{name}" } }
+    end
+
+    def config_with_engine(name)
+      CC::Yaml.parse(<<-EOYAML)
+        engines:
+          #{name}:
+            enabled: true
+      EOYAML
+    end
+
+    def null_formatter
+      formatter = stub(started: nil, write: nil, run: nil, finished: nil, close: nil)
+      formatter.stubs(:engine_running).yields
+      formatter
+    end
+  end
+end

--- a/spec/cc/analyzer/engines_spec.rb
+++ b/spec/cc/analyzer/engines_spec.rb
@@ -45,7 +45,7 @@ module CC::Analyzer
       let(:registry) { {} }
 
       it "does not raise" do
-        lambda { engines }
+        engines
       end
     end
 
@@ -105,8 +105,8 @@ module CC::Analyzer
       it "respects those paths" do
         expected_config = {
           "enabled" => true,
-          :exclude_paths => %w[.ignorethis],
-          :include_paths => %w[.gitignore]
+          :exclude_paths => %w(.ignorethis),
+          :include_paths => %w(.gitignore)
         }
         Engine.expects(:new).with(
           "rubocop",


### PR DESCRIPTION
This reduces the responsibility of Analyzer::EnginesRunner so it only
runs analyses on an array of pre-instantiated Engines. Choosing and
instantiating engines with the correct config is now the responsibility
of Analyzer::Engines.

This is motivated in part by desired changes in stream handling in
platform -- separating these responsibilities here will give us more
flexibility elsewhere. In addition, the hope is that this might lead to
phasing out EnginesRunner entirely.