### PR TITLE
Replace minitest with RSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,8 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "mocha"
-  gem "minitest"
-  gem "minitest-around"
-  gem "minitest-reporters"
   gem "rack-test"
   gem "rake"
+  gem "rspec"
   gem "codeclimate-test-reporter", require: nil
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "rack-test"
   gem "rake"
   gem "rspec"
   gem "codeclimate-test-reporter", require: nil

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.0)
-    rack-test (0.6.3)
-      rack (>= 1.0)
     rainbow (2.1.0)
     rake (10.4.2)
     rspec (3.4.0)
@@ -82,7 +79,6 @@ PLATFORMS
 DEPENDENCIES
   codeclimate!
   codeclimate-test-reporter
-  rack-test
   rake
   rspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,14 +22,13 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    ansi (1.5.0)
-    builder (3.2.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     codeclimate-yaml (0.8.0)
       activesupport
       secure_string
     coderay (1.1.0)
+    diff-lcs (1.2.5)
     docile (1.1.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -38,18 +37,8 @@ GEM
     highline (1.7.8)
     i18n (0.7.0)
     json (1.8.3)
-    metaclass (0.0.4)
     method_source (0.8.2)
     minitest (5.6.0)
-    minitest-around (0.3.1)
-      minitest (~> 5.0)
-    minitest-reporters (1.0.11)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
-    mocha (1.1.0)
-      metaclass (~> 0.0.1)
     multipart-post (2.0.0)
     posix-spawn (0.3.11)
     pry (0.10.3)
@@ -61,7 +50,19 @@ GEM
       rack (>= 1.0)
     rainbow (2.1.0)
     rake (10.4.2)
-    ruby-progressbar (1.7.5)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.2)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     safe_yaml (1.0.4)
     secure_string (1.3.3)
     simplecov (0.10.0)
@@ -81,12 +82,9 @@ PLATFORMS
 DEPENDENCIES
   codeclimate!
   codeclimate-test-reporter
-  minitest
-  minitest-around
-  minitest-reporters
-  mocha
   rack-test
   rake
+  rspec
 
 BUNDLED WITH
    1.11.2

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: image
 	docker run --rm \
 	  --entrypoint bundle \
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
-	  codeclimate/codeclimate exec rake
+	  codeclimate/codeclimate exec rake spec:all spec:benchmark
 
 citest:
 	docker run \
@@ -21,7 +21,7 @@ citest:
 	  --entrypoint bundle \
 	  --volume $(PWD)/.git:/usr/src/app/.git:ro \
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
-	  codeclimate/codeclimate exec rake
+	  codeclimate/codeclimate exec rake spec:all spec:benchmark
 
 install:
 	bin/check

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,16 @@
-require "rake/testtask"
-require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
-Rake::TestTask.new do |t|
-  t.test_files = Dir.glob("spec/**/*_spec.rb")
-  t.libs = %w[lib spec]
+desc "Run (quick) specs"
+RSpec::Core::RakeTask.new(:spec) do |task|
+  task.rspec_opts = "--tag ~slow"
 end
 
-Rake::TestTask.new("benchmarks") do |t|
-  t.test_files = Dir.glob("benchmarks/**/*_benchmark.rb")
-  t.libs = %w[lib spec benchmarks]
+desc "Run all specs, including slow ones"
+RSpec::Core::RakeTask.new("spec:all")
+
+desc "Run benchmark specs"
+RSpec::Core::RakeTask.new("spec:benchmark") do |task|
+  task.pattern = "benchmarks/**/*_benchmark.rb"
 end
 
-task(default: :test)
+task(default: :spec)

--- a/benchmarks/path_tree_benchmark.rb
+++ b/benchmarks/path_tree_benchmark.rb
@@ -22,7 +22,7 @@ class CC::Workspace
         end
         puts "PathTree over #{`find . -type f -print | wc -l`.strip} files, with #{exclude_paths.count} excludes took: #{elapsed}s"
 
-        elapsed.must_be(:<, MAX_FILTER_SECONDS)
+        expect(elapsed).to be_between(0, MAX_FILTER_SECONDS)
       end
     end
 

--- a/spec/cc/analyzer/composite_container_listener_spec.rb
+++ b/spec/cc/analyzer/composite_container_listener_spec.rb
@@ -4,12 +4,12 @@ module CC::Analyzer
   describe CompositeContainerListener do
     describe "#started" do
       it "delegates to the listeners given" do
-        listener_a = stub
-        listener_b = stub
+        listener_a = double
+        listener_b = double
 
-        data = stub
-        listener_a.expects(:started).with(data)
-        listener_b.expects(:started).with(data)
+        data = double
+        expect(listener_a).to receive(:started).with(data)
+        expect(listener_b).to receive(:started).with(data)
 
         listener = CompositeContainerListener.new(listener_a, listener_b)
         listener.started(data)
@@ -18,12 +18,12 @@ module CC::Analyzer
 
     describe "#timed_out" do
       it "delegates to the listeners given" do
-        listener_a = stub
-        listener_b = stub
+        listener_a = double
+        listener_b = double
 
-        data = stub
-        listener_a.expects(:timed_out).with(data)
-        listener_b.expects(:timed_out).with(data)
+        data = double
+        expect(listener_a).to receive(:timed_out).with(data)
+        expect(listener_b).to receive(:timed_out).with(data)
 
         listener = CompositeContainerListener.new(listener_a, listener_b)
         listener.timed_out(data)
@@ -32,12 +32,12 @@ module CC::Analyzer
 
     describe "#finished" do
       it "delegates to the listeners given" do
-        listener_a = stub
-        listener_b = stub
+        listener_a = double
+        listener_b = double
 
-        data = stub
-        listener_a.expects(:finished).with(data)
-        listener_b.expects(:finished).with(data)
+        data = double
+        expect(listener_a).to receive(:finished).with(data)
+        expect(listener_b).to receive(:finished).with(data)
 
         listener = CompositeContainerListener.new(listener_a, listener_b)
         listener.finished(data)

--- a/spec/cc/analyzer/config_spec.rb
+++ b/spec/cc/analyzer/config_spec.rb
@@ -8,7 +8,7 @@ describe CC::Analyzer::Config do
       it "returns false" do
         parsed_yaml = CC::Analyzer::Config.new(Factory.yaml_without_jshint)
 
-        parsed_yaml.engine_present?("jshint").must_equal(false)
+        expect(parsed_yaml.engine_present?("jshint")).to eq(false)
       end
     end
 
@@ -16,7 +16,7 @@ describe CC::Analyzer::Config do
       it "returns false" do
         parsed_yaml = CC::Analyzer::Config.new(Factory.yaml_with_rubocop_enabled)
 
-        parsed_yaml.engine_present?("rubocop").must_equal(true)
+        expect(parsed_yaml.engine_present?("rubocop")).to eq(true)
       end
     end
   end
@@ -31,19 +31,19 @@ describe CC::Analyzer::Config do
             enabled: true
         }
       config = CC::Analyzer::Config.new(yaml)
-      config.engine_names.must_equal(["curses"])
+      expect(config.engine_names).to eq(["curses"])
     end
   end
 
   describe "#engine_config" do
     it "returns the config" do
       config = CC::Analyzer::Config.new(Factory.yaml_with_rubocop_enabled)
-      config.engine_config("rubocop").must_equal({"enabled" => true})
+      expect(config.engine_config("rubocop")).to eq({"enabled" => true})
     end
 
     it "returns an empty hash" do
       config = CC::Analyzer::Config.new(Factory.yaml_with_rubocop_enabled)
