### PR TITLE
Disable Rails/Output check in inferred config

### DIFF
--- a/config/rubocop/.rubocop.yml
+++ b/config/rubocop/.rubocop.yml
@@ -1148,7 +1148,7 @@ Rails/HasAndBelongsToMany:
 
 Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
-  Enabled: true
+  Enabled: false
 
 Rails/ReadWriteAttribute:
   Description: >-


### PR DESCRIPTION
Default may make sense but the description of the issue is
confusing if your app isn't a rails app: "Do not write to stdout.
Use Rails' logger if you want to log"

/c @jpignata changed my mind after seeing the description