### PR TITLE
Fix output reader behavior in the face of timeouts

### DIFF
--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -129,10 +129,7 @@ module CC::Analyzer
         end
 
         it "times out slow containers" do
-          old_timeout = ENV["CONTAINER_TIMEOUT_SECONDS"]
-          ENV["CONTAINER_TIMEOUT_SECONDS"] = "1"
-
-          begin
+          with_timeout(1) do
             listener = TestContainerListener.new
             listener.expects(:finished).never
             container = Container.new(
@@ -153,8 +150,6 @@ module CC::Analyzer
             @container_result.exit_status.wont_equal nil
             @container_result.duration.must_be :>=, 0
             @container_result.duration.must_be :<, 2_000
-          ensure
-            ENV["CONTAINER_TIMEOUT_SECONDS"] = old_timeout
           end
         end
 
@@ -171,24 +166,14 @@ module CC::Analyzer
             listener: listener,
           )
           container.on_output do |str|
+            sleep 0.5
             stdout_lines << str
           end
 
-          slow_read_stdout = Proc.new do |out|
-            Thread.new do
-              out.each_line(container.instance_variable_get(:@output_delimeter)) do |chunk|
-                sleep 0.5
-                output = chunk.chomp(container.instance_variable_get(:@output_delimeter))
-                container.instance_variable_get(:@on_output).call(output)
-              end
-            end
-          end
-          container.stub :read_stdout, slow_read_stdout do
-            run_container(container)
+          run_container(container)
 
-            assert_container_stopped
-            @container_result.timed_out?.must_equal false
-          end
+          assert_container_stopped
+          @container_result.timed_out?.must_equal false
         end
 
         it "stops containers that emit more than the configured maximum output bytes" do
@@ -276,6 +261,14 @@ module CC::Analyzer
       Process.expects(:waitpid2).with(pid).returns([nil, status])
 
       return [pid, out, err]
+    end
+
+    def with_timeout(timeout)
+      old_timeout = ENV["CONTAINER_TIMEOUT_SECONDS"]
+      ENV["CONTAINER_TIMEOUT_SECONDS"] = timeout.to_s
+      yield
+    ensure
+      ENV["CONTAINER_TIMEOUT_SECONDS"] = old_timeout
     end
   end
 end

--- a/spec/cc/analyzer/include_paths_builder_spec.rb
+++ b/spec/cc/analyzer/include_paths_builder_spec.rb
@@ -203,7 +203,7 @@ module CC::Analyzer
       end
 
       it "generates correct paths" do
-        builder.build.must_equal ["subdir/subdir_trackable.rb", "trackable.rb"]
+        builder.build.sort.must_equal ["subdir/subdir_trackable.rb", "trackable.rb"].sort
       end
     end
 


### PR DESCRIPTION
Previous behavior:

- Engine would run and complete in minutes
- Process.waitpid would return a successful status
- The else branch of if @timed_out would be followed
- If the engine produced a significant amount of stdout, and we're slow to read
  it, the output buffers in the docker process (bloating RAM) and we block in
  the Thread#join calls
- The timeout thread eventually reaches 15 minutes and invokes
  reap_running_container directly (not stop)
- The docker kill is a no-op because the container's already finished
- Because it didn't go via #stop, @on_output is left untouched and continues to
  churn

In such cases, the builder runs for as long as it takes to get through the
output. Things eventually do finish, but it takes forever and the memory bloat
of the buffered stdout can cause operational issues.

The fix is to ensure the stdout/stderr processing is governed by the timeout
thread. For this to function correctly, we had to move a few things around:

- When we intentionally stop things, always go through #stop
- If we call #stop, kill the output readers then and there
- Thread#join the output readers *before* checking @timed_out 

In addition, we now pass a message argument through to the log entry written
when we kill a container.

/cc @codeclimate/review

There are two lead-up commits to fix up the specs a bit, then the key failing
spec, then the fix.

I'm going to test this branch locally on my reproduction case before shipping.