### PR TITLE
Init: add output for steps

### DIFF
--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -38,6 +38,7 @@ module CC
       end
 
       def create_codeclimate_yaml
+        say "Generating .codeclimate.yml..."
         config = CC::CLI::Config.new
 
         config_generator.eligible_engines.each do |(engine_name, engine_config)|
@@ -49,6 +50,7 @@ module CC
       end
 
       def create_default_configs
+        say "Generating default configuration for engines..."
         available_configs.each do |config_path|
           file_name = File.basename(config_path)
           if filesystem.exist?(file_name)


### PR DESCRIPTION
On large repos, `init` can take long enough to scan for engines that it
can feel hung/unresponsive since it outputs nothing until after it's
calculated the full `.codeclimate.yml`.

This adds a brief message to let the user know that work is happening.

I also added a status message about generating the default config for
engines: we output messages if we don't generate a config for an
engine because the file already exists, or if we do generate the file,
but we never tell the user we *are* going to generate configuration for engines:
without that context, telling them we decided not to copy something  we never
mentioned we might copy in the first place is odd. Especially in the existing-yaml case,
when there's a decent chance *all* of the files we might copy already exist.

FWIW I tried to user `Analyzer::Spinner` here so the status line could
get some nice animation. Something within `create_codeclimate_yaml` must
be heavily blocking on IO or something, though, because the thread to
animate the spinner was getting woken very sporadically, resulting in a
very slow & unreliable spin animation. For now I think it's preferable
to have static text.