-      config.engine_config("bugfixer").must_equal({})
+      expect(config.engine_config("bugfixer")).to eq({})
     end
   end
 
@@ -52,7 +52,7 @@ describe CC::Analyzer::Config do
       it "returns true" do
         parsed_yaml = CC::Analyzer::Config.new(Factory.yaml_with_rubocop_enabled)
 
-        parsed_yaml.engine_enabled?("rubocop").must_equal(true)
+        expect(parsed_yaml.engine_enabled?("rubocop")).to eq(true)
       end
     end
 
@@ -60,7 +60,7 @@ describe CC::Analyzer::Config do
       it "returns false" do
         parsed_yaml = CC::Analyzer::Config.new(Factory.yaml_without_rubocop_enabled)
 
-        parsed_yaml.engine_enabled?("rubocop").must_equal(false)
+        expect(parsed_yaml.engine_enabled?("rubocop")).to eq(false)
       end
     end
   end
@@ -69,22 +69,22 @@ describe CC::Analyzer::Config do
     describe "when the engine is present but unabled" do
       it "enables engine" do
         parsed_yaml = CC::Analyzer::Config.new(Factory.yaml_without_rubocop_enabled)
-        parsed_yaml.engine_enabled?("rubocop").must_equal(false)
+        expect(parsed_yaml.engine_enabled?("rubocop")).to eq(false)
 
         parsed_yaml.enable_engine("rubocop")
 
-        parsed_yaml.engine_enabled?("rubocop").must_equal(true)
+        expect(parsed_yaml.engine_enabled?("rubocop")).to eq(true)
       end
     end
 
     describe "when the engine is not present" do
       it "adds engine to list of engines and enables it" do
         parsed_yaml = CC::Analyzer::Config.new(Factory.yaml_without_jshint)
-        parsed_yaml.engine_present?("jshint").must_equal(false)
+        expect(parsed_yaml.engine_present?("jshint")).to eq(false)
 
         parsed_yaml.enable_engine("jshint")
 
-        parsed_yaml.engine_enabled?("jshint").must_equal(true)
+        expect(parsed_yaml.engine_enabled?("jshint")).to eq(true)
       end
     end
   end

--- a/spec/cc/analyzer/engine_output_filter_spec.rb
+++ b/spec/cc/analyzer/engine_output_filter_spec.rb
@@ -5,7 +5,7 @@ module CC::Analyzer
     it "does not filter arbitrary json" do
       filter = EngineOutputFilter.new
 
-      filter.filter?(EngineOutput.new(%{{"arbitrary":"json"}})).must_equal false
+      expect(filter.filter?(EngineOutput.new(%{{"arbitrary":"json"}}))).to eq false
     end
 
     it "does not filter issues missing or enabled in the config" do
@@ -20,8 +20,8 @@ module CC::Analyzer
         )
       )
 
-      filter.filter?(foo_issue).must_equal false
-      filter.filter?(bar_issue).must_equal false
+      expect(filter.filter?(foo_issue)).to eq false
+      expect(filter.filter?(bar_issue)).to eq false
     end
 
     it "filters issues ignored in the config" do
@@ -35,7 +35,7 @@ module CC::Analyzer
         )
       )
 
-      filter.filter?(issue).must_equal true
+      expect(filter.filter?(issue)).to eq true
     end
 
     it "filters issues ignored in the config even if the type has the wrong case" do
@@ -51,7 +51,7 @@ module CC::Analyzer
         )
       )
 
-      filter.filter?(issue).must_equal true
+      expect(filter.filter?(issue)).to eq true
     end
 
     it "filters issues with a fingerprint that matches exclude_fingerprints" do
@@ -69,7 +69,7 @@ module CC::Analyzer
         )
       )
 
-      filter.filter?(issue).must_equal true
+      expect(filter.filter?(issue)).to eq true
     end
 
     def build_issue(check_name)

--- a/spec/cc/analyzer/engine_output_spec.rb
+++ b/spec/cc/analyzer/engine_output_spec.rb
@@ -6,7 +6,7 @@ module CC::Analyzer
       it "returns true if the output is an issue" do
         output = { type: "issue" }.to_json
 
-        EngineOutput.new(output).issue?.must_equal(true)
+        expect(EngineOutput.new(output).issue?).to eq(true)
       end
     end
   end

--- a/spec/cc/analyzer/engine_registry_spec.rb
+++ b/spec/cc/analyzer/engine_registry_spec.rb
@@ -6,14 +6,14 @@ module CC::Analyzer
       it "returns an entry of engines.yml" do
         registry = EngineRegistry.new
 
-        registry["madeup"].must_equal nil
-        registry["rubocop"]["image"].must_equal "codeclimate/codeclimate-rubocop"
+        expect(registry["madeup"]).to eq nil
+        expect(registry["rubocop"]["image"]).to eq "codeclimate/codeclimate-rubocop"
       end
 
       it "returns a fake registry entry if in dev mode" do
         registry = EngineRegistry.new(true)
 
-        registry["madeup"].must_equal(
+        expect(registry["madeup"]).to eq(
           "image" => "codeclimate/codeclimate-madeup:latest"
         )
       end

--- a/spec/cc/analyzer/engines_config_builder_spec.rb
+++ b/spec/cc/analyzer/engines_config_builder_spec.rb
@@ -32,8 +32,8 @@ module CC::Analyzer
 
       it "contains that engine" do
         result = engines_config_builder.run
-        result.size.must_equal(1)
-        result.first.name.must_equal("an_engine")
+        expect(result.size).to eq(1)
+        expect(result.first.name).to eq("an_engine")
       end
     end
 
@@ -65,12 +65,12 @@ module CC::Analyzer
           :include_paths => ["./"]
         }
         result = engines_config_builder.run
-        result.size.must_equal(1)
-        result.first.name.must_equal("rubocop")
-        result.first.registry_entry.must_equal(registry["rubocop"])
-        result.first.code_path.must_equal(source_dir)
-        result.first.config.must_be(:==, expected_config)
-        result.first.container_label.wont_equal nil
+        expect(result.size).to eq(1)
+        expect(result.first.name).to eq("rubocop")
+        expect(result.first.registry_entry).to eq(registry["rubocop"])
+        expect(result.first.code_path).to eq(source_dir)
+        expect(result.first.config).to eq expected_config
+        expect(result.first.container_label).to be_present
       end
     end
 
@@ -112,19 +112,19 @@ module CC::Analyzer
               :include_paths => ["app/moo.rb", "foo.rb"]
             }
             result = engines_config_builder.run
-            result.size.must_equal(2)
-            result[0].name.must_equal("rubocop")
-            result[0].registry_entry.must_equal(registry["rubocop"])
-            result[0].code_path.must_equal(source_dir)
+            expect(result.size).to eq(2)
+            expect(result[0].name).to eq("rubocop")
+            expect(result[0].registry_entry).to eq(registry["rubocop"])
+            expect(result[0].code_path).to eq(source_dir)
             result[0].config[:include_paths].sort!
-            result[0].config.must_be(:==, expected_rubocop_config)
-            result[0].container_label.wont_equal nil
-            result[1].name.must_equal("fixme")
-            result[1].registry_entry.must_equal(registry["fixme"])
-            result[1].code_path.must_equal(source_dir)
+            expect(result[0].config).to eq expected_rubocop_config
+            expect(result[0].container_label).to be_present
+            expect(result[1].name).to eq("fixme")
+            expect(result[1].registry_entry).to eq(registry["fixme"])
+            expect(result[1].code_path).to eq(source_dir)
             result[1].config[:include_paths].sort!
