### PR TITLE
Replace recursive directory class with minimizer

### DIFF
--- a/lib/cc/analyzer/include_paths_builder.rb
+++ b/lib/cc/analyzer/include_paths_builder.rb
@@ -1,13 +1,10 @@
 require "file_utils_ext"
+require "cc/analyzer/path_minimizer"
 
 module CC
   module Analyzer
     class IncludePathsBuilder
-      def self.relevant_entries(path)
-        Dir.entries(path).reject do |e|
-          %w(. .. .git).include?(e) || File.symlink?(File.join(path, e))
-        end
-      end
+      IGNORE_PATHS = [".", "..", ".git"].freeze
 
       attr_reader :cc_include_paths
 
@@ -16,153 +13,85 @@ module CC
         @cc_include_paths = cc_include_paths
       end
 
-      def build
-        if cc_include_paths.any?
-          paths = filter_by_cc_includes
+      def build(extra_excludes = [])
+        if extra_excludes.empty?
+          build_without_extra_excludes
         else
-          root = Directory.new(".", ignored_files)
-          paths = root.included_paths
-        end
-
-        paths.each do |path|
-          raise_on_unreadable_files(path)
+          build_with_extra_excludes(extra_excludes)
         end
       end
 
-      protected
+      private
 
-      def filter_by_cc_includes
-        paths = []
-        cc_include_paths.each do |path|
-          if File.directory?(path)
-            root = Directory.new(path, ignored_files)
-            paths += root.included_paths
-          elsif !ignored_files.include?(path)
-            paths << path
-          end
+      def build_without_extra_excludes
+        @_build_without_extra_excludes ||= PathMinimizer.new(paths).minimize
+      end
+
+      def build_with_extra_excludes(excludes)
+        new_paths = paths.reject { |path| matches_globs?(path, excludes) }
+        PathMinimizer.new(new_paths).minimize
+      end
+
+      def paths
+        @_paths ||=
+          all_matching_paths.
+          reject { |f| ignored_files.include?(f) }.
+          each { |f| raise_if_unreadable(f) }.
+          select { |f| FileUtils.readable_by_all?(f) }.
+          reject { |f| File.symlink?(f) }
+      end
+
+      def all_matching_paths
+        include_paths.reject do |path|
+          matches_exclude?(path) || File.symlink?(path)
         end
-        paths.uniq
+      end
+
+      def include_paths
+        if @cc_include_paths.empty?
+          Dir.glob("**/*", File::FNM_DOTMATCH)
+        else
+          @cc_include_paths.map do |path|
+            glob_or_include_path(path)
+          end.flatten
+        end
+      end
+
+      def glob_or_include_path(path)
+        if File.directory?(path)
+          paths = Dir.glob("#{path}/**/*", File::FNM_DOTMATCH) - ["#{path}/."]
+          paths.push(path)
+        else
+          path
+        end
+      end
+
+      def matches_exclude?(path)
+        matches_globs?(path, @cc_exclude_paths)
+      end
+
+      def matches_globs?(path, globs)
+        globs.any? do |exclude_path|
+          File.fnmatch(exclude_path, path)
+        end
+      end
+
+      def raise_if_unreadable(path)
+        if !File.directory?(path) && !FileUtils.readable_by_all?(path)
+          raise CC::Analyzer::UnreadableFileError, "Can't read #{path}"
+        end
       end
 
       def ignored_files
+        return @_ignored_files if @_ignored_files
+
         Tempfile.open(".cc_gitignore") do |tmp|
           tmp.write(File.read(".gitignore")) if File.file?(".gitignore")
           tmp << @cc_exclude_paths.join("\n")
           tmp.close
           tracked_and_ignored = `git ls-files -zi -X #{tmp.path} 2>/dev/null`.split("\0")
           untracked_and_ignored = `git ls-files -zio -X #{tmp.path} 2>/dev/null`.split("\0")
