### PR TITLE
Use docker kill, not Process.kill

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,11 @@ machine:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     registry_root: us.gcr.io/code_climate
 
+dependencies:
+  pre:
+    # Run in container_spec
+    - docker pull alpine
+
 test:
   override:
     - bundle exec rake


### PR DESCRIPTION
It's generally believed that sending kill -9 to the docker-run client process in
an attempt to kill the running container is unreliable and incorrect. Really,
how could it work? The client process must exit immediately and can do nothing
to handle such a signal (like, for example, tell the docker server to stop the
container).

That said, this approach *seems* to work reliably in the timeout case. The spec
added here around the timeout behavior, which I believe is an accurate
reproduction of what should not work, works 100% reliably with either version of
the code.

What did not work was Container#stop. When a spec was added around this
behavior, the following was seen:

- The Process.kill("TERM") was ignored, but
- The Process.kill("KILL") occurring on eventual timeout was also ignored
- The container was left running

This should explain the zombie container we see. Container#stop is used on
invalid output, which phpcodesniffer (a common offender) is known to produce.

It's worth noting that replacing TERM with KILL in the #stop method (something
I'd expect to work, given how timing out via this signal works reliably) did not
address the issue -- the same behavior was seen.

Understanding all this, and aided by the two new integration specs (which
actually run and kill real containers), both uses of Process.kill were replaced
with the assumed-better docker-kill approach.