### PR TITLE
Fix analyzation of individual paths

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -16,6 +16,7 @@ module CC
     autoload :LocationDescription, "cc/analyzer/location_description"
     autoload :LoggingContainerListener, "cc/analyzer/logging_container_listener"
     autoload :PathPatterns, "cc/analyzer/path_patterns"
+    autoload :PathMinimizer, "cc/analyzer/path_minimizer"
     autoload :RaisingContainerListener, "cc/analyzer/raising_container_listener"
     autoload :SourceBuffer, "cc/analyzer/source_buffer"
     autoload :StatsdContainerListener, "cc/analyzer/statsd_container_listener"

--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -11,11 +11,11 @@ module CC
         :container_label,
       )
 
-      def initialize(registry:, config:, container_label:, source_dir:, include_paths:)
+      def initialize(registry:, config:, container_label:, source_dir:, requested_paths:)
         @registry = registry
         @config = config
         @container_label = container_label
-        @include_paths = include_paths
+        @requested_paths = requested_paths
         @source_dir = source_dir
       end
 
@@ -54,6 +54,10 @@ module CC
             end
           end
         end
+      end
+
+      def include_paths
+        IncludePathsBuilder.new(exclude_paths, Array(@requested_paths)).build
       end
 
       def exclude_paths

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -47,14 +47,8 @@ module CC
           config: @config,
           container_label: @container_label,
           source_dir: @source_dir,
-          include_paths: include_paths,
+          requested_paths: requested_paths,
         ).run
-      end
-
-      def include_paths
-        @_include_paths ||= IncludePathsBuilder.new(
-          @config.exclude_paths || [], @requested_paths
-        ).build
       end
 
       def engines

--- a/lib/cc/analyzer/path_entries.rb
+++ b/lib/cc/analyzer/path_entries.rb
@@ -1,0 +1,27 @@
+module CC
+  module Analyzer
+    class PathEntries
+      def initialize(initial_path)
+        @initial_path = initial_path.gsub(%r{/$}, "")
+      end
+
+      def entries
+        if File.directory?(initial_path)
+          all_entries.reject do |path|
+            path.end_with?("/.") || path.start_with?(".git/")
+          end
+        else
+          initial_path
+        end
+      end
+
+      private
+
+      attr_reader :initial_path
+
+      def all_entries
+        Dir.glob("#{initial_path}/**/*", File::FNM_DOTMATCH).push(initial_path)
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/path_filter.rb
+++ b/lib/cc/analyzer/path_filter.rb
@@ -1,0 +1,60 @@
+module CC
+  module Analyzer
+    class PathFilter
+      attr_reader :paths
+
+      def initialize(paths)
+        @paths = paths
+      end
+
+      def raise_if_any_unreadable_files
+        paths.each do |path|
+          if !File.directory?(path) && !FileUtils.readable_by_all?(path)
+            raise CC::Analyzer::UnreadableFileError, "Can't read #{path}"
+          end
+        end
+
+        self
+      end
+
+      def reject_unreadable_paths
+        @paths = paths - unreadable_path_entries
+        self
+      end
+
+      def reject_paths(ignore_paths)
+        @paths = paths - ignore_paths
+        self
+      end
+
+      def select_readable_files
+        @paths = paths.select { |path| FileUtils.readable_by_all?(path) }
+        self
+      end
+
+      def reject_symlinks
+        @paths = paths.reject { |path| File.symlink?(path) }
+        self
+      end
+
+      def reject_globs(globs)
+        patterns = PathPatterns.new(globs)
+        @paths = paths.reject { |path| patterns.match?(pathpatterns.match?(path)) }
+        self
+      end
+
+      private
+
+      def unreadable_path_entries
+        @_unreadable_path_entries ||=
+          unreadable_paths.flat_map { |path| PathEntries.new(path).entries }
+      end
+
+      def unreadable_paths
+        paths.select do |path|
+          File.directory?(path) && !FileUtils.readable_by_all?(path)
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engines_config_builder_spec.rb
+++ b/spec/cc/analyzer/engines_config_builder_spec.rb
@@ -8,17 +8,13 @@ module CC::Analyzer
   describe EnginesConfigBuilder do
     include FileSystemHelpers
 
-    let(:include_paths) do
-      IncludePathsBuilder.new(config.exclude_paths || [], requested_paths).build
-    end
-
     let(:engines_config_builder) do
       EnginesConfigBuilder.new(
         registry: registry,
         config: config,
         container_label: container_label,
         source_dir: source_dir,
-        include_paths: include_paths
+        requested_paths: requested_paths
       )
     end
     let(:container_label) { nil }