-          tracked_and_ignored + untracked_and_ignored
-        end
-      end
-
-      def raise_on_unreadable_files(path)
-        if File.directory?(path)
-          raise_on_unreadable_files_in_directory(path)
-        elsif !FileUtils.readable_by_all?(path)
-          raise CC::Analyzer::UnreadableFileError, "Can't read #{path}"
-        end
-      end
-
-      def raise_on_unreadable_files_in_directory(path)
-        IncludePathsBuilder.relevant_entries(path).each do |entry|
-          sub_path = File.join(path, entry)
-          raise_on_unreadable_files(sub_path)
-        end
-      end
-
-      class Directory
-        def initialize(path, excluded_files)
-          @path = path
-          @excluded_files = ensure_hashified(excluded_files)
-        end
-
-        def all_included?
-          readable_by_all? &&
-            files_all_included? &&
-            subdirectories_all_included?
-        end
-
-        def included_paths
-          if all_included?
-            [@path + "/"]
-          elsif readable_by_all?
-            result = []
-            result += included_file_entries
-            result += included_subdirectory_results
-            result
-          else
-            []
-          end
-        end
-
-        protected
-
-        def ensure_hashified(obj)
-          if obj.is_a?(Array)
-            obj.each_with_object({}) do |included, result|
-              result[included] = true
-            end
-          else
-            obj
-          end
-        end
-
-        def files_all_included?
-          file_entries.none? { |e| @excluded_files[e] }
-        end
-
-        def file_entries
-          @file_entries ||= relevant_full_entries.reject do |e|
-            File.directory?(e)
-          end
-        end
-
-        def full_entry(entry)
-          if @path == "."
-            entry
-          else
-            File.join(@path, entry)
-          end
-        end
-
-        def included_file_entries
-          file_entries.reject { |file_entry| @excluded_files[file_entry] }
-        end
-
-        def included_subdirectory_results
-          subdirectories.each_with_object([]) do |subdirectory, result|
-            result.concat(subdirectory.included_paths)
-          end
-        end
-
-        def readable_by_all?
-          FileUtils.readable_by_all?(@path)
-        end
-
-        def relevant_full_entries
-          unless @relevant_full_entries
-            raw_entries = IncludePathsBuilder.relevant_entries(@path)
-            @relevant_full_entries = raw_entries.map do |e|
-              full_entry(e)
-            end
-          end
-          @relevant_full_entries
-        end
-
-        def subdirectories
-          unless @subdirectories
-            entries = relevant_full_entries.select do |e|
-              File.directory?(e)
-            end
-            @subdirectories = entries.map do |e|
-              Directory.new(e, @excluded_files)
-            end
-          end
-          @subdirectories
-        end
-
-        def subdirectories_all_included?
-          subdirectories.all?(&:all_included?)
+          @_ignored_files = tracked_and_ignored + untracked_and_ignored
         end
       end
     end

--- a/lib/cc/analyzer/path_minimizer.rb
+++ b/lib/cc/analyzer/path_minimizer.rb
@@ -1,0 +1,77 @@
+module CC
+  module Analyzer
+    class PathMinimizer
+      def initialize(paths)
+        @paths = paths
+      end
+
+      def minimize
+        if diff.empty?
+          ["./"]
+        else
+          filtered_paths
+        end
+      end
+
+      private
+
+      attr_reader :paths
+
+      def diff
+        @_diff ||=
+          (all_files - paths).
+          reject { |path| File.symlink?(path) }.
+          map { |path| build_entry_combinations(path) }.
+          flatten
+      end
+
+      def filtered_paths
+        @_filtered_paths ||=
+          paths.
+          reject { |path| filter_path?(path) }.
+          select { |path| FileUtils.readable_by_all?(path) }.
+          map { |path| add_trailing_slash(path) }
+      end
+
+      def filter_path?(path)
+        dir = File.dirname(path)
+
+        in_diff = in_diff?(path) || in_diff?(dir)
+        is_nested = nested?(path) || nested?(dir)
+        is_ignored = IncludePathsBuilder::IGNORE_PATHS.include?(path)
+
+        in_diff || is_nested || is_ignored
+      end
+
+      def in_diff?(path)
+        diff.include?(path)
+      end
+
+      def nested?(path)
+        File.dirname(path) != "."
+      end
+
+      def add_trailing_slash(path)
+        if File.directory?(path)
+          "#{path}/"
+        else
+          path
+        end
+      end
+
+      def build_entry_combinations(path)
+        split = path.split("/")
+
+        0.upto(split.length - 1).map do |n|
+          split[0..n].join("/")
+        end
+      end
+
+      def all_files
+        @_all_files ||= Dir.glob("**/*", File::FNM_DOTMATCH).reject do |path|
+          path == "." || path.end_with?("/.")
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engines_config_builder_spec.rb
+++ b/spec/cc/analyzer/engines_config_builder_spec.rb
@@ -1,5 +1,8 @@
 require "spec_helper"
 require "file_utils_ext"
+require "cc/analyzer"
+require "cc/analyzer/include_paths_builder"
+require "cc/analyzer/path_patterns"
 
 module CC::Analyzer
   describe EnginesConfigBuilder do
@@ -34,10 +37,6 @@ module CC::Analyzer
       let(:config) { config_with_engine("an_engine") }
       let(:registry) { registry_with_engine("an_engine") }
 
-      before do
-        FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
-      end
-
       it "contains that engine" do
         result = engines_config_builder.run
         result.size.must_equal(1)
@@ -65,10 +64,6 @@ module CC::Analyzer
         EOYAML
       end
       let(:registry) { registry_with_engine("rubocop") }
-
-      before do
-        FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
-      end
 
       it "keeps that config and adds some entries" do
         expected_config = {

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -19,7 +19,6 @@ module CC::Analyzer
       formatter = null_formatter
 
       expect_engine_run("an_engine", "/code", formatter)
-      FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
 
       EnginesRunner.new(registry, formatter, "/code", config).run
     end
@@ -42,7 +41,6 @@ module CC::Analyzer
 
       it "does not call #close" do
         expect_engine_run("an_engine", "/code", formatter)
-        FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
         EnginesRunner.new(registry, formatter, "/code", config).run
       end
     end


### PR DESCRIPTION
This replaces the existing Directory class with a minimizer class which
takes the paths to check against and diffs it against all the files in
project to get directories where possible instead of a list of files.

This change is necessary to be able to use engine specific excludes
without having to build up the include_paths over and over for each
engine.