### PR TITLE
Init: respect excludes when enabling engines

### DIFF
--- a/lib/cc/analyzer/filesystem.rb
+++ b/lib/cc/analyzer/filesystem.rb
@@ -1,6 +1,8 @@
 module CC
   module Analyzer
     class Filesystem
+      attr_reader :root
+
       def initialize(root)
         @root = root
       end
@@ -22,30 +24,14 @@ module CC
         File.chown(root_uid, root_gid, path_for(path))
       end
 
-      def any?(&block)
-        file_paths.any?(&block)
-      end
-
-      def files_matching(globs)
-        Dir.chdir(@root) do
-          globs.map do |glob|
-            Dir.glob(glob)
-          end.flatten.sort.uniq
-        end
+      def ls
+        Dir.entries(root).reject { |entry| [".", ".."].include?(entry) }
       end
 
       private
 
-      def file_paths
-        @file_paths ||= Dir.chdir(@root) do
-          `find . -type f -print0`.strip.split("\0").map do |path|
-            path.sub(%r{^\.\/}, "")
-          end
-        end
-      end
-
       def path_for(path)
-        File.join(@root, path)
+        File.join(root, path)
       end
 
       def root_uid
@@ -57,7 +43,7 @@ module CC
       end
 
       def root_stat
-        @root_stat ||= File.stat(@root)
+        @root_stat ||= File.stat(root)
       end
     end
   end

--- a/spec/cc/analyzer/filesystem_spec.rb
+++ b/spec/cc/analyzer/filesystem_spec.rb
@@ -14,46 +14,6 @@ module CC::Analyzer
       end
     end
 
-    describe "#any?" do
-      it "returns true if any files match any extensions" do
-        root = Dir.mktmpdir
-        File.write(File.join(root, "foo.rb"), "")
-        File.write(File.join(root, "foo.js"), "")
-        Dir.mkdir(File.join(root, "foo"))
-        File.write(File.join(root, "foo", "foo.sh"), "")
-        File.write(File.join(root, "foo", "bar.php"), "")
-
-        filesystem = Filesystem.new(root)
-
-        filesystem.any? { |p| /\.sh$/ =~ p }.must_equal(true)
-      end
-
-      it "returns false if no files match any extensions" do
-        root = Dir.mktmpdir
-        File.write(File.join(root, "foo.rb"), "")
-        File.write(File.join(root, "foo.js"), "")
-        Dir.mkdir(File.join(root, "foo"))
-        File.write(File.join(root, "foo", "foo.sh"), "")
-        File.write(File.join(root, "foo", "bar.php"), "")
-
-        filesystem = Filesystem.new(root)
-
-        filesystem.any? { |p| /\.hs$/ =~ p }.must_equal(false)
-      end
-    end
-
-    describe "#files_matching" do
-      it "returns files that match the globs" do
-        root = Dir.mktmpdir
-        File.write("#{root}/foo.js", "Foo")
-        File.write("#{root}/foo.rb", "Foo")
-
-        filesystem = Filesystem.new(root)
-
-        filesystem.files_matching(["*.js"]).must_equal(["foo.js"])
-      end
-    end
-
     describe "#read_path" do
       it "returns the content for the given file" do
         root = Dir.mktmpdir

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -55,6 +55,15 @@ module CC::CLI
         end
         generator.eligible_engines.must_equal expected_engines
       end
+
+      it "does not enable an engine based on excluded paths" do
+        make_tree <<-EOM
+          foo.rb
+          vendor/other.js
+        EOM
+
+        generator.eligible_engines.keys.wont_include("eslint")
+      end
     end
 
     describe "#errors" do


### PR DESCRIPTION
`ConfigGenerator` now has a slightly improved algorithm for finding
files matching engine's `enable_regexps`. This fixes a bug & noticeably
improves performance in some cases as well.

The bug fix is that because we used to check the *entire* tree for files
matching an engine's patterns, you could enable an engine whose only
matching files were in auto-exclude paths. E.g. a project under
`vendor/` might have some JavaScript files used for local scripting or
something while your own code had no JS at all.

The performance benefit comes for similar reasons as the recent
refactor of workspace calculation with exclude paths: we touch
less data & less of the filesystem.

The new algorithm is similar to the old one: we still shell out to
`find` for available files, but `find` now only searches files that are
*NOT* within the excluded directories. I tried a variety of
implementations here, including things more similar to (or using) the
new `PathTree` implementation, but this was still the fastest
implementation across a variety of cases.

I also made a behavior change here: this won't auto-enable any engine
based on files in "."-prependend directories: this is an opinion I'm happy to back
away from, but in general "."-prepended directories & files are usually stuff not
related to your actual code that you would want analyzed, so this seems
reasonable. It does introduce a slight gap in behavior in that we don't
exclude those directories from analysis, just from enabling engines.

This also removes unused functionality from `Analysis::Filesystem`.