### PR TITLE
Run specs in docker, fix race condition

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
 .git
 .bundle
+*.md
+Makefile
+bin/prep-release
+bin/release
+circle.yml
+pkg
+tags

--- a/circle.yml
+++ b/circle.yml
@@ -1,27 +1,17 @@
 machine:
   services:
     - docker
-  environment:
-    CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-    PRIVATE_REGISTRY: us.gcr.io/code_climate
 
 dependencies:
   override:
     # Used by container_spec
     - docker pull alpine
-    - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
-    - bundle install
+    - make image
 
 test:
   override:
-    - bundle exec rake
+    - make citest
 
-deployment:
-  registry:
-    branch: master
-    commands:
-      - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
-      - curl https://sdk.cloud.google.com | bash
-      - gcloud auth activate-service-account --key-file /tmp/gcloud_key.json
-      - gcloud docker -a
-      - docker push $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -172,6 +172,7 @@ module CC
       def reap_running_container(message)
         Analyzer.logger.warn("killing container name=#{@name} message=#{message.inspect}")
         POSIX::Spawn::Child.new("docker", "kill", @name)
+        POSIX::Spawn::Child.new("docker", "wait", @name, timeout: 5.minutes)
       end
 
       def timeout


### PR DESCRIPTION
I went with separate test and citest make targets (vs "test: image test_only")
because running on CI is also different in that it should pass the CI-related
enviroment variables too.

d845ec6 has details about the race condition but not the fix, d0ee4b3 actually
implements what I think is a real fix.

/cc @codeclimate/review