### PR TITLE
Print issue with begin line only, if no endline is specified

### DIFF
--- a/lib/cc/analyzer/location_description.rb
+++ b/lib/cc/analyzer/location_description.rb
@@ -10,7 +10,7 @@ module CC
       def to_s
         if location["lines"]
           begin_line = location["lines"]["begin"]
-          end_line = location["lines"]["end"]
+          end_line = location["lines"]["end"] || begin_line
         elsif location["positions"]
           begin_line = position_to_line(location["positions"]["begin"])
           end_line = position_to_line(location["positions"]["end"])

--- a/spec/cc/analyzer/location_description_spec.rb
+++ b/spec/cc/analyzer/location_description_spec.rb
@@ -15,6 +15,12 @@ module CC::Analyzer
         LocationDescription.new(Object.new, location).to_s.must_equal("1-3")
       end
 
+      it "with only begin line" do
+        location = {"lines" => {"begin" => 1}}
+
+        LocationDescription.new(Object.new, location).to_s.must_equal("1")
+      end
+
       it "with linecols" do
         location = {
           "positions" => {


### PR DESCRIPTION
This way, engines can also pass simply lines: { begin: line_num }

We should do this and be resilient to a questionable but not illogical
input, or complain loudly.

**Fix**: currently the brakeman engine only returns `begin: line`

```CONSOLE
Starting analysis
Running brakeman: Done!

== Gemfile.lock (2 issues) ==
87-: Rails 4.2.0 does not encode JSON keys (CVE-2015-3226). Upgrade to Rails version 4.2.2 [brakeman]
87-: Rails 4.2.0 is vulnerable to denial of service via XML parsing (CVE-2015-3227). Upgrade to Rails version 4.2.2 [brakeman]
```

cc @codeclimate/review 