### PR TITLE
Rename ignored_issues to excluded_fingerprints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.14.2)
       activesupport (~> 4.2, >= 4.2.1)
-      codeclimate-yaml (~> 0.6.0)
+      codeclimate-yaml (~> 0.6.1)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.9.1)
       highline (~> 1.7, >= 1.7.2)
@@ -24,7 +24,7 @@ GEM
       tzinfo (~> 1.1)
     ansi (1.5.0)
     builder (3.2.2)
-    codeclimate-yaml (0.6.0)
+    codeclimate-yaml (0.6.1)
       activesupport
       secure_string
     coderay (1.1.0)

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.6.0"
+  s.add_dependency "codeclimate-yaml", "~> 0.6.1"
   s.add_dependency "faraday", "~> 0.9.1"
   s.add_dependency "faraday_middleware", "~> 0.9.1"
   s.add_dependency "highline", "~> 1.7", ">= 1.7.2"

--- a/lib/cc/analyzer/engine_output_filter.rb
+++ b/lib/cc/analyzer/engine_output_filter.rb
@@ -39,7 +39,7 @@ module CC
 
       def ignore_fingerprint?(json)
         if (fingerprint = json["fingerprint"])
-          @config.fetch("ignored_issues", []).include?(fingerprint)
+          @config.fetch("exclude_fingerprints", []).include?(fingerprint)
         else
           false
         end

--- a/spec/cc/analyzer/engine_output_filter_spec.rb
+++ b/spec/cc/analyzer/engine_output_filter_spec.rb
@@ -68,7 +68,7 @@ module CC::Analyzer
       filter.filter?(issue.to_json).must_equal true
     end
 
-    it "filters issues with a fingerprint that matches ignored_issues" do
+    it "filters issues with a fingerprint that matches exclude_fingerprints" do
       issue = {
         "type" => "Issue",
         "check_name" => "foo",
@@ -77,7 +77,7 @@ module CC::Analyzer
 
       filter = EngineOutputFilter.new(
         engine_config(
-          "ignored_issues" => [
+          "exclude_fingerprints" => [
             "05a33ac5659c1e90cad1ce32ff8a91c0"
           ]
         )


### PR DESCRIPTION
This renames `ignored_issues` to `excluded_fingerprints` to keep the
`exclude_*` convention.