### PR TITLE
improve io waiting, ensure timeout thread runs immediately

### DIFF
--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -57,7 +57,7 @@ module CC
         _, status = Process.waitpid2(pid)
 
         if @timed_out
-          duration = timeout
+          duration = timeout * 1000
           @listener.timed_out(container_data(duration: duration))
         else
           sleep 1 until !t_out.alive? && !t_err.alive?

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -74,9 +74,7 @@ module CC
           @stderr_io.string,
         )
       ensure
-        t_timeout.kill if t_timeout
-        t_out.kill if t_out
-        t_err.kill if t_err
+        [t_timeout, t_out, t_err].each { |t| t.kill if t }
       end
 
       def stop

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -60,7 +60,7 @@ module CC
           duration = timeout
           @listener.timed_out(container_data(duration: duration))
         else
-          sleep 0.01 until !t_out.alive? && !t_err.alive?
+          t_out.join || t_err.join
           duration = ((Time.now - started) * 1000).round
           @listener.finished(container_data(duration: duration, status: status))
         end
@@ -78,9 +78,6 @@ module CC
         if @timed_out
           t_out.kill if t_out
           t_err.kill if t_err
-        else
-          t_out.join if t_out
-          t_err.join if t_err
         end
       end
 

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -60,7 +60,7 @@ module CC
           duration = timeout
           @listener.timed_out(container_data(duration: duration))
         else
-          t_out.join || t_err.join
+          t_out.join && t_err.join
           duration = ((Time.now - started) * 1000).round
           @listener.finished(container_data(duration: duration, status: status))
         end
@@ -75,10 +75,8 @@ module CC
         )
       ensure
         t_timeout.kill if t_timeout
-        if @timed_out
-          t_out.kill if t_out
-          t_err.kill if t_err
-        end
+        t_out.kill if t_out
+        t_err.kill if t_err
       end
 
       def stop
@@ -128,7 +126,7 @@ module CC
           sleep timeout
           @timed_out = true
           reap_running_container
-        end
+        end.run
       end
 
       def check_output_bytes(last_read_byte_count)

--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -153,7 +153,6 @@ module CC::Analyzer
             @container_result.exit_status.wont_equal nil
             @container_result.duration.must_be :>=, 0
             @container_result.duration.must_be :<, 2_000
-
           ensure
             ENV["CONTAINER_TIMEOUT_SECONDS"] = old_timeout
           end

--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -90,7 +90,7 @@ module CC::Analyzer
         result.exit_status.must_equal 0
         result.timed_out?.must_equal false
         result.duration.must_be :>=, 0
-        result.duration.must_be :<, 1
+        result.duration.must_be :<, 2_000
         result.stderr.must_equal ""
       end
 

--- a/spec/support/test_container_listener.rb
+++ b/spec/support/test_container_listener.rb
@@ -18,7 +18,7 @@ class TestContainerListener < CC::Analyzer::ContainerListener
   def timed_out(data)
     @timed_out_image = data.image
     @timed_out_name = data.name
-    @timed_out_seconds = data.duration
+    @timed_out_seconds = data.duration / 1_000
     @timed_out = true
   end
 


### PR DESCRIPTION
1. Yesterday's patch for IO wait worked, but this technique is more performant (and I'm deleting redundant code I missed yesterday, and adding a spec.)
2. Due to how the timeout thread was instantiated, it might not be scheduled soon, and so actual timeout could be well after what was desired. By running the thread immediately, this should improve this behavior.

This is working for me locally, and I have managed to make things timeout correctly locally. It should also be noted that timeout behavior was already specced as well, and those specs were running fine. So I think the missed timeout I saw in production this morning was something different, possibly an isolated problem, but almost certainly not a consequence of the other recent changes. This should tighten things up overall. I'll continue to dig into potential ways timeouts could be delayed or missed as well.

:eyeglasses: @codeclimate/review 