### PR TITLE
Enable the codeclimate-kibit engine

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -133,6 +133,18 @@ hlint:
     - \.hs$
   default_ratings_paths:
     - "**.hs"
+kibit:
+  image: codeclimate/codeclimate-kibit
+  description: Static code analyzer for Clojure, ClojureScript, cljx and other Clojure variants.
+  community: true
+  enable_regexps:
+    - \.clj$
+    - \.cljc$
+    - \.cljs$
+  default_ratings_paths:
+    - "**.clj"
+    - "**.cljc"
+    - "**.cljs"
 nodesecurity:
   image: codeclimate/codeclimate-nodesecurity
   description: Security tool for Node.js dependencies.


### PR DESCRIPTION
:information_desk_person: Although the [kibit Code Climate engine](https://github.com/andrewhr/codeclimate-kibit) is referenced in the [online documentation](https://docs.codeclimate.com/docs/kibit), it is not enabled in the list of engines. :crying_cat_face: 

As a Docker image for the engine hasn't been published to Docker Hub yet, which may be why it isn't listed in the [list of community supported engines](https://docs.codeclimate.com/docs/list-of-engines).

This change prempts the publishing of this Docker image and general availability of the `codeclimate-kibit` engine. :smile_cat: 

:warning: Depends on:
* [x] andrewhr/codeclimate-kibit#1