### PR TITLE
add init f

### DIFF
--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -34,12 +34,12 @@ module CC
       def process_args
         while (arg = @args.shift)
           case arg
-          when "-f"
-            @formatter = Formatters.resolve(@args.shift).new(filesystem)
-          when "-e", "--engine"
-            @engine_options << @args.shift
           when "--dev"
             @dev_mode = true
+          when "-e", "--engine"
+            @engine_options << @args.shift
+          when "-f"
+            @formatter = Formatters.resolve(@args.shift).new(filesystem)
           else
             @path_options << arg
           end

--- a/lib/cc/cli/command.rb
+++ b/lib/cc/cli/command.rb
@@ -7,9 +7,11 @@ module CC
   module CLI
     class Command
       CODECLIMATE_YAML = ".codeclimate.yml".freeze
+      InvalidOption = Class.new(StandardError)
 
       def initialize(args = [])
         @args = args
+        @force = false
       end
 
       def run
@@ -20,7 +22,19 @@ module CC
         name[/[^:]*$/].split(/(?=[A-Z])/).map(&:downcase).join("-")
       end
 
+      def process_args
+        while (arg = @args.shift)
+          case arg
+          when "-f", "--f", "--force"
+            @force = true
+          else
+            raise InvalidOption, "option #{arg} not found. Try running codeclimate --help for a list of valid commands."
+          end
+        end
+      end
+
       def execute
+        process_args
         run
       end
 
@@ -48,6 +62,8 @@ module CC
       end
 
       private
+
+      attr_reader :force
 
       def colorize(string, *args)
         rainbow.wrap(string).color(*args)

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -8,7 +8,7 @@ module CC
       include CC::Analyzer
 
       def run
-        if !upgrade? && filesystem.exist?(CODECLIMATE_YAML)
+        if !upgrade? && filesystem.exist?(CODECLIMATE_YAML) && !force
           warn "Config file .codeclimate.yml already present.\nTry running 'validate-config' to check configuration."
           create_default_configs
         elsif upgrade? && engines_enabled?


### PR DESCRIPTION
This change allows users to overwrite a `.codeclimate.yml` file if present.

For the time being, it will not overwrite default engine configs if they are already
present -e.g. .rubocop.yml, with the thought that users might be more likely to have special configurations
there.

This PR also adds options processing to the `Command` class (overwritten by `Analyze`), and throws an error when unrecognized parameters get passed:
```
Ashleys-MacBook-Pro-2:nillson ashleybaldwin-hunter$ codeclimate init --x
error: (CC::CLI::Command::InvalidOption) option --x not found. Try running codeclimate --help for a list of valid commands.
```