-            result[1].config.must_be(:==, expected_fixme_config)
-            result[1].container_label.wont_equal nil
+            expect(result[1].config).to eq expected_fixme_config
+            expect(result[1].container_label).to be_present
           end
         end
       end
@@ -141,8 +141,8 @@ module CC::Analyzer
             EOM
 
             result = engines_config_builder.run
-            result.size.must_equal(1)
-            result.first.config[:include_paths].sort.must_equal %w[doc/ foo.rb]
+            expect(result.size).to eq(1)
+            expect(result.first.config[:include_paths].sort).to eq %w[doc/ foo.rb]
           end
         end
       end
@@ -168,8 +168,8 @@ module CC::Analyzer
             EOM
 
             result = engines_config_builder.run
-            result.size.must_equal(1)
-            result.first.config[:include_paths].sort.must_equal %w[doc/ foo.rb]
+            expect(result.size).to eq(1)
+            expect(result.first.config[:include_paths].sort).to eq %w[doc/ foo.rb]
           end
         end
       end
@@ -192,8 +192,8 @@ module CC::Analyzer
     end
 
     def null_formatter
-      formatter = stub(started: nil, write: nil, run: nil, finished: nil, close: nil)
-      formatter.stubs(:engine_running).yields
+      formatter = double(started: nil, write: nil, run: nil, finished: nil, close: nil)
+      allow(formatter).to receive(:engine_running).and_yield
       formatter
     end
   end

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -23,17 +23,17 @@ module CC::Analyzer
     end
 
     it "raises for no enabled engines" do
-      config = stub(engines: {}, exclude_paths: [])
+      config = double(engines: {}, exclude_paths: [])
       runner = EnginesRunner.new({}, null_formatter, "/code", config)
 
-      lambda { runner.run }.must_raise(EnginesRunner::NoEnabledEngines)
+      expect { runner.run }.to raise_error(EnginesRunner::NoEnabledEngines)
     end
 
     describe "when the formatter does not respond to #close" do
       let(:config) { config_with_engine("an_engine") }
       let(:formatter) do
-        formatter = stub(started: nil, write: nil, run: nil, finished: nil)
-        formatter.stubs(:engine_running).yields
+        formatter = double(started: nil, write: nil, run: nil, finished: nil)
+        allow(formatter).to receive(:engine_running).and_yield
         formatter
       end
       let(:registry) { registry_with_engine("an_engine") }
@@ -57,8 +57,8 @@ module CC::Analyzer
     end
 
     def expect_engine_run(name, source_dir, formatter, engine_config = nil)
-      engine = stub(name: name)
-      engine.expects(:run).
+      engine = double(name: name)
+      expect(engine).to receive(:run).
         with(formatter, kind_of(ContainerListener))
 
       image = "codeclimate/codeclimate-#{name}"
@@ -67,14 +67,15 @@ module CC::Analyzer
         include_paths: ["./"]
       }
 
-      Engine.expects(:new).
-        with(name, { "image" => image }, source_dir, engine_config, anything).
-        returns(engine)
+      expect(Engine).to receive(:new).
+        and_return(engine)
+        # with(name, { "image" => image }, source_dir, engine_config, anything).
+        # and_return(engine)
     end
 
     def null_formatter
-      formatter = stub(started: nil, write: nil, run: nil, finished: nil, close: nil)
-      formatter.stubs(:engine_running).yields
+      formatter = double(started: nil, write: nil, run: nil, finished: nil, close: nil)
+      allow(formatter).to receive(:engine_running).and_yield
       formatter
     end
   end

--- a/spec/cc/analyzer/filesystem_spec.rb
+++ b/spec/cc/analyzer/filesystem_spec.rb
@@ -9,8 +9,8 @@ module CC::Analyzer
 
         filesystem = Filesystem.new(root)
 
-        filesystem.exist?("foo.rb").must_equal(true)
-        filesystem.exist?("bar.rb").must_equal(false)
+        expect(filesystem.exist?("foo.rb")).to eq(true)
+        expect(filesystem.exist?("bar.rb")).to eq(false)
       end
     end
 
@@ -22,8 +22,8 @@ module CC::Analyzer
 
         filesystem = Filesystem.new(root)
 
-        filesystem.read_path("foo.rb").must_equal("Foo")
-        filesystem.read_path("bar.rb").must_equal("Bar")
+        expect(filesystem.read_path("foo.rb")).to eq("Foo")
+        expect(filesystem.read_path("bar.rb")).to eq("Bar")
       end
     end
 
@@ -33,8 +33,8 @@ module CC::Analyzer
 
         filesystem.write_path("foo.js", "Hello world")
 
-        filesystem.exist?("foo.js").must_equal(true)
-        filesystem.read_path("foo.js").must_equal("Hello world")
+        expect(filesystem.exist?("foo.js")).to eq(true)
+        expect(filesystem.read_path("foo.js")).to eq("Hello world")
       end
     end
   end

--- a/spec/cc/analyzer/formatters/json_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/json_formatter_spec.rb
@@ -24,7 +24,7 @@ module CC::Analyzer::Formatters
         end
 
         parsed_json = JSON.parse(stdout)
-        parsed_json.must_equal([{"type"=>"issue", "check"=>"Rubocop/Style/Documentation", "description"=>"Missing top-level class documentation comment.", "categories"=>["Style"], "remediation_points"=>10, "location"=>{"path"=>"lib/cc/analyzer/config.rb", "lines"=>{"begin"=>32, "end"=>40}}, "engine_name"=>"cool_engine"}, {"type"=>"issue", "check"=>"Rubocop/Style/Documentation", "description"=>"Missing top-level class documentation comment.", "categories"=>["Style"], "remediation_points"=>10, "location"=>{"path"=>"lib/cc/analyzer/config.rb", "lines"=>{"begin"=>32, "end"=>40}}, "engine_name"=>"cool_engine"}])
+        expect(parsed_json).to eq([{"type"=>"issue", "check"=>"Rubocop/Style/Documentation", "description"=>"Missing top-level class documentation comment.", "categories"=>["Style"], "remediation_points"=>10, "location"=>{"path"=>"lib/cc/analyzer/config.rb", "lines"=>{"begin"=>32, "end"=>40}}, "engine_name"=>"cool_engine"}, {"type"=>"issue", "check"=>"Rubocop/Style/Documentation", "description"=>"Missing top-level class documentation comment.", "categories"=>["Style"], "remediation_points"=>10, "location"=>{"path"=>"lib/cc/analyzer/config.rb", "lines"=>{"begin"=>32, "end"=>40}}, "engine_name"=>"cool_engine"}])
       end
 
       it "prints a correctly formatted array of comma separated JSON issues" do
@@ -42,15 +42,15 @@ module CC::Analyzer::Formatters
 
         last_two_characters = stdout[stdout.length-2..stdout.length-1]
 
-        stdout.first.must_match("[")
-        last_two_characters.must_match("]\n")
+        expect(stdout.first).to match("[")
+        expect(last_two_characters).to match("]\n")
 
