### PR TITLE
Fixes to circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,17 +3,20 @@ machine:
     - docker
   environment:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-    registry_root: us.gcr.io/code_climate
+    PRIVATE_REGISTRY: us.gcr.io/code_climate
 
 dependencies:
-  pre:
-    # Run in container_spec
+  override:
+    # Used by container_spec
     - docker pull alpine
+    - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
 
 test:
   override:
-    - bundle exec rake
-    - docker build -t=$registry_root/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
+    - docker run
+      --volume /var/run/docker.sock:/var/run/docker.sock
+      --entrypoint bundle
+      $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM exec rake
 
 deployment:
   registry:
@@ -23,4 +26,4 @@ deployment:
       - curl https://sdk.cloud.google.com | bash
       - gcloud auth activate-service-account --key-file /tmp/gcloud_key.json
       - gcloud docker -a
-      - docker push $registry_root/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
+      - docker push $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM


### PR DESCRIPTION
- Use dependency.override, not pre
- Use conventional PRIVATE_REGISTRY variable
- Build the CLI image as a dependency
- Run tests in a docker container

This is an attempt to address intermittent failures in the Container#stop specs
by running tests in a more consistent environment.

/cc @codeclimate/review 