### PR TITLE
Restore Glob Functionality to Workspace Refactor

### DIFF
--- a/lib/cc/workspace.rb
+++ b/lib/cc/workspace.rb
@@ -1,6 +1,7 @@
 module CC
   class Workspace
     autoload :Exclusions, "cc/workspace/exclusions"
+    autoload :PathTree, "cc/workspace/path_tree"
     autoload :PathsValidator, "cc/workspace/paths_validator"
 
     def initialize(paths: nil, prefix: "")

--- a/lib/cc/workspace.rb
+++ b/lib/cc/workspace.rb
@@ -4,21 +4,22 @@ module CC
     autoload :PathTree, "cc/workspace/path_tree"
     autoload :PathsValidator, "cc/workspace/paths_validator"
 
-    def initialize(paths: nil, prefix: "")
-      @prefix = prefix
+    DEFAULT_PATH = "."
 
+    def initialize(paths: nil)
+      @path_tree = PathTree.new(DEFAULT_PATH)
       if paths.present?
         validator = PathsValidator.new(paths)
         validator.run
 
-        @paths = paths
+        path_tree.include_paths(paths)
       end
 
-      CLI.debug("workspace initialize", prefix: prefix)
+      CLI.debug("workspace initialize")
     end
 
     def paths
-      @paths || ["./"]
+      path_tree.all_paths
     end
 
     def filter(exclude_paths)
@@ -28,8 +29,13 @@ module CC
 
       CLI.debug("workspace filter start", exclude_paths: exclude_paths)
 
-      @paths ||= Dir.glob("*", File::FNM_DOTMATCH)
-      @paths = @paths.flat_map { |name| expand(name, exclusions) }
+      exclusions.exclude_paths.each do |exclusion|
+        if exclusions.glob?(exclusion)
+          path_tree.exclude_paths(exclusions.expanded_glob(exclusion))
+        else
+          path_tree.exclude_paths([exclusion])
+        end
+      end
 
       CLI.debug("workspace filter end", paths: paths)
 
@@ -38,30 +44,6 @@ module CC
 
     private
 
