### PR TITLE
Only add default config if one exists for engine

### DIFF
--- a/lib/cc/analyzer/config.rb
+++ b/lib/cc/analyzer/config.rb
@@ -35,11 +35,13 @@ module CC
         if engine_present?(engine_name)
           @config["engines"][engine_name]["enabled"] = true
         else
-          @config["engines"][engine_name] = {
-            "enabled" => true,
-            "config" => default_config(engine_name),
-          }
+          @config["engines"][engine_name] = { "enabled" => true }
+          enable_default_config(engine_name) if default_config(engine_name)
         end
+      end
+
+      def enable_default_config(engine_name)
+        @config["engines"][engine_name]["config"] = default_config(engine_name)
       end
 
       def exclude_paths

--- a/spec/cc/cli/engines/enable_spec.rb
+++ b/spec/cc/cli/engines/enable_spec.rb
@@ -69,6 +69,24 @@ module CC::CLI::Engines
           end
         end
       end
+
+      describe "when engine has no default configuration" do
+        it "it omits the config key entirely" do
+          within_temp_dir do
+            create_yaml(Factory.create_yaml_with_no_engines)
+
+            stdout, stderr = capture_io do
+              Enable.new(args = ["coffeelint"]).run
+            end
+
+            content_after = File.read(".codeclimate.yml")
+
+            config = CC::Analyzer::Config.new(content_after).engine_config("coffeelint")
+
+            config.must_equal({"enabled" => true})
+          end
+        end
+      end
     end
 
     def filesystem


### PR DESCRIPTION
It is confusing to add a blank config key and results in errors
for certain engines, like coffeelint

https://github.com/codeclimate/codeclimate-coffeelint/pull/12

cc @codeclimate/review @fhwang 