### PR TITLE
Fix unknown formatter error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :test do
   gem "minitest-around"
   gem "minitest-reporters"
   gem "rack-test"
+  gem "rake"
 end

--- a/lib/cc/analyzer/formatters.rb
+++ b/lib/cc/analyzer/formatters.rb
@@ -1,5 +1,7 @@
 module CC
   module Analyzer
+    autoload :InvalidFormatterError, "cc/analyzer/invalid_formatter_error"
+
     module Formatters
       autoload :Formatter,  "cc/analyzer/formatters/formatter"
       autoload :JSONFormatter, "cc/analyzer/formatters/json_formatter"
@@ -12,7 +14,7 @@ module CC
       }.freeze
 
       def self.resolve(name)
-        FORMATTERS[name.to_sym] or raise InvalidFormatterError, "'#{name}' is not a valid formatter. Valid options are: #{FORMATTERS.keys.join(", ")}"
+        FORMATTERS[name.to_sym] or raise InvalidFormatterError, "'#{name}' is not a valid formatter. Valid options are: #{Formatters::FORMATTERS.keys.join(", ")}"
       end
     end
   end

--- a/lib/cc/analyzer/formatters/formatter.rb
+++ b/lib/cc/analyzer/formatters/formatter.rb
@@ -29,8 +29,6 @@ module CC
         def failed(output)
         end
 
-        InvalidFormatterError = Class.new(StandardError)
-
         private
 
         attr_reader :current_engine

--- a/lib/cc/analyzer/invalid_formatter_error.rb
+++ b/lib/cc/analyzer/invalid_formatter_error.rb
@@ -1,0 +1,5 @@
+module CC
+  module Analyzer
+    InvalidFormatterError = Class.new(StandardError)
+  end
+end

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -44,7 +44,7 @@ module CC
             @path_options << arg
           end
         end
-      rescue Formatters::Formatter::InvalidFormatterError => e
+      rescue InvalidFormatterError => e
         fatal(e.message)
       end
 

--- a/spec/cc/cli/analyze_spec.rb
+++ b/spec/cc/cli/analyze_spec.rb
@@ -110,6 +110,14 @@ module CC::CLI
 
           Analyze.new(%w[-f json])
         end
+
+        it "errors with a helpful message when a formatter is unknown" do
+          stdout, _ = capture_io do
+            Analyze.new(%w[-f nope])
+          end
+
+          stdout.must_match("'nope' is not a valid formatter")
+        end
       end
     end
 


### PR DESCRIPTION
This fixes an error I encountered when referencing an unknown
formatter. There's already logic for outputting a helpful error message,
but it looks like we broke that behavior at some point after moving
some references around.