### PR TITLE
Add default environments to default eslintrc

### DIFF
--- a/config/eslint/.eslintrc
+++ b/config/eslint/.eslintrc
@@ -245,3 +245,9 @@ rules:
   yoda:
   - 0
   - never
+env:
+  browser: true
+  node: true
+  jquery: true
+  amd: true
+  commonjs: true


### PR DESCRIPTION
Right now it doesn't specify default environments which results in
variables like $ and jQuery being reported as issues. This adds
browser, node, jquery, amd, and commonjs as default environments as a
starting point for repos running with an inferred configuration.