### PR TITLE
[wrapper] do not use docker-machine if there is no name

### DIFF
--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -28,7 +28,7 @@ invalid_docker_host() {
   invalid_setup "invalid DOCKER_HOST=$host, must be unset or unix:///var/run/docker.sock"
 }
 
-if command -v docker-machine > /dev/null 2>&1; then
+if [ -n "$DOCKER_MACHINE_NAME" ] && command -v docker-machine > /dev/null 2>&1; then
   docker-machine ssh $DOCKER_MACHINE_NAME -- \
     test -S /var/run/docker.sock > /dev/null 2>&1 || socket_missing
 


### PR DESCRIPTION
some people have it installed, but do not use it

i could not use codeclimate wrapper with installed docker-machine
but also working local install