### PR TITLE
Init: don't create engine configs when inappropriate

### DIFF
--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -121,7 +121,8 @@ module CC::CLI
         it "still generates default config files" do
           filesystem.exist?(".codeclimate.yml").must_equal(false)
 
-          File.new(".codeclimate.yml", "w")
+          yaml = "---\nengines:\n  rubocop:\n    enabled: true"
+          File.write(".codeclimate.yml", yaml)
 
           filesystem.exist?(".codeclimate.yml").must_equal(true)
 
@@ -129,7 +130,7 @@ module CC::CLI
 
           init.expects(:create_default_engine_configs)
 
-          _, stderr, exit_code = capture_io_and_exit_code do
+          capture_io_and_exit_code do
             init.run
           end
         end


### PR DESCRIPTION
Because of the behavior where we create engine configs even if a
`.codeclimate.yml` exists, there was a case where
`#create_default_engine_configs` would do the wrong thing: that method
still called `#available_engines` on `ConfigGenerator` to decide which
engines to create configs for. However, in the case of a
`.codeclimate.yml` created or edited by the user, there could be engines
that `available_engines` considers available, but that are not enabled
in the yaml. In that case, this method would create config files
for engines the user isn't using.

This changes the behavior to read the engines from the
`.codeclimate.yml`, since it must exist by the time this method is
called. As a bonus, in cases where the `.codeclimate.yml` already
existed & we didn't generate it, reading this from the yaml can be much
faster than using the `ConfigGenerator` logic.