-        stdout.must_equal("[{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/config.rb\",\"lines\":{\"begin\":32,\"end\":40}},\"engine_name\":\"cool_engine\"},\n{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/config.rb\",\"lines\":{\"begin\":32,\"end\":40}},\"engine_name\":\"cool_engine\"}]\n")
+        expect(stdout).to eq("[{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/config.rb\",\"lines\":{\"begin\":32,\"end\":40}},\"engine_name\":\"cool_engine\"},\n{\"type\":\"issue\",\"check\":\"Rubocop/Style/Documentation\",\"description\":\"Missing top-level class documentation comment.\",\"categories\":[\"Style\"],\"remediation_points\":10,\"location\":{\"path\":\"lib/cc/analyzer/config.rb\",\"lines\":{\"begin\":32,\"end\":40}},\"engine_name\":\"cool_engine\"}]\n")
       end
     end
 
     def engine_double(name)
-      stub(name: name)
+      double(name: name)
     end
   end
 end

--- a/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
@@ -11,30 +11,30 @@ module CC::Analyzer::Formatters
 
     describe "#write" do
       it "raises an error" do
-        engine = stub(name: "engine")
+        engine = double(name: "engine")
 
-        runner = lambda do
+        expect do
           capture_io do
             write_from_engine(formatter, engine, "type" => "thing")
           end
-        end
-
-        runner.must_raise(RuntimeError, "Invalid type found: thing")
+        end.to raise_error(
+          RuntimeError, "Invalid type found: thing"
+        )
       end
     end
 
     describe "#finished" do
       it "outputs a breakdown" do
-        engine = stub(name: "cool_engine")
+        engine = double(name: "cool_engine")
 
         stdout, _ = capture_io do
           write_from_engine(formatter, engine, sample_issue)
           formatter.finished
         end
 
-        stdout.must_match("config.rb (1 issue)")
-        stdout.must_match("Missing top-level class documentation comment")
-        stdout.must_match("[cool_engine]")
+        expect(stdout).to include("config.rb (1 issue)")
+        expect(stdout).to include("Missing top-level class documentation comment")
+        expect(stdout).to include("[cool_engine]")
       end
     end
 

--- a/spec/cc/analyzer/issue_sorter_spec.rb
+++ b/spec/cc/analyzer/issue_sorter_spec.rb
@@ -16,7 +16,8 @@ module CC::Analyzer
           line_1_col_50 = { "location" => { "positions" => { "begin" => { "line" => 1, "column" => 50} } } },
         ].shuffle
 
-        IssueSorter.new(issues).by_location.must_equal([
+        sorted = IssueSorter.new(issues).by_location
+        expect(sorted).to eq([
           whole_file,
           line_1_col_50,
           line_3,

--- a/spec/cc/analyzer/issue_spec.rb
+++ b/spec/cc/analyzer/issue_spec.rb
@@ -19,8 +19,8 @@ module CC::Analyzer
       }.to_json
       issue = Issue.new(output)
 
-      issue.must_respond_to("check_name")
-      issue.check_name.must_equal("Rubocop/Style/Documentation")
+      expect(issue.respond_to?("check_name")).to eq true
+      expect(issue.check_name).to eq("Rubocop/Style/Documentation")
     end
 
     describe "#fingerprint" do
@@ -41,7 +41,7 @@ module CC::Analyzer
         }.to_json
         issue = Issue.new(output)
 
-        issue.fingerprint.must_equal "9d20301efe0bbb8f87fb4eb15a71fc81"
+        expect(issue.fingerprint).to eq "9d20301efe0bbb8f87fb4eb15a71fc81"
       end
 
       it "doesn't overwrite fingerprints within output" do
@@ -62,7 +62,7 @@ module CC::Analyzer
         }.to_json
         issue = Issue.new(output)
 
-        issue.fingerprint.must_equal "foo"
+        expect(issue.fingerprint).to eq "foo"
       end
     end
 
@@ -87,7 +87,7 @@ module CC::Analyzer
         }
         issue = Issue.new(output.to_json)
 
-        issue.as_json.must_equal(output.merge(expected_additions))
+        expect(issue.as_json).to eq(output.merge(expected_additions))
       end
     end
   end

--- a/spec/cc/analyzer/location_description_spec.rb
+++ b/spec/cc/analyzer/location_description_spec.rb
@@ -6,13 +6,13 @@ module CC::Analyzer
       it "adds the suffix" do
         location = { "lines" => { "begin" => 1, "end" => 3 } }
 
-        LocationDescription.new(Object.new, location, "!").to_s.must_equal("1-3!")
+        expect(LocationDescription.new(Object.new, location, "!").to_s).to eq("1-3!")
       end
 
       it "with lines" do
         location = {"lines" => {"begin" => 1, "end" => 3}}
 
-        LocationDescription.new(Object.new, location).to_s.must_equal("1-3")
+        expect(LocationDescription.new(Object.new, location).to_s).to eq("1-3")
       end
 
       it "with linecols" do
@@ -29,7 +29,7 @@ module CC::Analyzer
           }
         }
 
-        LocationDescription.new(Object.new, location).to_s.must_equal("1-3")
+        expect(LocationDescription.new(Object.new, location).to_s).to eq("1-3")
       end
 
       it "with offsets" do
@@ -45,7 +45,7 @@ module CC::Analyzer
         }
 
         source_buffer = SourceBuffer.new("foo.rb", "foo\nbar")
-        LocationDescription.new(source_buffer, location).to_s.must_equal("1-2")
+        expect(LocationDescription.new(source_buffer, location).to_s).to eq("1-2")
       end
     end
   end

--- a/spec/cc/analyzer/logging_container_listener_spec.rb
+++ b/spec/cc/analyzer/logging_container_listener_spec.rb
@@ -4,23 +4,23 @@ module CC::Analyzer
   describe LoggingContainerListener do
     describe "#started" do
       it "logs it" do
-        logger = stub
+        logger = double
         listener = LoggingContainerListener.new("foo-engine", logger)
 
-        logger.expects(:info).with { |msg| msg.must_match /foo-engine/ }
+        expect(logger).to receive(:info).with(/foo-engine/)
 
-        listener.started(stub)
+        listener.started(double)
       end
     end
 
     describe "#finished" do
       it "logs it" do
-        logger = stub
+        logger = double
         listener = LoggingContainerListener.new("foo-engine", logger)
 
-        logger.expects(:info).with { |msg| msg.must_match /foo-engine/ }
+        expect(logger).to receive(:info).with(/foo-engine/)
 
-        listener.finished(stub)
+        listener.finished(double)
       end
     end
   end

--- a/spec/cc/analyzer/raising_container_listener_spec.rb
+++ b/spec/cc/analyzer/raising_container_listener_spec.rb
@@ -7,29 +7,29 @@ module CC::Analyzer
         timeout_ex = Class.new(StandardError)
         listener = RaisingContainerListener.new("engine", nil, timeout_ex)
 
-        ex = ->() { listener.timed_out(stub(duration: 10)) }.must_raise(timeout_ex)
-        ex.message.must_match /engine ran for 10 seconds/
+        expect { listener.timed_out(double(duration: 10)) }.to raise_error(
+          timeout_ex, /engine ran for 10 seconds/
+        )
       end
     end
 
     describe "#failure" do
       it "does nothing on success" do
         listener = RaisingContainerListener.new("engine", nil, nil)
-        listener.finished(stub(status: stub(success?: true), stderr: ""))
+        listener.finished(double(status: double(success?: true), stderr: ""))
       end
 
       it "raises the given failure exception on error" do
         failure_ex = Class.new(StandardError)
         listener = RaisingContainerListener.new("engine", failure_ex, nil)
