### PR TITLE
Increase upper limit in duration expectation

### DIFF
--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -125,7 +125,7 @@ module CC::Analyzer
           @container_result.timed_out?.must_equal false
           @container_result.exit_status.wont_equal nil
           @container_result.duration.must_be :>=, 0
-          @container_result.duration.must_be :<, 5_000
+          @container_result.duration.must_be :<, 10_000
         end
 
         it "times out slow containers" do


### PR DESCRIPTION
This assertion is designed to ensure the command was stopped and did not run to
completion. It seems the mechanics of stopping the container can take right
around 5 seconds and so a 5 second assertion fails intermittently on CI.

Example: https://circleci.com/gh/codeclimate/codeclimate/545

Given that the command, if not stopped, will run for 10 seconds, using that as
the assertion should reduce false-positives without risk of false-negatives.

/cc @codeclimate/review