### PR TITLE
Enable duplication by default

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -54,14 +54,14 @@ duplication:
   image: codeclimate/codeclimate-duplication
   description: Structural duplication detection for Ruby, Python, JavaScript, and PHP.
   community: false
-  # enable_regexps:
-  #   - \.inc$
-  #   - \.js$
-  #   - \.jsx$
-  #   - \.module$
-  #   - \.php$
-  #   - \.py$
-  #   - \.rb$
+  enable_regexps:
+    - \.inc$
+    - \.js$
+    - \.jsx$
+    - \.module$
+    - \.php$
+    - \.py$
+    - \.rb$
   default_ratings_paths:
     - "**.inc"
     - "**.js"

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -39,12 +39,10 @@ module CC::CLI
       it "calculates eligible_engines based on existing files" do
         write_fixture_source_files
 
-        #expected_engine_names = %w(rubocop eslint csslint fixme duplication)
-        expected_engine_names = %w(rubocop eslint csslint fixme)
+        expected_engine_names = %w(rubocop eslint csslint fixme duplication)
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end
-
         generator.eligible_engines.must_equal expected_engines
       end
 

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -31,13 +31,12 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
-              #"duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
+              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "eslint" => { "enabled"=>true },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            #"ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
-            "ratings" => { "paths" => ["**.css", "**.js", "**.jsx", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
             "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
           })
 
@@ -172,13 +171,12 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
-              #"duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
+              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "eslint" => { "enabled"=>true },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            #"ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
-            "ratings" => { "paths" => ["**.css", "**.js", "**.jsx", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
             "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
           })
 
@@ -204,12 +202,11 @@ module CC::CLI
           YAML.safe_load(new_content).must_equal({
             "engines" => {
               "csslint" => { "enabled"=>true },
-              #"duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
+              "duplication" => { "enabled" => true, "config" => { "languages" => ["ruby", "javascript", "python", "php"] } },
               "fixme" => { "enabled"=>true },
               "rubocop" => { "enabled"=>true },
             },
-            #"ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
-            "ratings" => { "paths" => ["**.css", "**.rb"] },
+            "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
             "exclude_paths" => ["excluded.rb"],
           })
 

--- a/spec/cc/cli/upgrade_config_generator_spec.rb
+++ b/spec/cc/cli/upgrade_config_generator_spec.rb
@@ -35,8 +35,7 @@ module CC::CLI
         File.write(".codeclimate.yml", create_classic_yaml)
         write_fixture_source_files
 
-        #expected_engine_names = %w(rubocop csslint fixme duplication)
-        expected_engine_names = %w(rubocop csslint fixme)
+        expected_engine_names = %w(rubocop csslint fixme duplication)
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end


### PR DESCRIPTION
This reverts commit 42b73547439936963e1367e1bb00224f9c8b1e06.

I think duplication has looked healthy enough to turn back on by default.

See https://metrics.librato.com/s/spaces/119114/explore/1292334?duration=1185843 and https://bugsnag.com/code-climate/builder/errors/5646488122e6214965e7da4d?filters%5Bevent.since%5D%5B%5D=30d

@codeclimate/review