### PR TITLE
Split out bin/prep-release

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -19,6 +19,14 @@ Otherwise, invoke the `docker run` command found in the README.
 
 ## Releasing a new version
 
+Prep and open a PR bumping the version:
+
+```console
+bin/prep-release VERSION
+```
+
+Once merged, release it:
+
 ```console
 bin/release VERSION
 ```

--- a/bin/prep-release
+++ b/bin/prep-release
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Open a PR for releasing a new version of this repository.
+#
+# Usage: bin/prep-release VERSION
+#
+###
+set -e
+
+if [ -z "$1" ]; then
+  echo "usage: bin/prep-release VERSION" >&2
+  exit 64
+fi
+
+version=$1
+old_version=$(< VERSION)
+
+if ! bundle exec rake; then
+  echo "test failure, not releasing" >&2
+  exit 1
+fi
+
+printf "RELEASE %s => %s\n" "$old_version" "$version"
+git checkout master
+git pull
+
+git checkout -b "release-$version"
+
+printf "%s\n" "$version" > VERSION
+bundle
+git add VERSION Gemfile.lock
+git commit -m "Release v$version"
+git push
+
+if command -v gh > /dev/null 2>&1; then
+  gh pull-request -m "Release v$version"
+else
+  echo "gh not installed? Please open the PR manually" >&2
+fi
+
+echo "After merging the version-bump PR, run bin/release"

--- a/bin/release
+++ b/bin/release
@@ -1,6 +1,8 @@
 #!/bin/sh
 #
-# Release a new version of this repository
+# Release a new version of this repository.
+#
+# Assumes bin/prep-release was run and the PR merged.
 #
 # Usage: bin/release VERSION
 #
@@ -13,22 +15,11 @@ if [ -z "$1" ]; then
 fi
 
 version=$1
-old_version=$(< VERSION)
 
-if ! bundle exec rake; then
-  echo "test failure, not releasing" >&2
-  exit 1
-fi
-
-printf "RELEASE %s => %s\n" "$old_version" "$version"
 git checkout master
 git pull
 
-printf "%s\n" "$version" > VERSION
-bundle
-git add VERSION Gemfile.lock
-git commit -m "Release v$version"
-
+printf "RELEASE %s\n" "$version"
 rake release
 
 docker build --rm -t codeclimate/codeclimate .
@@ -39,6 +30,4 @@ docker push codeclimate/codeclimate
 echo "Be sure to update release notes:"
 echo ""
 echo "  https://github.com/codeclimate/codeclimate/releases/new?tag=v$version"
-echo ""
-echo "  https://github.com/codeclimate/codeclimate/compare/v$old_version...v$version"
 echo ""


### PR DESCRIPTION
Now that master is a protected branch, we can't script the entire release
process because we're required to open the version bump as a PR and merge in
the web UI.

This patch splits out a bin/pre-release for the tasks associated with opening
that PR. bin/release is then reduced to only the steps to perform after that PR
is merged to master.

/cc @codeclimate/review

These scripts were used to release v0.9.4