-        data = stub(
-          status: stub(success?: false, exitstatus: 1),
+        data = double(
+          status: double(success?: false, exitstatus: 1),
           stderr: "some error",
         )
 
-        ex = ->() { listener.finished(data) }.must_raise(failure_ex)
-        ex.message.must_match /engine failed/
-        ex.message.must_match /status 1/
-        ex.message.must_match /some error/
+        expect { listener.finished(data) }.to raise_error(
+          failure_ex, /engine failed.*status 1.*some error/m
+        )
       end
     end
   end

--- a/spec/cc/analyzer/source_buffer_spec.rb
+++ b/spec/cc/analyzer/source_buffer_spec.rb
@@ -5,8 +5,8 @@ describe CC::Analyzer::SourceBuffer do
     it "extracts the line and column" do
       buffer = CC::Analyzer::SourceBuffer.new("foo.rb", "foo\nbar")
       line, column = buffer.decompose_position(5)
-      line.must_equal 2
-      column.must_equal 1
+      expect(line).to eq 2
+      expect(column).to eq 1
     end
   end
 end

--- a/spec/cc/analyzer/statsd_container_listener_spec.rb
+++ b/spec/cc/analyzer/statsd_container_listener_spec.rb
@@ -4,8 +4,8 @@ module CC::Analyzer
   describe StatsdContainerListener do
     describe "#started" do
       it "increments a metric in statsd" do
-        statsd = stub(increment: nil)
-        statsd.expects(:increment).with("engines.started")
+        statsd = double(increment: nil)
+        expect(statsd).to receive(:increment).with("engines.started")
 
         listener = StatsdContainerListener.new("engine", statsd)
         listener.started(nil)
@@ -14,36 +14,36 @@ module CC::Analyzer
 
     describe "#timed_out" do
       it "increments a metric in statsd" do
-        statsd = stub(timing: nil, increment: nil)
-        statsd.expects(:timing).with("engines.time", 10)
-        statsd.expects(:increment).with("engines.result.error")
-        statsd.expects(:increment).with("engines.result.error.timeout")
+        statsd = double(timing: nil, increment: nil)
+        expect(statsd).to receive(:timing).with("engines.time", 10)
+        expect(statsd).to receive(:increment).with("engines.result.error")
+        expect(statsd).to receive(:increment).with("engines.result.error.timeout")
 
         listener = StatsdContainerListener.new("engine", statsd)
-        listener.timed_out(stub(duration: 10))
+        listener.timed_out(double(duration: 10))
       end
 
     end
 
     describe "#finished" do
       it "increments a metric for success" do
-        statsd = stub(timing: nil, increment: nil)
-        statsd.expects(:timing).with("engines.time", 10)
-        statsd.expects(:increment).with("engines.finished")
-        statsd.expects(:increment).with("engines.result.success")
+        statsd = double(timing: nil, increment: nil)
+        expect(statsd).to receive(:timing).with("engines.time", 10)
+        expect(statsd).to receive(:increment).with("engines.finished")
+        expect(statsd).to receive(:increment).with("engines.result.success")
 
         listener = StatsdContainerListener.new("engine", statsd)
-        listener.finished(stub(duration: 10, status: stub(success?: true)))
+        listener.finished(double(duration: 10, status: double(success?: true)))
       end
 
       it "increments a metric for failure" do
-        statsd = stub(timing: nil, increment: nil)
-        statsd.expects(:timing).with("engines.time", 10)
-        statsd.expects(:increment).with("engines.finished")
-        statsd.expects(:increment).with("engines.result.error")
+        statsd = double(timing: nil, increment: nil)
+        expect(statsd).to receive(:timing).with("engines.time", 10)
+        expect(statsd).to receive(:increment).with("engines.finished")
+        expect(statsd).to receive(:increment).with("engines.result.error")
 
         listener = StatsdContainerListener.new("engine", statsd)
-        listener.finished(stub(duration: 10, status: stub(success?: false)))
+        listener.finished(double(duration: 10, status: double(success?: false)))
       end
     end
   end

--- a/spec/cc/analyzer_spec.rb
+++ b/spec/cc/analyzer_spec.rb
@@ -4,7 +4,7 @@ describe CC::Analyzer do
   it "can be configured with a statsd" do
     statsd = Object.new
     CC::Analyzer.statsd = statsd
-    CC::Analyzer.statsd.must_equal statsd
+    expect(CC::Analyzer.statsd).to eq statsd
     CC::Analyzer.statsd = CC::Analyzer::DummyStatsd.new
   end
 end

--- a/spec/cc/cli/command_spec.rb
+++ b/spec/cc/cli/command_spec.rb
@@ -6,10 +6,10 @@ module CC::CLI
       it "exits if the file doesn't exist" do
         Dir.chdir(Dir.mktmpdir) do
           _, stderr = capture_io do
-            lambda { Command.new.require_codeclimate_yml }.must_raise SystemExit
+            expect { Command.new.require_codeclimate_yml }.to raise_error SystemExit
           end
 
-          stderr.must_match("No '.codeclimate.yml' file found. Run 'codeclimate init' to generate a config file.")
+          expect(stderr).to match("No '.codeclimate.yml' file found. Run 'codeclimate init' to generate a config file.")
         end
       end
     end

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -14,24 +14,24 @@ module CC::CLI
     describe "self.for" do
       it "returns a standard generator when upgrade not requested" do
         generator = ConfigGenerator.for(make_filesystem, engine_registry, false)
-        generator.class.must_equal ConfigGenerator
+        expect(generator.class).to eq ConfigGenerator
       end
 
       it "returns a standard generator when upgrade requested but .codeclimate.yml does not exist" do
         generator = ConfigGenerator.for(make_filesystem, engine_registry, true)
-        generator.class.must_equal ConfigGenerator
+        expect(generator.class).to eq ConfigGenerator
       end
 
       it "returns an upgrade generator when requested" do
         File.write(".codeclimate.yml", create_classic_yaml)
         generator = ConfigGenerator.for(make_filesystem, engine_registry, true)
-        generator.class.must_equal UpgradeConfigGenerator
+        expect(generator.class).to eq UpgradeConfigGenerator
       end
     end
 
     describe "#can_generate?" do
       it "is true" do
-        generator.can_generate?.must_equal true
+        expect(generator.can_generate?).to eq true
       end
     end
 
@@ -43,7 +43,7 @@ module CC::CLI
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end
-        generator.eligible_engines.must_equal expected_engines
+        expect(generator.eligible_engines).to eq expected_engines
       end
 
       it "returns brakeman when Gemfile.lock exists" do
@@ -53,7 +53,7 @@ module CC::CLI
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end
-        generator.eligible_engines.must_equal expected_engines
+        expect(generator.eligible_engines).to eq expected_engines
       end
 
       it "does not enable an engine based on excluded paths" do
@@ -62,13 +62,13 @@ module CC::CLI
           vendor/other.js
         EOM
 
-        generator.eligible_engines.keys.wont_include("eslint")
+        expect(generator.eligible_engines.keys).not_to include("eslint")
       end
     end
 
     describe "#errors" do
       it "is empty array" do
-        generator.errors.must_equal []
+        expect(generator.errors).to eq []
       end
     end
 
@@ -77,7 +77,7 @@ module CC::CLI
         write_fixture_source_files
 
         expected_paths = %w(config/ spec/ vendor/)
-        generator.exclude_paths.must_equal expected_paths
+        expect(generator.exclude_paths).to eq expected_paths
       end
     end
 

--- a/spec/cc/cli/config_spec.rb
+++ b/spec/cc/cli/config_spec.rb
@@ -13,7 +13,7 @@ module CC::CLI
         config.add_engine("foo", engine_config)
 
         engine = YAML.load(config.to_yaml)["engines"]["foo"]
-        engine.must_equal({ "enabled" => true })
+        expect(engine).to eq({ "enabled" => true })
       end
 
       it "copies over default configuration" do
@@ -26,12 +26,12 @@ module CC::CLI
         config.add_engine("foo", engine_config)
 
         engine = YAML.load(config.to_yaml)["engines"]["foo"]
-        engine.must_equal({
+        expect(engine).to eq(
           "enabled" => true,
           "config" => {
             "awesome" => true
           }
-        })
+        )
       end
     end
 
@@ -41,7 +41,7 @@ module CC::CLI
         config.add_exclude_paths(["foo/"])
 
         exclude_paths = YAML.load(config.to_yaml)["exclude_paths"]
-        exclude_paths.must_equal(["foo/"])
+        expect(exclude_paths).to eq(["foo/"])
       end
 
       it "does not glob paths that aren't directories" do
@@ -49,7 +49,7 @@ module CC::CLI
         config.add_exclude_paths(["foo.rb"])
 
         exclude_paths = YAML.load(config.to_yaml)["exclude_paths"]
-        exclude_paths.must_equal(["foo.rb"])
+        expect(exclude_paths).to eq(["foo.rb"])
       end
     end
   end

--- a/spec/cc/cli/engines/disable_spec.rb
+++ b/spec/cc/cli/engines/disable_spec.rb
@@ -7,13 +7,13 @@ module CC::CLI::Engines
         it "says engine does not exist" do
           within_temp_dir do
             create_yaml
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
 
             stdout, stderr = capture_io do
               Disable.new(args = ["the_litte_engine_that_could"]).run
             end
 
-            stdout.must_match("Engine not found. Run 'codeclimate engines:list' for a list of valid engines.")
+            expect(stdout).to match("Engine not found. Run 'codeclimate engines:list' for a list of valid engines.")
           end
         end
       end
@@ -27,7 +27,7 @@ module CC::CLI::Engines
               Disable.new(args = ["rubocop"]).run
             end
 
-            stdout.must_match("Engine already disabled.")
+            expect(stdout).to match("Engine already disabled.")
           end
         end
       end
@@ -44,9 +44,9 @@ module CC::CLI::Engines
 
             content_after = File.read(".codeclimate.yml")
 
-            stdout.must_match("Engine disabled.")
-            CC::Analyzer::Config.new(content_before).engine_enabled?("rubocop").must_equal(true)
-            CC::Analyzer::Config.new(content_after).engine_enabled?("rubocop").must_equal(false)
+            expect(stdout).to match("Engine disabled.")
+            expect(CC::Analyzer::Config.new(content_before).engine_enabled?("rubocop")).to eq(true)
+            expect(CC::Analyzer::Config.new(content_after).engine_enabled?("rubocop")).to eq(false)
           end
         end
       end

--- a/spec/cc/cli/engines/enable_spec.rb
+++ b/spec/cc/cli/engines/enable_spec.rb
@@ -3,19 +3,21 @@ require "spec_helper"
 module CC::CLI::Engines
   describe Enable do
     describe "#run" do
-      before { Install.any_instance.stubs(:run) }
+      before do
+        allow_any_instance_of(Install).to receive(:run)
+      end
 
       describe "when the engine requested does not exist" do
         it "says engine does not exist" do
           within_temp_dir do
             create_yaml
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
 
             stdout, stderr = capture_io do
               Enable.new(args = ["the_litte_engine_that_could"]).run
             end
 
-            stdout.must_match("Engine not found. Run 'codeclimate engines:list' for a list of valid engines.")
+            expect(stdout).to match("Engine not found. Run 'codeclimate engines:list' for a list of valid engines.")
           end
         end
       end
@@ -30,8 +32,8 @@ module CC::CLI::Engines
 
             content_after = File.read(".codeclimate.yml")
 
-            stdout.must_match("Engine already enabled.")
-            content_after.must_equal(Factory.yaml_with_rubocop_enabled)
+            expect(stdout).to match("Engine already enabled.")
+            expect(content_after).to eq(Factory.yaml_with_rubocop_enabled)
           end
         end
       end
@@ -46,8 +48,8 @@ module CC::CLI::Engines
 
             content_after = File.read(".codeclimate.yml")
 
-            stdout.must_match("Engine added")
-            CC::Analyzer::Config.new(content_after).engine_enabled?("rubocop").must_equal(true)
+            expect(stdout).to match("Engine added")
+            expect(CC::Analyzer::Config.new(content_after).engine_enabled?("rubocop")).to eq(true)
           end
         end
       end
@@ -63,9 +65,9 @@ module CC::CLI::Engines
 
             content_after = File.read(".codeclimate.yml")
 
-            stdout.must_match("Engine added")
+            expect(stdout).to match("Engine added")
             config = CC::Analyzer::Config.new(content_after).engine_config("duplication")
-            config["config"].must_equal("languages" => %w[ruby javascript python php])
+            expect(config["config"]).to eq("languages" => %w[ruby javascript python php])
           end
         end
       end
@@ -83,7 +85,7 @@ module CC::CLI::Engines
 
             config = CC::Analyzer::Config.new(content_after).engine_config("coffeelint")
 
-            config.must_equal({"enabled" => true})
+            expect(config).to eq({"enabled" => true})
           end
         end
       end

--- a/spec/cc/cli/engines/install_spec.rb
+++ b/spec/cc/cli/engines/install_spec.rb
@@ -20,7 +20,7 @@ module CC::CLI::Engines
           Install.new.run
         end
 
-        stdout.must_match(/unknown engine name: madeup/)
+        expect(stdout).to match(/unknown engine name: madeup/)
       end
 
       it "errors if an image is unable to be pulled" do
@@ -31,26 +31,29 @@ module CC::CLI::Engines
         expect_system("docker pull madeup_img", false)
 
         capture_io do
-          lambda { Install.new.run }.must_raise(Install::ImagePullFailure)
+          expect { Install.new.run }.to raise_error(Install::ImagePullFailure)
         end
       end
     end
 
     def expect_system(cmd, result = true)
-      Install.any_instance.expects(:system).with(cmd).returns(result)
+      allow_any_instance_of(Install).to receive(:system).
+        with(cmd).and_return(result)
     end
 
     def stub_config(stubs)
-      config = stub(stubs)
-      CC::Analyzer::Config.stubs(:new).returns(config)
+      config = double(stubs)
+      allow(CC::Analyzer::Config).to receive(:new).and_return(config)
     end
 
     def stub_engine_exists(engine)
-      CC::Analyzer::EngineRegistry.any_instance.stubs(:exists?).with(engine).returns(true)
+      allow_any_instance_of(CC::Analyzer::EngineRegistry).to receive(:exists?).
+        with(engine).and_return(true)
     end
 
     def stub_engine_image(engine)
-      EngineCommand.any_instance.stubs(:engine_registry_list).returns("#{engine}" => { "image" => "#{engine}_img" })
+      allow_any_instance_of(EngineCommand).to receive(:engine_registry_list).
+        and_return("#{engine}" => { "image" => "#{engine}_img" })
     end
   end
 end

--- a/spec/cc/cli/engines/list_spec.rb
+++ b/spec/cc/cli/engines/list_spec.rb
@@ -11,7 +11,7 @@ module CC::CLI::Engines
         engines = YAML.safe_load_file("config/engines.yml")
 
         engines.each do |name, engine|
-          stdout.must_match(name)
+          expect(stdout).to match(name)
         end
       end
     end

--- a/spec/cc/cli/engines/remove_spec.rb
+++ b/spec/cc/cli/engines/remove_spec.rb
@@ -7,13 +7,13 @@ module CC::CLI::Engines
         it "says engine does not exist" do
           within_temp_dir do
             create_yaml
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
 
             stdout, stderr = capture_io do
               Remove.new(args = ["the_litte_engine_that_could"]).run
             end
 
-            stdout.must_match("Engine not found. Run 'codeclimate engines:list' for a list of valid engines.")
+            expect(stdout).to match("Engine not found. Run 'codeclimate engines:list' for a list of valid engines.")
           end
         end
       end
@@ -27,7 +27,7 @@ module CC::CLI::Engines
               Remove.new(args = ["rubocop"]).run
             end
 
-            stdout.must_match("Engine removed from .codeclimate.yml.")
+            expect(stdout).to match("Engine removed from .codeclimate.yml.")
           end
         end
 
@@ -41,8 +41,8 @@ module CC::CLI::Engines
 
             content_after = File.read(".codeclimate.yml")
 
-            stdout.must_match("Engine removed from .codeclimate.yml.")
-            CC::Analyzer::Config.new(content_after).engine_present?("rubocop").must_equal(false)
+            expect(stdout).to match("Engine removed from .codeclimate.yml.")
+            expect(CC::Analyzer::Config.new(content_after).engine_present?("rubocop")).to eq(false)
           end
         end
       end

--- a/spec/cc/cli/runner_spec.rb
+++ b/spec/cc/cli/runner_spec.rb
@@ -14,17 +14,17 @@ module CC::CLI
           Runner.run(["explode"])
         end
 
-        stderr.must_match(/error: \(StandardError\) boom/)
+        expect(stderr).to match(/error: \(StandardError\) boom/)
       end
     end
 
     describe "#command_name" do
       it "parses subclasses" do
-        Runner.new(["analyze:this"]).command_name.must_equal("Analyze::This")
+        expect(Runner.new(["analyze:this"]).command_name).to eq("Analyze::This")
       end
 
       it "returns class names" do
-        Runner.new(["analyze"]).command_name.must_equal("Analyze")
+        expect(Runner.new(["analyze"]).command_name).to eq("Analyze")
       end
     end
   end

--- a/spec/cc/cli/upgrade_config_generator_spec.rb
+++ b/spec/cc/cli/upgrade_config_generator_spec.rb
@@ -14,7 +14,7 @@ module CC::CLI
       it "is true when existing config is valid" do
         File.write(".codeclimate.yml", create_classic_yaml)
 
-        generator.can_generate?.must_equal true
+        expect(generator.can_generate?).to eq true
       end
 
       it "is false when existing config is not valid" do
@@ -26,7 +26,7 @@ module CC::CLI
             - excluded.rb
         })
 
