### PR TITLE
Always enable fixme engine when generating engines config

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -134,7 +134,8 @@ fixme:
   description: Find FIXME, TODO, HACK, etc. comments
   community: false
   enable_regexps:
-  default_ratings_paths:
+    - .+
+  default_ratings_paths: []
 foodcritic:
   image: codeclimate/codeclimate-foodcritic
   description: Lint tool for Chef cookbooks

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -32,7 +32,7 @@ module CC::CLI
       it "calculates eligible_engines based on existing files" do
         write_fixture_source_files
 
-        expected_engine_names = %w(rubocop eslint csslint)
+        expected_engine_names = %w(rubocop eslint csslint fixme)
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end
@@ -42,8 +42,9 @@ module CC::CLI
       it "returns brakeman when Gemfile.lock exists" do
         File.write("Gemfile.lock", "gemfile-lock-content")
 
+        expected_engine_names = %w(bundler-audit fixme)
         expected_engines = engine_registry.list.select do |name, _|
-          "bundler-audit" == name
+          expected_engine_names.include?(name)
         end
         generator.eligible_engines.must_equal expected_engines
       end

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -31,6 +31,7 @@ module CC::CLI
               "rubocop" => { "enabled"=>true },
               "eslint" => { "enabled"=>true },
               "csslint" => { "enabled"=>true },
+              "fixme" => { "enabled"=>true },
             },
             "ratings" => { "paths" => ["**.rb", "**.js", "**.jsx", "**.css"] },
             "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
@@ -150,6 +151,7 @@ module CC::CLI
               "rubocop" => { "enabled"=>true },
               "eslint" => { "enabled"=>true },
               "csslint" => { "enabled"=>true },
+              "fixme" => { "enabled"=>true },
             },
             "ratings" => { "paths" => ["**.rb", "**.js", "**.jsx", "**.css"] },
             "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
@@ -178,6 +180,7 @@ module CC::CLI
             "engines" => {
               "rubocop" => { "enabled"=>true },
               "csslint" => { "enabled"=>true },
+              "fixme" => { "enabled"=>true },
             },
             "ratings" => { "paths" => ["**.rb", "**.css"] },
             "exclude_paths" => ["excluded.rb"],

--- a/spec/cc/cli/upgrade_config_generator_spec.rb
+++ b/spec/cc/cli/upgrade_config_generator_spec.rb
@@ -15,7 +15,7 @@ module CC::CLI
         File.write(".codeclimate.yml", create_classic_yaml)
         write_fixture_source_files
 
-        expected_engine_names = %w(rubocop csslint)
+        expected_engine_names = %w(rubocop csslint fixme)
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end


### PR DESCRIPTION
The behavior added in this PR adds the fixme engine after matching against any file within the include paths.