### PR TITLE
Fix brakeman ratings_paths

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -18,8 +18,12 @@ brakeman:
   enable_regexps:
     - ^script\/rails$
   default_ratings_paths:
-    - "app/**"
+    - "Gemfile.lock"
+    - "**.erb"
+    - "**.haml"
     - "**.rb"
+    - "**.rhtml"
+    - "**.slim"
 bundler-audit:
   image: codeclimate/codeclimate-bundler-audit
   description: Patch-level verification for Bundler.


### PR DESCRIPTION
The value of `app/**` results in things like images in `assets` being rated as "A"s, which isn't appropriate, since nothing is really scanning those files.

This restricts the pattern more to files & extensions we know brakeman looks at.

cc @codeclimate/review 