### PR TITLE
Add radon engine to manifest

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -141,6 +141,14 @@ phpmd:
     - "**.php"
     - "**.module"
     - "**.inc"
+radon:
+  image: codeclimate/codeclimate-radon
+  description: Python tool used to compute Cyclomatic Complexity.
+  community: true
+  enable_regexps:
+    - \.py$
+  default_ratings_paths:
+    - "**.py"
 requiresafe:
   image: codeclimate/codeclimate-requiresafe
   description: Security tool for Node.js dependencies


### PR DESCRIPTION
The radon engine is currently generated from a [CC fork of the
radon project](https://github.com/mrb/radon), with hopes to be
integrated natively into the orginal project quickly.

Although the radon tool provides many code metrics, including
raw metrics, maintainability, halstead metrics and cyclomatic
complexity, the present engine wrapper will only report on
complexity issues.

More information about radon can be found at:
https://github.com/rubik/radon

Users can configure the minimum level of complexity they'd like to have
reported in their .codeclimate.yml file (A-F):

```
engines:
  radon:
    enabled: true
    config:
      threshold: 'd'
```

following, radon's conventions.

For more information about how radon grade levels translate to
cyclomatic complexity, please see the [radon docs](http://radon.readthedocs.org/en/latest/commandline.html).

@codeclimate/review @mrb @jpignata @BlakeWilliams 