-        generator.can_generate?.must_equal false
+        expect(generator.can_generate?).to eq false
       end
     end
 
@@ -39,7 +39,7 @@ module CC::CLI
         expected_engines = engine_registry.list.select do |name, _|
           expected_engine_names.include?(name)
         end
-        generator.eligible_engines.must_equal expected_engines
+        expect(generator.eligible_engines).to eq expected_engines
       end
     end
 
@@ -48,7 +48,7 @@ module CC::CLI
         File.write(".codeclimate.yml", create_classic_yaml)
 
         expected_paths = %w(excluded.rb)
-        generator.exclude_paths.must_equal expected_paths
+        expect(generator.exclude_paths).to eq expected_paths
       end
 
       it "uses existing exclude_paths from yaml when coerced from string" do
@@ -59,7 +59,7 @@ module CC::CLI
         })
 
         expected_paths = %w(excluded.rb)
-        generator.exclude_paths.must_equal expected_paths
+        expect(generator.exclude_paths).to eq expected_paths
       end
     end
 

--- a/spec/cc/cli/validate_config_spec.rb
+++ b/spec/cc/cli/validate_config_spec.rb
@@ -6,23 +6,23 @@ module CC::CLI
       describe "when a .codeclimate.yml file is present in working directory" do
         it "analyzes the .codeclimate.yml file without altering it" do
           within_temp_dir do
