### PR TITLE
Install Bundler gem helper tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,7 @@
+require "bundler/gem_helper"
 require "rspec/core/rake_task"
+
+Bundler::GemHelper.install_tasks
 
 desc "Run (quick) specs"
 RSpec::Core::RakeTask.new(:spec) do |task|


### PR DESCRIPTION
We run `rake release`, a Bundler gem helper task, as part of our `bin/release`
script. This PR explicitly requires `bundler/gem_helper` and installs its
tasks within `Rakefile`, as they're not available by default:

```
Already on 'master'
Your branch is up-to-date with 'origin/master'.
Already up-to-date.
RELEASE 0.18.2
rake aborted!
Don't know how to build task 'release'
```