### PR TITLE
Enforce a maximum output byte count on containers

### DIFF
--- a/lib/cc/analyzer/include_paths_builder.rb
+++ b/lib/cc/analyzer/include_paths_builder.rb
@@ -49,8 +49,8 @@ module CC
           tmp.write(File.read(".gitignore")) if File.file?(".gitignore")
           tmp << @cc_exclude_paths.join("\n")
           tmp.close
-          tracked_and_ignored = `git ls-files -zi -X #{tmp.path}`.split("\0")
-          untracked_and_ignored = `git ls-files -zio -X #{tmp.path}`.split("\0")
+          tracked_and_ignored = `git ls-files -zi -X #{tmp.path} 2>/dev/null`.split("\0")
+          untracked_and_ignored = `git ls-files -zio -X #{tmp.path} 2>/dev/null`.split("\0")
           tracked_and_ignored + untracked_and_ignored
         end
       end


### PR DESCRIPTION
Currently engines can generate an unbounded amount of output on STDOUT
and STDERR while running. This is bad for a variety of reasons, but the
symptom most pressing is that Docker has a memory leak around dealing
with large STDOUT streams especially when there are "slow" readers
attached.

This implements a concept of maximum output bytes that when tripped will
stop the container. The maximum output bytes is defaulted to 150
megabytes.
    
* Consolidate Result and ContainerData into ContainerStatus struct
* Suppress STDERR on git ls-files calls

cc: @codeclimate/review 