### PR TITLE
Ignore box-model in default csslintrc

### DIFF
--- a/config/csslint/.csslintrc
+++ b/config/csslint/.csslintrc
@@ -1,2 +1,2 @@
 --exclude-exts=.min.css
---ignore=adjoining-classes,ids,order-alphabetical,unqualified-attributes
+--ignore=adjoining-classes,box-model,ids,order-alphabetical,unqualified-attributes


### PR DESCRIPTION
Details: https://github.com/CSSLint/csslint/wiki/Beware-of-box-model-size

Our reasoning is that if you understand the CSS box model, you would find this
rule annoying and we should optimize for experienced CSS authors.

/cc @codeclimate/review