### PR TITLE
green output

### DIFF
--- a/lib/cc/cli/command.rb
+++ b/lib/cc/cli/command.rb
@@ -24,7 +24,7 @@ module CC
         run
       end
 
-      def congrats(message)
+      def success(message)
         terminal.say colorize(message, :green)
       end
 

--- a/lib/cc/cli/command.rb
+++ b/lib/cc/cli/command.rb
@@ -24,6 +24,10 @@ module CC
         run
       end
 
+      def congrats(message)
+        terminal.say colorize(message, :green)
+      end
+
       def say(message)
         terminal.say message
       end

--- a/lib/cc/cli/help.rb
+++ b/lib/cc/cli/help.rb
@@ -14,7 +14,7 @@ module CC
 
       def commands
         [
-          "analyze [-f format]",
+          "analyze [-f format] [-e engine] <path>",
           "console",
           "engines:disable #{underline('engine_name')}",
           "engines:enable #{underline('engine_name')}",

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -9,8 +9,8 @@ module CC
 
       def run
         if !upgrade? && filesystem.exist?(CODECLIMATE_YAML)
+          warn "Config file .codeclimate.yml already present.\nTry running 'validate-config' to check configuration."
           create_default_configs
-          fatal "Config file .codeclimate.yml already present.\nTry running 'validate-config' to check configuration."
         elsif upgrade? && engines_enabled?
           fatal "--upgrade should not be used on a .codeclimate.yml configured for the Platform.\nTry running 'validate-config' to check configuration."
         else

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -33,7 +33,7 @@ module CC
         end
 
         create_codeclimate_yaml
-        say "Config file .codeclimate.yml successfully #{config_generator.post_generation_verb}.\nEdit and then try running 'validate-config' to check configuration."
+        say colorize("Config file .codeclimate.yml successfully #{config_generator.post_generation_verb}.\nEdit and then try running 'validate-config' to check configuration.", :green)
         create_default_configs
       end
 
@@ -55,7 +55,7 @@ module CC
             say "Skipping generating #{file_name} file (already exists)."
           else
             filesystem.write_path(file_name, File.read(config_path))
-            say "Config file #{file_name} successfully generated."
+            say colorize("Config file #{file_name} successfully generated.", :green)
           end
         end
       end

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -33,7 +33,7 @@ module CC
         end
 
         create_codeclimate_yaml
-        congrats "Config file .codeclimate.yml successfully #{config_generator.post_generation_verb}.\nEdit and then try running 'validate-config' to check configuration."
+        success "Config file .codeclimate.yml successfully #{config_generator.post_generation_verb}.\nEdit and then try running 'validate-config' to check configuration."
         create_default_configs
       end
 
@@ -55,7 +55,7 @@ module CC
             say "Skipping generating #{file_name} file (already exists)."
           else
             filesystem.write_path(file_name, File.read(config_path))
-            congrats "Config file #{file_name} successfully generated."
+            success "Config file #{file_name} successfully generated."
           end
         end
       end

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -9,6 +9,7 @@ module CC
 
       def run
         if !upgrade? && filesystem.exist?(CODECLIMATE_YAML)
+          create_default_configs
           fatal "Config file .codeclimate.yml already present.\nTry running 'validate-config' to check configuration."
         elsif upgrade? && engines_enabled?
           fatal "--upgrade should not be used on a .codeclimate.yml configured for the Platform.\nTry running 'validate-config' to check configuration."

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -33,7 +33,7 @@ module CC
         end
 
         create_codeclimate_yaml
-        say colorize("Config file .codeclimate.yml successfully #{config_generator.post_generation_verb}.\nEdit and then try running 'validate-config' to check configuration.", :green)
+        congrats "Config file .codeclimate.yml successfully #{config_generator.post_generation_verb}.\nEdit and then try running 'validate-config' to check configuration."
         create_default_configs
       end
 
@@ -55,7 +55,7 @@ module CC
             say "Skipping generating #{file_name} file (already exists)."
           else
             filesystem.write_path(file_name, File.read(config_path))
-            say colorize("Config file #{file_name} successfully generated.", :green)
+            congrats "Config file #{file_name} successfully generated."
           end
         end
       end

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -116,6 +116,22 @@ module CC::CLI
           stderr.must_match("Config file .codeclimate.yml already present.")
           exit_code.must_equal 1
         end
+
+        it "still generates default config files" do
+          filesystem.exist?(".codeclimate.yml").must_equal(false)
+
+          File.new(".codeclimate.yml", "w")
+
+          filesystem.exist?(".codeclimate.yml").must_equal(true)
+
+          init = Init.new
+
+          init.expects(:create_default_configs)
+
+          _, stderr, exit_code = capture_io_and_exit_code do
+            init.run
+          end
+        end
       end
 
       describe "when --upgrade flag is on" do

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -102,19 +102,19 @@ module CC::CLI
           content_after.must_equal(yaml_content_before)
         end
 
-        it "reports that there is a .codeclimate.yml file already present" do
+        it "warns that there is a .codeclimate.yml file already present" do
           filesystem.exist?(".codeclimate.yml").must_equal(false)
 
           File.new(".codeclimate.yml", "w")
 
           filesystem.exist?(".codeclimate.yml").must_equal(true)
 
-          _, stderr, exit_code = capture_io_and_exit_code do
+          stdout, _, exit_code = capture_io_and_exit_code do
             Init.new.run
           end
 
-          stderr.must_match("Config file .codeclimate.yml already present.")
-          exit_code.must_equal 1
+          stdout.must_match("WARNING: Config file .codeclimate.yml already present.")
+          exit_code.must_equal 0
         end
 
         it "still generates default config files" do


### PR DESCRIPTION
This PR has two changes to the `codeclimate init` command config generation:

*minor*
1) make successful output messaging green

*major*
2) generate default configs if possible, even if `.codeclimate.yml` already exists. Keep same error / exit code 1 behavior. 

Since it might still be useful for users with a `.codeclimate.yml` to get default configs by running
`codeclimate init`, this change generates applicable configs even when
.codeclimate.yml present, before finishing with the same warning message and
exit code 1:

```
$ codeclimate init
Config file .csslintrc successfully generated.
Skipping generating coffeelint.json file (already exists).
Config file .eslintrc successfully generated.
Skipping generating .rubocop.yml file (already exists).
Config file .codeclimate.yml already present.
Try running 'validate-config' to check configuration.
```

cc @codeclimate/review 