### PR TITLE
Replace EnginesBuilder with EnginesConfigBuilder.

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -7,7 +7,7 @@ module CC
     autoload :Engine, "cc/analyzer/engine"
     autoload :EngineOutputFilter, "cc/analyzer/engine_output_filter"
     autoload :EngineRegistry, "cc/analyzer/engine_registry"
-    autoload :EnginesBuilder, "cc/analyzer/engines_builder"
+    autoload :EnginesConfigBuilder, "cc/analyzer/engines_config_builder"
     autoload :EnginesRunner, "cc/analyzer/engines_runner"
     autoload :Filesystem, "cc/analyzer/filesystem"
     autoload :Formatters, "cc/analyzer/formatters"

--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -29,14 +29,6 @@ module CC
 
       private
 
-      def build_engine(engine_class, name, raw_engine_config)
-        label = @container_label || SecureRandom.uuid
-        engine_config = engine_config(raw_engine_config)
-        engine_class.new(
-          name, @registry[name], @source_dir, engine_config, label
-        )
-      end
-
       def engine_config(raw_engine_config)
         config = raw_engine_config.merge(
           exclude_paths: exclude_paths,

--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -2,7 +2,15 @@ require "securerandom"
 
 module CC
   module Analyzer
-    class EnginesBuilder
+    class EnginesConfigBuilder
+      Result = Struct.new(
+        :name,
+        :registry_entry,
+        :code_path,
+        :config,
+        :container_label,
+      )
+
       def initialize(registry:, config:, container_label:, source_dir:, requested_paths:)
         @registry = registry
         @config = config
@@ -11,9 +19,11 @@ module CC
         @source_dir = source_dir
       end
 
-      def run(engine_class = Analyzer::Engine)
+      def run
         names_and_raw_engine_configs.map do |name, raw_engine_config|
-          build_engine(engine_class, name, raw_engine_config)
+          label = @container_label || SecureRandom.uuid
+          engine_config = engine_config(raw_engine_config)
+          Result.new(name, @registry[name], @source_dir, engine_config, label)
         end
       end
 

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -32,13 +32,25 @@ module CC
       attr_reader :requested_paths
 
       def engines
-        @engines ||= EnginesBuilder.new(
-          registry: @registry,
-          config: @config,
-          container_label: @container_label,
-          source_dir: @source_dir,
-          requested_paths: @requested_paths,
-        ).run
+        unless @engines
+          configs = EnginesConfigBuilder.new(
+            registry: @registry,
+            config: @config,
+            container_label: @container_label,
+            source_dir: @source_dir,
+            requested_paths: @requested_paths,
+          ).run
+          @engines = configs.map do |result|
+            Engine.new(
+              result.name,
+              result.registry_entry,
+              result.code_path,
+              result.config,
+              result.container_label,
+            )
+          end
+        end
+        @engines
       end
 
       def run_engine(engine, container_listener)

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -31,26 +31,28 @@ module CC
 
       attr_reader :requested_paths
 
+      def build_engine(built_config)
+        Engine.new(
+          built_config.name,
+          built_config.registry_entry,
+          built_config.code_path,
+          built_config.config,
+          built_config.container_label,
+        )
+      end
+
+      def configs
+        EnginesConfigBuilder.new(
+          registry: @registry,
+          config: @config,
+          container_label: @container_label,
+          source_dir: @source_dir,
+          requested_paths: @requested_paths,
+        ).run
+      end
+
       def engines
-        unless @engines
-          configs = EnginesConfigBuilder.new(
-            registry: @registry,
-            config: @config,
-            container_label: @container_label,
-            source_dir: @source_dir,
-            requested_paths: @requested_paths,
-          ).run
-          @engines = configs.map do |result|
-            Engine.new(
-              result.name,
-              result.registry_entry,
-              result.code_path,
-              result.config,
-              result.container_label,
-            )
-          end
-        end
-        @engines
+        @engines ||= configs.map { |result| build_engine(result) }
       end
 
       def run_engine(engine, container_listener)


### PR DESCRIPTION
Giving builder more flexibility in how Engine instances are instantiated will make it easier to make certain classes more cohesive. This refactor will be followed up by one on the builder side.

Note that this PR breaks backwards compatibility, so I'll follow it up soon with a small refactor in builder.