### PR TITLE
bin-release: don't require version arg

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -4,20 +4,15 @@
 #
 # Assumes bin/prep-release was run and the PR merged.
 #
-# Usage: bin/release VERSION
+# Usage: bin/release
 #
 ###
 set -e
 
-if [ -z "$1" ]; then
-  echo "usage: bin/release VERSION" >&2
-  exit 64
-fi
-
-version=$1
-
 git checkout master
 git pull
+
+version=$(< VERSION)
 
 printf "RELEASE %s\n" "$version"
 rake release


### PR DESCRIPTION
since release is now a 2-step process, it seems silly to have to pass
the version to the release script since it'll be the value currently in
the VERSION file. If anything, there was a typo risk of typing the wrong
version & ending up with a mismatched release.

:eyes: @codeclimate/review