### PR TITLE
Exclude paths for a specific engine

### DIFF
--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -33,7 +33,7 @@ module CC
 
       def engine_config(raw_engine_config)
         config = raw_engine_config.merge(
-          exclude_paths: exclude_paths(raw_engine_config.config.fetch("exclude_paths")),
+          exclude_paths: exclude_paths(raw_engine_config.fetch("config", {})["exclude_paths"]),
           include_paths: include_paths,
         )
         # The yaml gem turns a config file string into a hash, but engines

--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -32,9 +32,11 @@ module CC
       attr_reader :include_paths
 
       def engine_config(raw_engine_config)
+        all_paths_to_exclude = exclude_paths(raw_engine_config.fetch("config", {})["exclude_paths"])
+
         config = raw_engine_config.merge(
-          exclude_paths: exclude_paths(raw_engine_config.fetch("config", {})["exclude_paths"]),
-          include_paths: include_paths,
+          exclude_paths: all_paths_to_exclude,
+          include_paths: include_paths(exclude_paths: all_paths_to_exclude),
         )
         # The yaml gem turns a config file string into a hash, but engines
         # expect the string. So we (for now) need to turn it into a string in
@@ -56,7 +58,7 @@ module CC
         end
       end
 
-      def include_paths
+      def include_paths(exclude_paths: nil)
         IncludePathsBuilder.new(exclude_paths, Array(@requested_paths)).build
       end
 

--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -33,7 +33,7 @@ module CC
 
       def engine_config(raw_engine_config)
         config = raw_engine_config.merge(
-          exclude_paths: exclude_paths,
+          exclude_paths: exclude_paths(raw_engine_config.config.fetch("exclude_paths")),
           include_paths: include_paths,
         )
         # The yaml gem turns a config file string into a hash, but engines
@@ -60,9 +60,14 @@ module CC
         IncludePathsBuilder.new(exclude_paths, Array(@requested_paths)).build
       end
 
-      def exclude_paths
-        PathPatterns.new(@config.exclude_paths || []).expanded +
-          gitignore_paths
+      def exclude_paths(raw_engine_config_exclude_paths = nil)
+        paths = PathPatterns.new(@config.exclude_paths || []).expanded + gitignore_paths
+
+        if raw_engine_config_exclude_paths
+          paths += PathPatterns.new(raw_engine_config_exclude_paths).expanded
+        end
+
+        paths.uniq
       end
 
       def gitignore_paths


### PR DESCRIPTION
re: https://github.com/codeclimate/codeclimate/issues/297

Attempting to add an `exclude_paths` option for specific engines like so:

```yml
---
engines:
  duplication:
    enabled: true
    config:
      languages:
      - ruby
      exclude_paths:
      - spec/*
  rubocop:
    enabled: true
```

~~Currently fails inside engine~~ update: no longer!

Where do I go from here?