### PR TITLE
Autoexclude config paths

### DIFF
--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -2,7 +2,7 @@ module CC
   module CLI
     class ConfigGenerator
       CODECLIMATE_YAML = Command::CODECLIMATE_YAML
-      AUTO_EXCLUDE_PATHS = %w(config/ db/ features/ node_modules/ script/ spec/ test/ tests/ vendor/).freeze
+      AUTO_EXCLUDE_PATHS = %w(.codeclimate.yml .csslintrc .eslintrc .rubocop.yml config/ db/ features/ node_modules/ script/ spec/ test/ tests/ vendor/).freeze
 
       def self.for(filesystem, engine_registry, upgrade_requested)
         if upgrade_requested && upgrade_needed?(filesystem)


### PR DESCRIPTION
This change reduces nonsensical errors -e.g. fixme engine finding `fixme` in .codeclimate.yml

Also prevents source file not found errors that come up when issues are found in config files that
are autogenerated during analysis on .com, but don't actually exist in repo.

e.g.
https://codeclimate.com/repos/566b4d8513282e4989000f3a/issues/categories/bugrisk

cc @codeclimate/review 