### PR TITLE
Add engine specific exclude_paths

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.14.2)
       activesupport (~> 4.2, >= 4.2.1)
-      codeclimate-yaml (~> 0.6.1)
+      codeclimate-yaml (~> 0.7.0)
       faraday (~> 0.9.1)
       faraday_middleware (~> 0.9.1)
       highline (~> 1.7, >= 1.7.2)
@@ -16,7 +16,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.4)
+    activesupport (4.2.5)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -26,7 +26,7 @@ GEM
     builder (3.2.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
-    codeclimate-yaml (0.6.1)
+    codeclimate-yaml (0.7.0)
       activesupport
       secure_string
     coderay (1.1.0)

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.6.1"
+  s.add_dependency "codeclimate-yaml", "~> 0.7.0"
   s.add_dependency "faraday", "~> 0.9.1"
   s.add_dependency "faraday_middleware", "~> 0.9.1"
   s.add_dependency "highline", "~> 1.7", ">= 1.7.2"

--- a/lib/cc/analyzer/path_patterns.rb
+++ b/lib/cc/analyzer/path_patterns.rb
@@ -32,7 +32,7 @@ module CC
         # are translated to **/*-style globs within cc-yaml's custom
         # Glob#value method. It was thought that that would work correctly
         # with Dir.glob but it turns out we have to actually invoke #value
-        # directrly for this to work. We need to guard this on class (not
+        # directly for this to work. We need to guard this on class (not
         # respond_to?) because our mocking framework adds a #value method to
         # all objects, apparently.
         if pattern.is_a?(CC::Yaml::Nodes::Glob)

--- a/spec/cc/analyzer/include_paths_builder_spec.rb
+++ b/spec/cc/analyzer/include_paths_builder_spec.rb
@@ -15,7 +15,7 @@ module CC::Analyzer
 
     before do
       system("git init > /dev/null")
-      FileUtils.stubs(:readable_by_all?).at_least_once.returns(true)
+      FileUtils.stubs(:readable_by_all?).returns(true)
     end
 
     describe "when the source directory contains only files that are tracked or trackable in Git" do
@@ -248,6 +248,17 @@ module CC::Analyzer
       it "skips it entirely" do
         FileUtils.readable_by_all?(".")
         result.include?("./").must_equal(true)
+      end
+    end
+
+    describe "when analyzing a single file" do
+      let(:cc_includes) { ["subdir/subdir_file.rb"] }
+
+      it "returns the file" do
+        make_file("root_file.rb")
+        make_file("subdir/subdir_file.rb")
+
+        builder.build.must_equal(["subdir/subdir_file.rb"])
       end
     end
 


### PR DESCRIPTION
This change allows engines to have their own configured `exclude_paths`
which are merged with the global exclude paths.

For example, you can skip all spec files for just Rubocop:

```
rubocop:
  enabled: true
  exclude_paths:
  - **/*spec.rb
```