### PR TITLE
Add "dist" directory to list of auto-excludes used for "init"

### DIFF
--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -2,7 +2,7 @@ module CC
   module CLI
     class ConfigGenerator
       CODECLIMATE_YAML = Command::CODECLIMATE_YAML
-      AUTO_EXCLUDE_PATHS = %w(config/ db/ features/ node_modules/ script/ spec/ test/ tests/ vendor/).freeze
+      AUTO_EXCLUDE_PATHS = %w(config/ db/ dist/ features/ node_modules/ script/ spec/ test/ tests/ vendor/).freeze
 
       def self.for(filesystem, engine_registry, upgrade_requested)
         if upgrade_requested && upgrade_needed?(filesystem)


### PR DESCRIPTION
/c @codeclimate/review 