### PR TITLE
Build include_paths once

### DIFF
--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -11,11 +11,11 @@ module CC
         :container_label,
       )
 
-      def initialize(registry:, config:, container_label:, source_dir:, requested_paths:)
+      def initialize(registry:, config:, container_label:, source_dir:, include_paths:)
         @registry = registry
         @config = config
         @container_label = container_label
-        @requested_paths = requested_paths
+        @include_paths = include_paths
         @source_dir = source_dir
       end
 
@@ -28,6 +28,8 @@ module CC
       end
 
       private
+
+      attr_reader :include_paths
 
       def engine_config(raw_engine_config)
         config = raw_engine_config.merge(
@@ -52,12 +54,6 @@ module CC
             end
           end
         end
-      end
-
-      def include_paths
-        IncludePathsBuilder.new(
-          @config.exclude_paths || [], @requested_paths
-        ).build
       end
 
       def exclude_paths

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -47,8 +47,14 @@ module CC
           config: @config,
           container_label: @container_label,
           source_dir: @source_dir,
-          requested_paths: @requested_paths,
+          include_paths: include_paths,
         ).run
+      end
+
+      def include_paths
+        @_include_paths ||= IncludePathsBuilder.new(
+          @config.exclude_paths || [], @requested_paths
+        ).build
       end
 
       def engines

--- a/spec/cc/analyzer/engines_config_builder_spec.rb
+++ b/spec/cc/analyzer/engines_config_builder_spec.rb
@@ -5,13 +5,17 @@ module CC::Analyzer
   describe EnginesConfigBuilder do
     include FileSystemHelpers
 
+    let(:include_paths) do
+      IncludePathsBuilder.new(config.exclude_paths || [], requested_paths).build
+    end
+
     let(:engines_config_builder) do
       EnginesConfigBuilder.new(
         registry: registry,
         config: config,
         container_label: container_label,
         source_dir: source_dir,
-        requested_paths: requested_paths
+        include_paths: include_paths
       )
     end
     let(:container_label) { nil }

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -25,7 +25,7 @@ module CC::Analyzer
     end
 
     it "raises for no enabled engines" do
-      config = stub(engines: {})
+      config = stub(engines: {}, exclude_paths: [])
       runner = EnginesRunner.new({}, null_formatter, "/code", config)
 
       lambda { runner.run }.must_raise(EnginesRunner::NoEnabledEngines)


### PR DESCRIPTION
Currently `include_paths` is called in `EnginesConfigBuilder` which is
initialized once for each engine which means we may have to build
`include_paths` several times when analyzing a repo.

Since building `include_paths` can be slow this hoists `include_paths`
into `EnginesRunner` and passes `include_paths` to
`EnginesConfigBuilder`.