### PR TITLE
Remove upgrade_languages key from brakeman engine description

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -13,8 +13,6 @@ brakeman:
   image: codeclimate/codeclimate-brakeman
   description: Static analysis tool which checks Ruby on Rails applications for security vulnerabilities.
   community: true
-  upgrade_languages:
-    - Ruby
   enable_regexps:
     - \.rb$
   default_ratings_paths:


### PR DESCRIPTION
I added this key when adding the Brakeman engine, but realized we
probably don't want or need it for now:

Upgrade_languages key is one of several variables used by Code Climate
to generate a .codeclimate.yml when none exists.

Since community engines (of which Brakeman is one), don't get added to
the generated config, the presence of the `upgrade_languages` key on
brakeman is behavior neutral, but confusing.

Although Brakeman only analyzes ruby applications, not all ruby projects
are apps suitable for Brakeman's security analysis, so we shouldn't use
the language alone as a reason to add the engine.

@codeclimate/review 

cc @jpignata @pbrisbin 