### PR TITLE
Don't enable duplication by default

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -54,14 +54,14 @@ duplication:
   image: codeclimate/codeclimate-duplication
   description: Structural duplication detection for Ruby, Python, JavaScript, and PHP.
   community: false
-  enable_regexps:
-    - \.inc$
-    - \.js$
-    - \.jsx$
-    - \.module$
-    - \.php$
-    - \.py$
-    - \.rb$
+  # enable_regexps:
+  #   - \.inc$
+  #   - \.js$
+  #   - \.jsx$
+  #   - \.module$
+  #   - \.php$
+  #   - \.py$
+  #   - \.rb$
   default_ratings_paths:
     - "**.inc"
     - "**.js"

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -39,10 +39,12 @@ module CC::CLI
       it "calculates eligible_engines based on existing files" do
         write_fixture_source_files
 
-        expected_engine_names = %w(rubocop eslint csslint fixme duplication)
+        #expected_engine_names = %w(rubocop eslint csslint fixme duplication)
+        expected_engine_names = %w(rubocop eslint csslint fixme)
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end
+
         generator.eligible_engines.must_equal expected_engines
       end
 

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -31,12 +31,13 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
-              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
+              #"duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "eslint" => { "enabled"=>true },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
+            #"ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.js", "**.jsx", "**.rb"] },
             "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
           })
 
@@ -171,12 +172,13 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
-              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
+              #"duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "eslint" => { "enabled"=>true },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
+            #"ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.js", "**.jsx", "**.rb"] },
             "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
           })
 
@@ -202,11 +204,12 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
-              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
+              #"duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
+            #"ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.rb"] },
             "exclude_paths" => ["excluded.rb"],
           })
 

--- a/spec/cc/cli/upgrade_config_generator_spec.rb
+++ b/spec/cc/cli/upgrade_config_generator_spec.rb
@@ -35,7 +35,8 @@ module CC::CLI
         File.write(".codeclimate.yml", create_classic_yaml)
         write_fixture_source_files
 
-        expected_engine_names = %w(rubocop csslint fixme duplication)
+        #expected_engine_names = %w(rubocop csslint fixme duplication)
+        expected_engine_names = %w(rubocop csslint fixme)
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end


### PR DESCRIPTION
By surfacing & no longer silently swallowing errors that could lead to non-deterministic results, we are now in a bit of a tough spot because this is surfacing errors that look like straight-up bugs in the babel parser, but which programmatically aren't very distinguishable from previously mentioned non-deterministic results bugs.

(The underlying errors are parsing timeouts: previously these were low at 20 seconds and being swallowed, which was bad because memory pressure/gc behavior could swing execution to one side or the other of that line. Now they are high at 5 minutes & fatal, but due to what look like babel issues reliably happen on some files. It might be reasonable to swallow these extreme timeouts, but it would only take 2 or 3 of them to timeout the whole engine, so it hardly seems worthwhile.)