### PR TITLE
tweak eslint defaults: complexity, max-statements

### DIFF
--- a/config/eslint/.eslintrc
+++ b/config/eslint/.eslintrc
@@ -44,7 +44,7 @@ rules:
   # Best Practices
   accessor-pairs: 2
   block-scoped-var: 0
-  complexity: [2, 11]
+  complexity: [2, 6]
   consistent-return: 0
   curly: 0
   default-case: 0
@@ -149,7 +149,7 @@ rules:
   max-len: 0
   max-nested-callbacks: 0
   max-params: 0
-  max-statements: 0
+  max-statements: [2, 30]
   new-cap: 0
   new-parens: 0
   newline-after-var: 0


### PR DESCRIPTION
Trying to match up the defaults here to what we have for RuboCop so we
can have a bit more consistency across languages.

This changes the triggering complexity threshold to 6 (same as in our
default .rubocop.yml in this repo), and max-statements (which is subtly
different from max length, but similar enough I think we can use the
same val for now) to 30 (which is RuboCop's internal default: we don't
set it explicitly in our `.rubocop.yml`).

:eyes: @codeclimate/review 