### PR TITLE
Automatically enable brakeman, pep8 and radon

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -13,6 +13,8 @@ brakeman:
   image: codeclimate/codeclimate-brakeman
   description: Static analysis tool which checks Ruby on Rails applications for security vulnerabilities.
   community: false
+  upgrade_languages:
+    - Ruby
   enable_regexps:
     - ^script\/rails$
   default_ratings_paths:

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -12,9 +12,9 @@
 brakeman:
   image: codeclimate/codeclimate-brakeman
   description: Static analysis tool which checks Ruby on Rails applications for security vulnerabilities.
-  community: true
+  community: false
   enable_regexps:
-    - \.rb$
+    - ^script\/rails$
   default_ratings_paths:
     - "app/**"
     - "**.rb"
@@ -114,7 +114,9 @@ nodesecurity:
 pep8:
   image: codeclimate/codeclimate-pep8
   description: Static analysis tool to check Python code against the style conventions outlined in PEP-8.
-  community: true
+  community: false
+  upgrade_languages:
+    - Python
   enable_regexps:
     - \.py$
   default_ratings_paths:
@@ -150,7 +152,9 @@ phpmd:
 radon:
   image: codeclimate/codeclimate-radon
   description: Python tool used to compute Cyclomatic Complexity.
-  community: true
+  community: false
+  upgrade_languages:
+    - Python
   enable_regexps:
     - \.py$
   default_ratings_paths:

--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -2,7 +2,7 @@ module CC
   module CLI
     class ConfigGenerator
       CODECLIMATE_YAML = Command::CODECLIMATE_YAML
-      AUTO_EXCLUDE_PATHS = %w(config/ db/ features/ node_modules/ script/ spec/ test/ vendor/).freeze
+      AUTO_EXCLUDE_PATHS = %w(config/ db/ features/ node_modules/ script/ spec/ test/ tests/ vendor/).freeze
 
       def self.for(filesystem, engine_registry, upgrade_requested)
         if upgrade_requested && upgrade_needed?(filesystem)


### PR DESCRIPTION
This change makes the above engines become automatically turned on when a user runs `codeclimate init` or an analysis on .com without a `.codeclimate.yml` (using an inferred config).

@codeclimate/review @jpignata 