### PR TITLE
Simplify exclude_paths generated by init

### DIFF
--- a/lib/cc/cli/config.rb
+++ b/lib/cc/cli/config.rb
@@ -21,13 +21,7 @@ module CC
 
       def add_exclude_paths(paths)
         config["exclude_paths"] ||= []
-        config["exclude_paths"] += paths.map do |path|
-          if path.ends_with?("/")
-            "#{path}**/*"
-          else
-            path
-          end
-        end
+        config["exclude_paths"] |= paths
       end
 
       private

--- a/spec/cc/cli/config_spec.rb
+++ b/spec/cc/cli/config_spec.rb
@@ -41,7 +41,7 @@ module CC::CLI
         config.add_exclude_paths(["foo/"])
 
         exclude_paths = YAML.load(config.to_yaml)["exclude_paths"]
-        exclude_paths.must_equal(["foo/**/*"])
+        exclude_paths.must_equal(["foo/"])
       end
 
       it "does not glob paths that aren't directories" do

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -37,7 +37,7 @@ module CC::CLI
               "rubocop" => { "enabled"=>true },
             },
             "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
-            "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
+            "exclude_paths" => ["config/", "spec/", "vendor/"],
           })
 
           CC::Yaml.parse(new_content).errors.must_be_empty
@@ -178,7 +178,7 @@ module CC::CLI
               "rubocop" => { "enabled"=>true },
             },
             "ratings" => { "paths" => ["**.css", "**.inc", "**.js", "**.jsx", "**.module", "**.php", "**.py", "**.rb"] },
-            "exclude_paths" => ["config/**/*", "spec/**/*", "vendor/**/*"],
+            "exclude_paths" => ["config/", "spec/", "vendor/"],
           })
 
           CC::Yaml.parse(new_content).errors.must_be_empty


### PR DESCRIPTION
Previously we appended `**/*` to all auto-excluded directories: that's
no longer required by the new exclude behavior, so no reason to keep it.

cc @codeclimate/review