### PR TITLE
Include engine's default configuration when adding to `codeclimate.yml`

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -25,6 +25,12 @@ duplication:
   community: false
   enable_regexps:
   default_ratings_paths:
+  default_config:
+    languages:
+      - ruby
+      - javascript
+      - python
+      - php
 gofmt:
   image: codeclimate/codeclimate-gofmt
   description: gofmt

--- a/lib/cc/analyzer/config.rb
+++ b/lib/cc/analyzer/config.rb
@@ -35,7 +35,10 @@ module CC
         if engine_present?(engine_name)
           @config["engines"][engine_name]["enabled"] = true
         else
-          @config["engines"][engine_name] = { "enabled" => true }
+          @config["engines"][engine_name] = {
+            "enabled" => true,
+            "config" => default_config(engine_name),
+          }
         end
       end
 
@@ -67,6 +70,16 @@ module CC
             @config["engines"][name] = { "enabled" => engine_config }
           end
         end
+      end
+
+      def default_config(engine_name)
+        if (engine_config = engine_registry[engine_name])
+          engine_config["default_config"]
+        end
+      end
+
+      def engine_registry
+        @engine_registry ||= CC::Analyzer::EngineRegistry.new
       end
     end
   end

--- a/spec/cc/cli/engines/enable_spec.rb
+++ b/spec/cc/cli/engines/enable_spec.rb
@@ -51,6 +51,24 @@ module CC::CLI::Engines
           end
         end
       end
+
+      describe "when engine has a default configuration" do
+        it "it includes the config when enabling an engine" do
+          within_temp_dir do
+            create_yaml(Factory.create_yaml_with_no_engines)
+
+            stdout, stderr = capture_io do
+              Enable.new(args = ["duplication"]).run
+            end
+
+            content_after = File.read(".codeclimate.yml")
+
+            stdout.must_match("Engine added")
+            config = CC::Analyzer::Config.new(content_after).engine_config("duplication")
+            config["config"].must_equal("languages" => %w[ruby javascript python php])
+          end
+        end
+      end
     end
 
     def filesystem


### PR DESCRIPTION
Some engines require a default configuration before they can work
properly. One such engine is the duplication engine which requires
languages to be specified before analysis. This pulls in any default
configuration specified in the engines registry when enabling an engine
within a `.codeclimate.yml` configuration file.

Follows codeclimate/codeclimate-duplication#24