### PR TITLE
Add timeout on docker kill invocation

### DIFF
--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -171,8 +171,8 @@ module CC
 
       def reap_running_container(message)
         Analyzer.logger.warn("killing container name=#{@name} message=#{message.inspect}")
-        POSIX::Spawn::Child.new("docker", "kill", @name)
-        POSIX::Spawn::Child.new("docker", "wait", @name, timeout: 5.minutes)
+        POSIX::Spawn::Child.new("docker", "kill", @name, timeout: 2.minutes)
+        POSIX::Spawn::Child.new("docker", "wait", @name, timeout: 2.minutes)
       end
 
       def timeout


### PR DESCRIPTION
I went with two minutes here and reduced the timeout on docker wait to match.
The five minutes originally chosen was entirely arbitrary. Allowing up to ten
minutes of additional time in a timeout scenario didn't seem like a good idea
and my gut is that if it doesn't stop within two, it probably won't.

/cc @codeclimate/review