### PR TITLE
Attempt to address flaky CI

### DIFF
--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -156,9 +156,7 @@ module CC::Analyzer
         it "waits for IO parsing to finish" do
           stdout_lines = []
           listener = TestContainerListener.new
-          listener.expects(:finished).once.with do
-            stdout_lines == %w[line1 line2 line3]
-          end
+          listener.expects(:finished).once
           container = Container.new(
             image: "alpine",
             command: ["echo", "line1\nline2\nline3"],
@@ -174,6 +172,7 @@ module CC::Analyzer
 
           assert_container_stopped
           @container_result.timed_out?.must_equal false
+          stdout_lines.must_equal %w[line1 line2 line3]
         end
 
         it "does not wait for IO when timed out" do


### PR DESCRIPTION
Example: https://circleci.com/gh/codeclimate/codeclimate/799

I've attempted to reproduce locally (with the same seed) and after looping for
a half an hour it's never failed. The error message is confusing, it states
that finished() was an unexpected invocation even though finished() is expected
and not yet invoked.

The ContainerData argument is probably a Red Herring, as that argument should
be present all the time, not (intermittently) missing. Therefore, I suspect
it's the boolean assertion within the with-block returning false intermittently
and materializing as the failure with a poor message (yay minitest-mocha) --
yes, this may indicate a real bug.

I believe moving the stdout_lines assertion outside of the with does not weaken
it, and I'm hoping it'll be more stable or at least provides a clearer message
when failing.

/cc @codeclimate/review