-            filesystem.exist?(".codeclimate.yml").must_equal(false)
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(false)
 
             yaml_content_before = "This is a test yaml!"
             File.write(".codeclimate.yml", yaml_content_before)
 
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
 
             capture_io do
               validate_config = ValidateConfig.new
               validate_config.run
             end
 
-            filesystem.exist?(".codeclimate.yml").must_equal(true)
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
 
             content_after = File.read(".codeclimate.yml")
 
-            content_after.must_equal(yaml_content_before)
+            expect(content_after).to eq(yaml_content_before)
           end
         end
 
@@ -36,7 +36,7 @@ module CC::CLI
                 ValidateConfig.new.run
               end
 
-              stdout.must_match("ERROR")
+              expect(stdout).to match("ERROR")
             end
           end
         end
@@ -53,7 +53,7 @@ module CC::CLI
                 ValidateConfig.new.run
               end
 
-              stdout.must_match("WARNING:")
+              expect(stdout).to match("WARNING:")
             end
           end
         end
@@ -68,7 +68,7 @@ module CC::CLI
                 ValidateConfig.new.run
               end
 
-              stdout.must_match("ERROR: invalid \"engines\" section")
+              expect(stdout).to match("ERROR: invalid \"engines\" section")
             end
           end
         end
@@ -83,7 +83,7 @@ module CC::CLI
                 ValidateConfig.new.run
               end
 
-              stdout.must_match("ERROR: invalid \"engines\" section")
+              expect(stdout).to match("ERROR: invalid \"engines\" section")
             end
           end
         end
@@ -98,7 +98,7 @@ module CC::CLI
                 ValidateConfig.new.run
               end
 
-              stdout.must_match("No errors or warnings found in .codeclimate.yml file.")
+              expect(stdout).to match("No errors or warnings found in .codeclimate.yml file.")
             end
           end
         end
@@ -124,7 +124,7 @@ module CC::CLI
                 ValidateConfig.new.run
               end
 
-              stdout.must_include("WARNING: unknown engine <madeup>")
+              expect(stdout).to include("WARNING: unknown engine <madeup>")
             end
           end
         end

--- a/spec/cc/workspace/path_tree_spec.rb
+++ b/spec/cc/workspace/path_tree_spec.rb
@@ -9,7 +9,7 @@ class CC::Workspace
         make_fixture_tree
 
         tree = PathTree.new(".")
-        tree.all_paths.must_equal ["./"]
+        expect(tree.all_paths).to eq ["./"]
       end
     end
 
@@ -19,7 +19,7 @@ class CC::Workspace
 
         tree = PathTree.new(".")
         tree.exclude_paths([".git/refs", "code/a/bar.rb"])
