### PR TITLE
Enable duplication engine automatically for supported languages

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -55,7 +55,21 @@ duplication:
   description: Structural duplication detection for Ruby, Python, JavaScript, and PHP.
   community: false
   enable_regexps:
+    - \.inc$
+    - \.js$
+    - \.jsx$
+    - \.module$
+    - \.php$
+    - \.py$
+    - \.rb$
   default_ratings_paths:
+    - "**.inc"
+    - "**.js"
+    - "**.jsx"
+    - "**.module"
+    - "**.php"
+    - "**.py"
+    - "**.rb"
   default_config:
     languages:
       - ruby

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -39,7 +39,7 @@ module CC::CLI
       it "calculates eligible_engines based on existing files" do
         write_fixture_source_files
 
-        expected_engine_names = %w(rubocop eslint csslint fixme)
+        expected_engine_names = %w(rubocop eslint csslint fixme duplication)
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -31,11 +31,12 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
+              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "eslint" => { "enabled"=>true },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            "ratings" => { "paths" => ["**.css", "**.js", "**.jsx", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
             "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
           })
 
@@ -170,11 +171,12 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
+              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "eslint" => { "enabled"=>true },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            "ratings" => { "paths" => ["**.css", "**.js", "**.jsx", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
             "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
           })
 
@@ -200,10 +202,11 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
+              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            "ratings" => { "paths" => ["**.css", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
             "exclude_paths" => ["excluded.rb"],
           })
 

--- a/spec/cc/cli/upgrade_config_generator_spec.rb
+++ b/spec/cc/cli/upgrade_config_generator_spec.rb
@@ -35,7 +35,7 @@ module CC::CLI
         File.write(".codeclimate.yml", create_classic_yaml)
         write_fixture_source_files
 
-        expected_engine_names = %w(rubocop csslint fixme)
+        expected_engine_names = %w(rubocop csslint fixme duplication)
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end


### PR DESCRIPTION
Duplicate of #259 

This PR updates our engines registry to enable the [duplication engine][] for any project with Ruby, Python, JavaScript, or PHP files.

[duplication engine]: https://circleci.com/gh/codeclimate/codeclimate-duplication