### PR TITLE
Only enable bundler-audit if Gemfile.lock in root

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -92,7 +92,7 @@ bundler-audit:
   upgrade_languages:
     - Ruby
   enable_regexps:
-    - Gemfile\.lock
+    - ^Gemfile\.lock$
   default_ratings_paths:
     - Gemfile.lock
 phpcodesniffer:


### PR DESCRIPTION
The previous regular expression pattern would match if there was a file named Gemfile.lock in any directory of the project but bundler-audit crashes if a Gemfile.lock isn't present in the project's root directory.