### PR TITLE
Don't raise on unreadable files when building paths: ignore them.

### DIFF
--- a/lib/cc/analyzer/include_paths_builder.rb
+++ b/lib/cc/analyzer/include_paths_builder.rb
@@ -24,7 +24,6 @@ module CC
         @_paths =
           PathFilter.new(include_paths).
           reject_paths(ignored_files).
-          raise_if_any_unreadable_files.
           reject_unreadable_paths.
           select_readable_files.
           reject_symlinks

--- a/lib/cc/analyzer/path_filter.rb
+++ b/lib/cc/analyzer/path_filter.rb
@@ -7,16 +7,6 @@ module CC
         @paths = paths
       end
 
-      def raise_if_any_unreadable_files
-        paths.each do |path|
-          if !File.directory?(path) && !FileUtils.readable_by_all?(path)
-            raise CC::Analyzer::UnreadableFileError, "Can't read #{path}"
-          end
-        end
-
-        self
-      end
-
       def reject_unreadable_paths
         @paths = paths - unreadable_path_entries
         self
@@ -28,7 +18,7 @@ module CC
       end
 
       def select_readable_files
-        @paths = paths.select { |path| FileUtils.readable_by_all?(path) }
+        @paths = paths.select { |path| File.exist?(path) && FileUtils.readable_by_all?(path) }
         self
       end
 

--- a/spec/cc/analyzer/include_paths_builder_spec.rb
+++ b/spec/cc/analyzer/include_paths_builder_spec.rb
@@ -202,8 +202,8 @@ module CC::Analyzer
         make_file("subdir/subdir_trackable.rb")
       end
 
-      it "raises an informative error" do
-        lambda { builder.build }.must_raise(CC::Analyzer::UnreadableFileError)
+      it "generates correct paths" do
+        builder.build.must_equal ["subdir/subdir_trackable.rb", "trackable.rb"]
       end
     end
 


### PR DESCRIPTION
This is to address a regression
(https://trello.com/c/yQr7T7nH/1211-unreadable-files-lead-to-u10-without-error-visible)
that made it into builder from some recent changes here: these raises
were not caught anywhere, and the result on .com was a U10 without any
informative error text (because of where the exception ocurred).

Based on a recent conversation including Bryan, we'll probably expect
handling unreadable files to be an engine concern (if we want to avoid
walking the entire tree, we effectively *must* make it an engine
concern). This backs out this specific bit of logic to intentionally
*not* raise instead.

In my testing, this didn't actually change CLI behavior for the affected
case at all. In .com, analysis ran successfully with this fix, with some
engines emitting warnings on stderr about the file not being readable,
which seems like correct behavior to me. (Crashing the engine & emitting
an E10 would also have been acceptable, but warnings are even better.)

Long story short: this behavior broke on .com in an ugly way. Removing
it improves .com experience and doesn't seem to change CLI behavior in
any important way.

cc @codeclimate/review