### PR TITLE
fix constructing multi-line pull request description

### DIFF
--- a/bin/prep-release
+++ b/bin/prep-release
@@ -34,12 +34,15 @@ git commit -m "Release v$version"
 git push origin $branch
 
 compare_link="https://github.com/codeclimate/codeclimate/compare/${old_version}...$(git rev-parse --short $branch)"
+pr_description_file=$(mktemp -t cc_commit_message) || exit 1
+printf "Release v$version\n\n$s\n" "$compare_link" > "$pr_description_file"
 if command -v hub > /dev/null 2>&1; then
-  hub pull-request -m "Release v$version\n\n$compare_link"
+  hub pull-request -F "$pr_description_file"
 elif command -v gh > /dev/null 2>&1; then
-  gh pull-request -m "Release v$version\n\n$compare_link"
+  gh pull-request -F "$pr_description_file"
 else
   echo "hub not installed? Please open the PR manually" >&2
 fi
+rm "$commit_message_file"
 
 echo "After merging the version-bump PR, run bin/release"


### PR DESCRIPTION
It appears `hub` doesn't like escaped chars in strings with `-m`. This
switches around to writing the message to a file and using that instead.

:eyes: @codeclimate/review