-    attr_reader :prefix
-
-    def expand(name, exclusions)
-      path = "#{prefix}#{name}"
-
-      return [] if %w[. .. .git].include?(name)
-      return [] if exclusions.include?(undir(path))
-      return [path] unless File.directory?(name)
-      return [dir(path)] unless exclusions.apply?(undir(path))
-
-      CLI.debug("workspace filter recurse", prefix: prefix, path: name)
-
-      Dir.chdir(name) do
-        workspace = self.class.new(prefix: dir(path))
-        workspace.filter(exclusions.exclude_paths).paths
-      end
-    end
-
-    def dir(path)
-      "#{undir(path)}#{File::SEPARATOR}"
-    end
-
-    def undir(path)
-      path.sub(/#{File::SEPARATOR}$/, "")
-    end
+    attr_reader :path_tree
   end
 end

--- a/lib/cc/workspace/exclusions.rb
+++ b/lib/cc/workspace/exclusions.rb
@@ -7,40 +7,18 @@ module CC
         @exclude_paths = exclude_paths.map { |p| normalize(p) }.compact
       end
 
-      def include?(path)
-        exclude_paths.include?(path)
+      def glob?(exclusion)
+        exclusion.include?("*")
       end
 
-      def apply?(path)
-        exclude_paths.any? do |exclude_path|
-          exclude_path.start_with?(path)
-        end
+      def expanded_glob(exclusion)
+        Dir.glob(exclusion)
       end
 
       private
 
       def normalize(pattern)
-        normalized = pattern.to_s.sub(%r{/\*\*(/\*)?$}, "")
-
-        if normalized.include?("*")
-          $stderr.puts(invalid_exclude_path_warning(pattern))
-        else
-          normalized
-        end
-      end
-
-      def invalid_exclude_path_warning(pattern)
-        <<-EOM
-WARNING: invalid exclude path: #{pattern.inspect}.
-
-Unfortunately, we no longer support wildcard patterns in exclude_paths, only
-file paths or directories relative to the project root. This pattern will be
-ignored.
-
-If you feel particularly limited by this, please open an Issue at
-https://github.com/codeclimate/codeclimate and we'll try to find a
-non-exclude_paths-based solution.
-        EOM
+        pattern.to_s.sub(%r{/\*\*(/\*)?$}, "")
       end
     end
   end

--- a/lib/cc/workspace/path_tree.rb
+++ b/lib/cc/workspace/path_tree.rb
@@ -24,10 +24,10 @@ module CC
 
       protected
 
-      attr_reader :child_dirs, :root_path, :child_files
+      attr_reader :root_path
 
       def populated?
-        !(child_dirs.empty? &&  child_files.empty?)
+        child_dirs.present? || child_files.present?
       end
 
       def delete(path_pieces)
@@ -75,6 +75,14 @@ module CC
       end
 
       private
+
+      def child_files
+        @child_files ||= Set.new
+      end
+
+      def child_dirs
+        @child_dirs ||= Hash.new
+      end
 
       def populate_all
         return if populated?

--- a/lib/cc/workspace/path_tree.rb
+++ b/lib/cc/workspace/path_tree.rb
@@ -1,0 +1,101 @@
+require "pathname"
+require "set"
+
+module CC
+  class Workspace
+    class PathTree
+      def initialize(root_path)
+        @root_path = root_path
+        @child_dirs = Hash.new
+        @child_files = Set.new
+      end
+
+      def exclude_paths(paths)
+        paths.each { |path| delete(path.split(File::SEPARATOR)) }
+      end
+
+      def include_paths(paths)
+        paths.each { |path| insert(path.split(File::SEPARATOR)) }
+      end
+
+      def all_paths
+        collect_paths(include_parent: false).sort.uniq
+      end
+
+      protected
+
+      attr_reader :child_dirs, :root_path, :child_files
+
+      def populated?
+        !(child_dirs.empty? &&  child_files.empty?)
+      end
+
+      def delete(path_pieces)
+        populate_all
+        if 1 == path_pieces.size
+          child_dirs.delete(path_pieces[0])
+          child_files.delete(path_pieces[0])
+        else
+          #TODO: child might not exist
+          child_dir = child_dirs[path_pieces[0]]
+          child_dir.delete(path_pieces.drop(1))
+          child_dirs.delete(path_pieces[0]) if !child_dir.populated?
+        end
+      end
+
+      def insert(path_pieces)
+        return if path_pieces.empty?
+        entry = Pathname.new(root_path).children.detect { |c| c.basename.to_s == path_pieces[0] }
+        if entry && entry.directory?
+          child_dirs[entry.basename.to_s] = PathTree.new(entry.to_s)
+          child_dirs[entry.basename.to_s].insert(path_pieces.drop(1))
+        elsif entry && entry.file? && path_pieces.count == 1
+          child_files << entry.basename.to_s
+        else
+          CLI.debug("Couldn't exclude because part of path doesn't exist", path: File.join(path_pieces))
+        end
+      end
+
+      def collect_paths(include_parent: true)
+        paths = []
+        if populated?
+          paths += child_files.map { |child_file| formatted_path(include_parent, child_file) }
+          paths += child_dirs.flat_map do |child_dir, child_tree|
+            if child_tree.populated?
+              child_tree.collect_paths
+            else
+              File.join(formatted_path(include_parent, child_dir), File::SEPARATOR)
+            end
+          end
+        else
+          paths << File.join(root_path, File::SEPARATOR)
+        end
+
+        paths
+      end
+
+      private
+
+      def populate_all
+        return if populated?
+
+        Pathname.new(root_path).each_child do |child_path|
+          if child_path.directory?
+            child_dirs[child_path.basename.to_s] = self.class.new(child_path.to_s)
+          else
+            child_files << child_path.basename.to_s
+          end
+        end
+      end
+
+      def formatted_path(include_parent, path)
+        if include_parent
+          File.join(root_path, path)
+        else
+          path
+        end
+      end
+    end
+  end
+end
+

--- a/spec/cc/workspace/path_tree_spec.rb
+++ b/spec/cc/workspace/path_tree_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+class CC::Workspace
+  describe PathTree do
+    include FileSystemHelpers
+
+    it "doesn't needlessly descend if nothing excluded" do
+      within_temp_dir do
+        make_fixture_tree
+
+        tree = PathTree.new(".")
+        tree.all_paths.must_equal ["./"]
+      end
+    end
+
+    it "excludes files, descending as needed" do
+      within_temp_dir do
+        make_fixture_tree
+
+        tree = PathTree.new(".")
+        tree.exclude_paths([".git/refs", "code/a/bar.rb"])
+        tree.all_paths.must_equal [".git/FETCH_HEAD", "code/a/baz.rb", "code/foo.rb", "foo.txt", "lib/"]
+      end
+    end
+
+    it "includes files, descending as needed" do
+      within_temp_dir do
+        make_fixture_tree
+
+        tree = PathTree.new(".")
+        tree.include_paths([".git/refs/", "code/"])
+        tree.all_paths.must_equal [".git/refs/", "code/"]
+      end
+    end
+
+    it "excludes files after explicit includes" do
+      within_temp_dir do
+        make_fixture_tree
+
+        tree = PathTree.new(".")
+        tree.include_paths([".git/refs/", "code/"])
+        tree.exclude_paths([".git/refs/heads/master", "code/a/bar.rb"])
+        tree.all_paths.must_equal ["code/a/baz.rb", "code/foo.rb"]
+      end
+    end
+
+    it "handles excluding nonexistent files" do
+      skip "TODO"
+    end
+
+    it "handles unreadable files" do
+      skip "TODO"
+    end
+
+    def make_fixture_tree
+      make_tree <<-EOM
+        .git/FETCH_HEAD
+        .git/refs/heads/master
+        code/a/bar.rb
+        code/a/baz.rb
+        code/foo.rb
+        foo.txt
+        lib/thing.rb
+      EOM
+    end
+  end
+end


### PR DESCRIPTION
I'm excited about the direction of #300, but I was concerned that completely removing glob support was overly extreme, and I'd had some thoughts while I was traveling about how it might be done performantly. This PR is my first draft at implementing those thoughts building on top of @pbrisbin's work.

The key differences with our old technique are as follows:
* Directory contents are never walked until they need to be due to explicit inclusions or exclusions. As a result:
    * The algorithm is much simpler than before: instead of a several-step process of collecting several disparate collections of paths, operating on relations between them, and then minimizing the resulting set, all operations are on a single sparse tree which is naturally minimized at all times.
   * Less overall file I/O & memory allocation for very large projects, since we're not walking every directory & building an in-memory list of every file path.
* Only things that look like globs are treated like globs. Excluding directories by name instead of pattern works just fine.
* There is no attempt to deal with unreadable files or symlinks or anything like that. (I think we'll still need to handle the case where a file we need to touch for interpreting an exclude can't be read, though).

I went out of my way to keep the existing specs from #300 mostly unchanged, except for the sole case of no longer warning on glob usage (obviously), and adding a spec for globs working. I tried to minimize changing existing bits as well to make this easier to review & keep it clearer what I was changing. So this is more of a PoC or first draft than a finished proposal of implementation. That said, the basic structure is pretty much what I had in mind.

As far as performance is concerned, this implementation works quite well on my local pathological case: it's indistinguishable from the current state of #300 as far as experienced performance goes. I'd like to write some actual code-based benchmarks before this ships so we'll have actual tests to tell us if the performance gets bad due to future changes.

:eyes: @codeclimate/review 

---------

TODOs:

- [ ] This work means `Workspace#dup` is no longer safe for multiple-engines, because the dup is using the same instance of `PathTree` as the original. I'll need to fix that & should also update the relative workspace spec to actually test the dup functionality rather than just multiple `#filter` calls.
- [ ] Handle potentially unreadable files when walking.
- [ ] Do symlinks need any special treatment?
- [ ] `.git` should be auto-excluded: that needs to be added.
- [ ] Write some benchmarks.
- [ ] make Specs test/use the results of a CC::YAML parse for both this class & Workspace.