### PR TITLE
Properly namespace exception so that the constant can be found

### DIFF
--- a/lib/cc/analyzer/formatters.rb
+++ b/lib/cc/analyzer/formatters.rb
@@ -12,7 +12,7 @@ module CC
       }.freeze
 
       def self.resolve(name)
-        FORMATTERS[name.to_sym] or raise InvalidFormatterError, "'#{name}' is not a valid formatter. Valid options are: #{FORMATTERS.keys.join(', ')}"
+        FORMATTERS[name.to_sym] or raise Formatter::InvalidFormatterError, "'#{name}' is not a valid formatter. Valid options are: #{FORMATTERS.keys.join(', ')}"
       end
     end
   end


### PR DESCRIPTION
Previously:

```
$ codeclimate analyze -f asdf
error: (NameError) uninitialized constant CC::Analyzer::Formatters::InvalidFormatterError
```

Now:

```
$ codeclimate analyze -f asdf
'asdf' is not a valid formatter. Valid options are: json, text
```