### PR TITLE
Container: fix race with IO processing

### DIFF
--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -60,6 +60,7 @@ module CC
           duration = timeout
           @listener.timed_out(container_data(duration: duration))
         else
+          sleep 0.01 until !t_out.alive? && !t_err.alive?
           duration = ((Time.now - started) * 1000).round
           @listener.finished(container_data(duration: duration, status: status))
         end

--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -90,7 +90,7 @@ module CC::Analyzer
         result.exit_status.must_equal 0
         result.timed_out?.must_equal false
         result.duration.must_be :>=, 0
-        result.duration.must_be :<, 1
+        result.duration.must_be :<, 20
         result.stderr.must_equal ""
       end
 


### PR DESCRIPTION
There's a race between the main thread getting to this point after the
process finishes, and the two threads that process output from stdout &
stderr. When main thread "wins" that race, the result can be an
incorrect status for the events data on the engine step down the line:
e.g. the engine emits invalid output, but by the time the background
thread has tried to parse it & emitted an error, the main thread has
already decided the container is finished, so the error is never
attached to the relevant step.

:eyeglasses: @codeclimate/review 