--- a/spec/cc/analyzer/include_paths_builder_spec.rb
+++ b/spec/cc/analyzer/include_paths_builder_spec.rb
@@ -113,7 +113,7 @@ module CC::Analyzer
     describe "when there is a subdirectory that isn't readable by all but is excluded in .gitignore" do
       before do
         make_file("unreadable_subdir/secret.rb")
-        FileUtils.expects(:readable_by_all?).with("unreadable_subdir").at_least_once.returns(false)
+        FileUtils.stubs(:readable_by_all?).with("unreadable_subdir").at_least_once.returns(false)
         make_file(".gitignore", "unreadable_subdir\n")
         make_file("trackable.rb")
         make_file("subdir/subdir_trackable.rb")
@@ -196,7 +196,8 @@ module CC::Analyzer
     describe "when there is a file that isn't readable by all and is not excluded by either .codeclimate.yml or .gitignore" do
       before do
         make_file("subdir/unreadable.rb")
-        FileUtils.expects(:readable_by_all?).with("subdir/unreadable.rb").at_least_once.returns(false)
+        FileUtils.readable_by_all?(".")
+        FileUtils.stubs(:readable_by_all?).with("subdir/unreadable.rb").at_least_once.returns(false)
         make_file("trackable.rb")
         make_file("subdir/subdir_trackable.rb")
       end
@@ -250,15 +251,14 @@ module CC::Analyzer
       end
     end
 
-    describe "when given extra excludes" do
-      before do
+    describe "when analyzing a single file" do
+      let(:cc_includes) { ["subdir/subdir_file.rb"] }
+
+      it "returns the file" do
         make_file("root_file.rb")
         make_file("subdir/subdir_file.rb")
-      end
 
-      it "returns a the only non-excluded file" do
-        builder.build.must_equal(["./"])
-        builder.build(["**/subdir*"]).must_equal(["root_file.rb"])
+        builder.build.must_equal(["subdir/subdir_file.rb"])
       end
     end
   end

--- a/spec/cc/analyzer/path_entries_spec.rb
+++ b/spec/cc/analyzer/path_entries_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+module CC::Analyzer
+  describe PathPatterns do
+    include FileSystemHelpers
+
+    around do |test|
+      within_temp_dir { test.call }
+    end
+
+    describe "#entries" do
+      it "filters out trailing slashes" do
+        make_file("lib/foo.rb")
+
+        paths = PathEntries.new("lib/").entries
+
+        paths.sort.must_equal(["lib", "lib/foo.rb"])
+      end
+
+      it "filters works without trailing slashes" do
+        make_file("lib/foo.rb")
+
+        paths = PathEntries.new("lib").entries
+
+        paths.sort.must_equal(["lib", "lib/foo.rb"])
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/path_minimizer_spec.rb
+++ b/spec/cc/analyzer/path_minimizer_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+module CC::Analyzer
+  describe PathMinimizer do
+    include FileSystemHelpers
+
+    around do |test|
+      within_temp_dir { test.call }
+    end
+
+    describe "#minimize" do
+      describe "when all files match" do
+        it "returns ./" do
+          make_file("lib/tasks/foo.rb")
+          make_file("foo.rb")
+
+          minimizer = PathMinimizer.new(["lib", "lib/tasks", "lib/tasks/foo.rb", "foo.rb"])
+          minimizer.minimize.must_equal(["./"])
+        end
+      end
+
+      it "breaks down lists of files into paths" do
+        make_file("lib/tasks/foo.rb")
+        make_file("foo.rb")
+
+        minimizer = PathMinimizer.new(["lib", "lib/tasks", "lib/tasks/foo.rb"])
+        minimizer.minimize.must_equal(["lib/"])
+      end
+
+      it "breaks down abitrarily nested lists of files into paths" do
+        make_file("lib/tasks/foo.rb")
+        make_file("lib/tasks/bar/foo.rb")
+        make_file("lib/tasks/bar/baz/foo.rb")
+        make_file("lib/tasks/foo.js")
+        make_file("foo.rb")
+
+        minimizer = PathMinimizer.new([
+          "lib",
+          "lib/tasks",
+          "lib/tasks/foo.rb",
+          "lib/tasks/bar",
+          "lib/tasks/bar/foo.rb",
+          "lib/tasks/bar/baz",
+          "lib/tasks/bar/baz/foo.rb"
+        ])
+
+        minimizer.minimize.must_equal(["lib/tasks/foo.rb", "lib/tasks/bar/"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This re-introduces `requested_paths` to several files that gets passed
into `include_paths_builder`. This was removed in an earlier commit but
is necessary for specifying individual files or paths to analyze instead
of analyzing the entire directory.