### PR TITLE
upgrade config: force existing exclude_paths to be an array

### DIFF
--- a/lib/cc/cli/upgrade_config_generator.rb
+++ b/lib/cc/cli/upgrade_config_generator.rb
@@ -4,7 +4,7 @@ module CC
   module CLI
     class UpgradeConfigGenerator < ConfigGenerator
       def exclude_paths
-        existing_yaml["exclude_paths"] || []
+        [existing_yaml["exclude_paths"]].flatten.select(&:present?)
       end
 
       def post_generation_verb

--- a/spec/cc/cli/upgrade_config_generator_spec.rb
+++ b/spec/cc/cli/upgrade_config_generator_spec.rb
@@ -26,10 +26,29 @@ module CC::CLI
     describe "#exclude_paths" do
       it "uses existing exclude_paths from yaml" do
         File.write(".codeclimate.yml", create_classic_yaml)
-        write_fixture_source_files
 
         expected_paths = %w(excluded.rb)
         generator.exclude_paths.must_equal expected_paths
+      end
+
+      it "forces existing include paths to be an array" do
+        File.write(".codeclimate.yml", %(
+          languages:
+            Ruby: true
+          exclude_paths: excluded.rb
+        ))
+
+        expected_paths = %w(excluded.rb)
+        generator.exclude_paths.must_equal expected_paths
+      end
+
+      it "handles yaml without exclude paths" do
+        File.write(".codeclimate.yml", %(
+          languages:
+            Ruby: true
+        ))
+
+        generator.exclude_paths.must_equal []
       end
     end
 


### PR DESCRIPTION
This is in response to a crash we just saw. I don't think this was
really valid config on classic either, but I guess we handled it there?

cc @codeclimate/review @brynary