### PR TITLE
Filter ignored issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.14.2)
       activesupport (~> 4.2, >= 4.2.1)
-      codeclimate-yaml (~> 0.5.0)
+      codeclimate-yaml (~> 0.6.0)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.9.1)
       highline (~> 1.7, >= 1.7.2)
@@ -24,7 +24,7 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     builder (3.2.2)
-    codeclimate-yaml (0.5.0)
+    codeclimate-yaml (0.6.0)
       activesupport
       secure_string
     coderay (1.1.0)
@@ -78,6 +78,3 @@ DEPENDENCIES
   mocha
   rack-test
   rake
-
-BUNDLED WITH
-   1.10.6

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.5.0"
+  s.add_dependency "codeclimate-yaml", "~> 0.6.0"
   s.add_dependency "faraday", "~> 0.9.1"
   s.add_dependency "faraday_middleware", "~> 0.9.1"
   s.add_dependency "highline", "~> 1.7", ">= 1.7.2"

--- a/lib/cc/analyzer/engine_output_filter.rb
+++ b/lib/cc/analyzer/engine_output_filter.rb
@@ -30,7 +30,19 @@ module CC
       end
 
       def ignore_issue?(json)
+        check_disabled?(json) || ignore_fingerprint?(json)
+      end
+
+      def check_disabled?(json)
         !check_config(json["check_name"]).fetch("enabled", true)
+      end
+
+      def ignore_fingerprint?(json)
+        if (fingerprint = json["fingerprint"])
+          @config.fetch("ignored_issues", []).include?(fingerprint)
+        else
+          false
+        end
       end
 
       def check_config(check_name)

--- a/spec/cc/analyzer/engine_output_filter_spec.rb
+++ b/spec/cc/analyzer/engine_output_filter_spec.rb
@@ -68,6 +68,24 @@ module CC::Analyzer
       filter.filter?(issue.to_json).must_equal true
     end
 
+    it "filters issues with a fingerprint that matches ignored_issues" do
+      issue = {
+        "type" => "Issue",
+        "check_name" => "foo",
+        "fingerprint" => "05a33ac5659c1e90cad1ce32ff8a91c0"
+      }
+
+      filter = EngineOutputFilter.new(
+        engine_config(
+          "ignored_issues" => [
+            "05a33ac5659c1e90cad1ce32ff8a91c0"
+          ]
+        )
+      )
+
+      filter.filter?(issue.to_json).must_equal true
+    end
+
     def build_issue(check_name)
       {
         "type" => EngineOutputFilter::ISSUE_TYPE,


### PR DESCRIPTION
Engines now have a config option named `ignored_issues` which takes a
sequence of fingerprint values to check against reported issues. If an
issue matches one of the values of `ignored_issues` we filter it out.