### PR TITLE
Specify remote and branch name when pushing to avoid git warning

### DIFF
--- a/bin/prep-release
+++ b/bin/prep-release
@@ -14,6 +14,7 @@ fi
 
 version=$1
 old_version=$(< VERSION)
+branch="release-$version"
 
 if ! bundle exec rake; then
   echo "test failure, not releasing" >&2
@@ -24,13 +25,13 @@ printf "RELEASE %s => %s\n" "$old_version" "$version"
 git checkout master
 git pull
 
-git checkout -b "release-$version"
+git checkout -b $branch
 
 printf "%s\n" "$version" > VERSION
 bundle
 git add VERSION Gemfile.lock
 git commit -m "Release v$version"
-git push
+git push origin $branch
 
 if command -v gh > /dev/null 2>&1; then
   gh pull-request -m "Release v$version"


### PR DESCRIPTION
I ran into this git warning when running the pre-release script:

```
warning: push.default is unset; its implicit value has changed in
Git 2.0 from 'matching' to 'simple'.
```

This PR specifies the origin and branch for a more explicit push which silences
the warning.