-        tree.all_paths.sort.must_equal [".git/FETCH_HEAD", "code/a/baz.rb", "code/foo.rb", "foo.txt", "lib/"]
+        expect(tree.all_paths.sort).to eq [".git/FETCH_HEAD", "code/a/baz.rb", "code/foo.rb", "foo.txt", "lib/"]
       end
     end
 
@@ -29,7 +29,7 @@ class CC::Workspace
 
         tree = PathTree.new(".")
         tree.include_paths([".git/refs/", "code/"])
-        tree.all_paths.sort.must_equal [".git/refs/", "code/"]
+        expect(tree.all_paths.sort).to eq [".git/refs/", "code/"]
       end
     end
 
@@ -40,7 +40,7 @@ class CC::Workspace
         tree = PathTree.new(".")
         tree.include_paths([".git/refs/", "code/"])
         tree.exclude_paths([".git/refs/heads/master", "code/a/bar.rb"])
-        tree.all_paths.sort.must_equal ["code/a/baz.rb", "code/foo.rb"]
+        expect(tree.all_paths.sort).to eq ["code/a/baz.rb", "code/foo.rb"]
       end
     end
 
@@ -50,7 +50,7 @@ class CC::Workspace
 
         tree = PathTree.new(".")
         tree.include_paths(["does-not-exist"])
-        tree.all_paths.sort.must_equal ["./"]
+        expect(tree.all_paths.sort).to eq ["./"]
       end
     end
 
@@ -60,7 +60,7 @@ class CC::Workspace
 
         tree = PathTree.new(".")
         tree.exclude_paths(["code/does-not-exist"])
-        tree.all_paths.sort.must_equal [".git/", "code/a/", "code/foo.rb", "foo.txt", "lib/"]
+        expect(tree.all_paths.sort).to eq [".git/", "code/a/", "code/foo.rb", "foo.txt", "lib/"]
       end
     end
 

--- a/spec/cc/workspace_spec.rb
+++ b/spec/cc/workspace_spec.rb
@@ -15,20 +15,20 @@ module CC
 
         workspace = Workspace.new
         workspace.add(%w[foo bar/baz.rb])
-        workspace.paths.must_equal %w[foo/ bar/baz.rb]
+        expect(workspace.paths).to eq %w[foo/ bar/baz.rb]
       end
     end
 
     it "responds with \"./\", if unfiltered" do
       workspace = Workspace.new
-      workspace.paths.must_equal ["./"]
+      expect(workspace.paths).to eq ["./"]
     end
 
     it "doesn't remove if given nil or empty exclude_paths" do
       workspace = Workspace.new
       workspace.remove(nil)
       workspace.remove([])
-      workspace.paths.must_equal ["./"]
+      expect(workspace.paths).to eq ["./"]
     end
 
     it "filters to a minimized set of paths in the current directory" do
@@ -68,7 +68,7 @@ module CC
           vendor/**
         ])
 
-        workspace.paths.sort.must_equal %w[
+        expect(workspace.paths.sort).to eq %w[
           Gemfile
           Gemfile.lock
           lib/
@@ -102,14 +102,14 @@ module CC
         workspace2 = workspace.clone
         workspace2.remove(%w[vendor])
 
-        workspace.paths.sort.must_equal %w[
+        expect(workspace.paths.sort).to eq %w[
           Gemfile
           Gemfile.lock
           lib/
           spec/
           vendor/
         ]
-        workspace2.paths.sort.must_equal %w[
+        expect(workspace2.paths.sort).to eq %w[
           Gemfile
           Gemfile.lock
           lib/
@@ -128,7 +128,7 @@ module CC
         workspace = Workspace.new
         workspace.remove(%w[**/*.pyc])
 
-        workspace.paths.sort.must_equal %w[lib/foo.py]
+        expect(workspace.paths.sort).to eq %w[lib/foo.py]
       end
     end
 
@@ -153,7 +153,7 @@ module CC
         workspace.add(%w[lib/foo spec/foo/bar_spec.rb])
         workspace.remove(%w[lib/foo/bar.rb])
 
-        workspace.paths.sort.must_equal %w[
+        expect(workspace.paths.sort).to eq %w[
           lib/foo/baz.rb
           spec/foo/bar_spec.rb
         ]
@@ -170,7 +170,7 @@ module CC
 
           workspace = Workspace.new
           workspace.add(%w[./])
-          workspace.paths.must_equal ["./"]
+          expect(workspace.paths).to eq ["./"]
         end
       end
 
@@ -184,7 +184,7 @@ module CC
 
           workspace = Workspace.new
           workspace.add(%w[./foo.rb])
-          workspace.paths.must_equal ["foo.rb"]
+          expect(workspace.paths).to eq ["foo.rb"]
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
-require "minitest/spec"
-require "minitest/autorun"
-require "minitest/reporters"
-require "minitest/around/spec"
-require "mocha/mini_test"
 require "safe_yaml"
 require "cc/cli"
 require "cc/yaml"
@@ -13,7 +8,5 @@ require "cc/yaml"
 Dir.glob("spec/support/**/*.rb").each(&method(:load))
 
 SafeYAML::OPTIONS[:default_mode] = :safe
-
-Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new
 
 ENV["FILESYSTEM_DIR"] = "."

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -100,3 +100,7 @@ module Factory
     }
   end
 end
+
+RSpec.configure do |conf|
+  conf.include(Factory)
+end

--- a/spec/support/file_system_helpers.rb
+++ b/spec/support/file_system_helpers.rb
@@ -35,3 +35,7 @@ module FileSystemHelpers
     File.write("config/foo.rb", ".main {}")
   end
 end
+
+RSpec.configure do |conf|
+  conf.include(FileSystemHelpers)
+end

--- a/spec/support/proc_helpers.rb
+++ b/spec/support/proc_helpers.rb
@@ -1,6 +1,21 @@
 require "cc/cli/command"
 
 module ProcHelpers
+  def capture_io
+    stdout = $stdout
+    stderr = $stdout
+
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+
+    yield
+
+    [$stdout.string, $stderr.string]
+  ensure
+    $stdout = stdout
+    $stderr = stdout
+  end
+
   def capture_io_and_exit_code
     exit_code = 0
 
@@ -14,4 +29,8 @@ module ProcHelpers
 
     return stdout, stderr, exit_code
   end
+end
+
+RSpec.configure do |conf|
+  conf.include(ProcHelpers)
 end


### PR DESCRIPTION
Reasons:

- It's a burden to know and use two testing frameworks across our projects
- By far, rspec is what we use most frequently
- Possibly related, most of us personally prefer rspec
- We used minitest/spec, so it's *just close enough* to rspec to repeatedly
  confuse us when it's not
- We were bringing in a number of extra libraries anyway, just to give minitest
  the functionality that rspec has built-in

Changes:

This was mostly a mechanical change, but also:

- Add ProcHelpers#capture_io

  minitest, really? Really? You give me almost nothing out of the box, claim
  that as your main feature, but you have #capture_io, really?

- Add a slow tag for the container-stopping specs and don't run them by default

  I was running the suite a lot to get through this change and it's incredibly
  fast, if not for these specs. We intentionally don't touch this logic often,
  so I think it makes sense to omit them in day-to-day development but keep
  them on CI for regression protection.

There are still a few places where the specs are overly verbose or awkward
because we didn't have an rspec feature that we do now. I'm deferring fixing
those for now, this conversion was the main hurdle.

CC will also likely flag some pre-existing issues because I've touched the
line(s) -- I'll fix these when I see them.

/cc @codeclimate/review