### PR TITLE
Allow container timeout to be specified in ENV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :test do
   gem "minitest-around"
   gem "minitest-reporters"
   gem "rack-test"
+  gem "rake"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rainbow (2.0.0)
+    rake (10.4.2)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     secure_string (1.3.3)
@@ -76,6 +77,7 @@ DEPENDENCIES
   minitest-reporters
   mocha
   rack-test
+  rake
 
 BUNDLED WITH
    1.10.6

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -116,7 +116,7 @@ module CC
       end
 
       def timeout
-        ENV["CONTAINER_TIMEOUT_SECONDS"] || DEFAULT_TIMEOUT
+        (ENV["CONTAINER_TIMEOUT_SECONDS"] || DEFAULT_TIMEOUT).to_i
       end
     end
   end


### PR DESCRIPTION
This mimics the functionality of
https://github.com/codeclimate/codeclimate/commit/5efbcef61d2587a8612b01f9e1047b9aefd0153b.
I also removed it from the arguments because nothing was using it, and
it was easier to do the defaulting where it is now.

@codeclimate/review