### PR TITLE
Tag docker images with version

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -18,7 +18,9 @@ printf "RELEASE %s\n" "$version"
 rake release
 
 docker build --rm -t codeclimate/codeclimate .
-docker push codeclimate/codeclimate
+docker push codeclimate/codeclimate:latest
+docker tag codeclimate/codeclimate "codeclimate/codeclimate:$version"
+docker push "codeclimate/codeclimate:$version"
 
 (cd ../homebrew-formulae/ && bin/release "$version")
 


### PR DESCRIPTION
In addition to git tags, this will tag docker releases with the version tag, in addition to updating "latest"

![3584216](https://cloud.githubusercontent.com/assets/188402/12043679/4245354e-ae55-11e5-91cc-e3f69b8055cc.jpg)

Would be nice to adjust the homebrew formula to pull the correct tag at some point as well, but that's more complicated, so I probably won't do it yet.

:eyeglasses: @codeclimate/review 