### PR TITLE
Match brakeman's rules for Rails' app detection

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -16,7 +16,7 @@ brakeman:
   upgrade_languages:
     - Ruby
   enable_regexps:
-    - ^script\/rails$
+    - ^app\/.*\.rb
   default_ratings_paths:
     - "Gemfile.lock"
     - "**.erb"


### PR DESCRIPTION
This may not be a preferred way, but it is how Brakeman determines
what is a valid Rails app to scan and what isn't. If we choose a
different hueristic, than you can get into a scenario where codeclimate
by default enables Brakeman (b/c a script/rails exists), and then
brakeman complains it's not a Rails app (No 'app' directory).

It's unlikely to be the case, but still worthwhile for them to match
and I see no downside.

I tested this to ensure it only triggers when there's an app directory at the top level.

/c @codeclimate/review 