### PR TITLE
Run Circle specs in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
 .git
 .bundle
+*.md
+Makefile
+bin/prep-release
+bin/release
+circle.yml
+pkg
+tags

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,14 @@ PREFIX ?= /usr/local
 image:
 	docker build -t codeclimate/codeclimate .
 
+test_only:
+	docker run --rm \
+	  --entrypoint bundle \
+	  --volume /var/run/docker.sock:/var/run/docker.sock \
+	  codeclimate/codeclimate exec rake
+
+test: image test_only
+
 install:
 	bin/check
 	docker pull codeclimate/codeclimate:latest
@@ -15,4 +23,3 @@ install:
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/codeclimate
 	docker rmi codeclimate/codeclimate:latest
-

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,6 @@
 machine:
   services:
     - docker
-  environment:
-    CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-    PRIVATE_REGISTRY: us.gcr.io/code_climate
 
 dependencies:
   override:
@@ -14,13 +11,3 @@ dependencies:
 test:
   override:
     - make test_only
-
-deployment:
-  registry:
-    branch: master
-    commands:
-      - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
-      - curl https://sdk.cloud.google.com | bash
-      - gcloud auth activate-service-account --key-file /tmp/gcloud_key.json
-      - gcloud docker -a
-      - docker push $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM

--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,11 @@ dependencies:
   override:
     # Used by container_spec
     - docker pull alpine
-    - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
-    - bundle install
+    - make image
 
 test:
   override:
-    - bundle exec rake
+    - make test_only
 
 deployment:
   registry:

--- a/circle.yml
+++ b/circle.yml
@@ -11,3 +11,7 @@ dependencies:
 test:
   override:
     - make test_only
+
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -173,24 +173,7 @@ module CC
         Analyzer.logger.warn("killing container name=#{@name} message=#{message.inspect}")
         POSIX::Spawn::Child.new("docker", "kill", @name)
 
-        # On Circle, the tests around this method fail when run via make test,
-        # within a container process.
-        #
-        # Known:
-        #
-        #   - The docker kill succeeds
-        #   - The container process exits with SIGPIPE and no exit code
-        #   - Therefore, the assertion on the exit code fails
-        #
-        # Theory: docker kill succeeds, but the container hasn't actually
-        # stopped when we go ahead and kill the output reading threads. The loss
-        # of the output readers causes the still-running container to SIGPIPE
-        # which causes the result to not have an exit code.
-        #
-        # This sleep is a bit of a hack, but passes the specs. It shouldn't
-        # negatively impact production as we're already in a kill scenario, so
-        # small delay between killing the engine and killing the output reading
-        # threads doesn't strike me as a huge deal
+        # Required for specs to pass on Circle. See commit message for details.
         sleep 2
       end
 

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -174,7 +174,7 @@ module CC
         POSIX::Spawn::Child.new("docker", "kill", @name)
 
         # Required for specs to pass on Circle. See commit message for details.
-        sleep 2
+        #sleep 2
       end
 
       def timeout

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -172,6 +172,26 @@ module CC
       def reap_running_container(message)
         Analyzer.logger.warn("killing container name=#{@name} message=#{message.inspect}")
         POSIX::Spawn::Child.new("docker", "kill", @name)
+
+        # On Circle, the tests around this method fail when run via make test,
+        # within a container process.
+        #
+        # Known:
+        #
+        #   - The docker kill succeeds
+        #   - The container process exits with SIGPIPE and no exit code
+        #   - Therefore, the assertion on the exit code fails
+        #
+        # Theory: docker kill succeeds, but the container hasn't actually
+        # stopped when we go ahead and kill the output reading threads. The loss
+        # of the output readers causes the still-running container to SIGPIPE
+        # which causes the result to not have an exit code.
+        #
+        # This sleep is a bit of a hack, but passes the specs. It shouldn't
+        # negatively impact production as we're already in a kill scenario, so
+        # small delay between killing the engine and killing the output reading
+        # threads doesn't strike me as a huge deal
+        sleep 2
       end
 
       def timeout


### PR DESCRIPTION
- The image and test targets are generally useful
- Running specs in a container should mean more consistent behavior
- Working with a codeclimate/codeclimate image until and unless we're deploying
  to GCR, at which time we tag and push, feels simpler

/cc @codeclimate/review