### PR TITLE
Exclude minified css via --exclude-ext options

### DIFF
--- a/config/csslint/.csslintrc
+++ b/config/csslint/.csslintrc
@@ -1,1 +1,2 @@
+--exclude-exts=.min.css
 --ignore=adjoining-classes,ids,order-alphabetical,unqualified-attributes


### PR DESCRIPTION
Excluding by extension is less robust but much easier to implement and more
performant than other options that involve inspecting file content.

The tradeoff is worth it because doing it via a default configuration like this
is both discoverable and easily correctable if it causes users trouble.

/cc @codeclimate/review