### PR TITLE
Ensure proper sorting of commingled location types

### DIFF
--- a/lib/cc/analyzer/issue_sorter.rb
+++ b/lib/cc/analyzer/issue_sorter.rb
@@ -16,13 +16,13 @@ module CC
 
         case
         when location["lines"]
-          location["lines"]["begin"].to_i
+          [location["lines"]["begin"].to_i]
         when location["positions"] && location["positions"]["begin"]["line"]
-          location["positions"]["begin"]["line"].to_i + location["positions"]["begin"]["column"].to_i
+          [location["positions"]["begin"]["line"].to_i, location["positions"]["begin"]["column"].to_i]
         when location["positions"] && location["positions"]["begin"]["offset"]
-          location["positions"]["begin"]["offset"].to_i + 1_000_000_000 # push offsets to end of list
+          [1_000_000_000] # push offsets to end of list
         else
-          0 # whole-file issues are first
+          [0] # whole-file issues are first
         end
       end
     end

--- a/spec/cc/analyzer/issue_sorter_spec.rb
+++ b/spec/cc/analyzer/issue_sorter_spec.rb
@@ -5,16 +5,27 @@ module CC::Analyzer
     describe "#by_location" do
       it "orders items correctly" do
         issues = [
-          whole_file_issue = { "location" => { } },
-          lines_issue = { "location" => { "lines" => { "begin" => 3 } } },
-          offsets_issue = { "location" => { "positions" => { "begin" => { "offset" => 600 } } } },
-          linecol_issue = { "location" => { "positions" => { "begin" => { "line" => 4, "column" => 1} } } },
-          linecol_issue2 = { "location" => { "positions" => { "begin" => { "line" => 4, "column" => 2} } } },
-        ]
+          whole_file = { "location" => { } },
+          offset_600 = { "location" => { "positions" => { "begin" => { "offset" => 600 } } } },
+          line_3 = { "location" => { "lines" => { "begin" => 3 } } },
+          line_4 = { "location" => { "lines" => { "begin" => 4 } } },
+          line_15 = { "location" => { "lines" => { "begin" => 15 } } },
+          line_4_col_1 = { "location" => { "positions" => { "begin" => { "line" => 4, "column" => 1} } } },
+          line_4_col_2 = { "location" => { "positions" => { "begin" => { "line" => 4, "column" => 2} } } },
+          line_4_col_83 = { "location" => { "positions" => { "begin" => { "line" => 4, "column" => 83} } } },
+          line_1_col_50 = { "location" => { "positions" => { "begin" => { "line" => 1, "column" => 50} } } },
+        ].shuffle
 
         IssueSorter.new(issues).by_location.must_equal([
-          whole_file_issue, lines_issue, linecol_issue,
-          linecol_issue2, offsets_issue
+          whole_file,
+          line_1_col_50,
+          line_3,
+          line_4,
+          line_4_col_1,
+          line_4_col_2,
+          line_4_col_83,
+          line_15,
+          offset_600,
         ])
       end
     end


### PR DESCRIPTION
The previous sorting function didn't work properly with a mixed set of
locations that had positions with columns and lines. This changes the
sorting mechanism to use an array so we could indicate a secondary sort
criterion.