### PR TITLE
ConfigGenerator: raise error if workspace is empty

### DIFF
--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -6,6 +6,8 @@ module CC
       CODECLIMATE_YAML = Command::CODECLIMATE_YAML
       AUTO_EXCLUDE_PATHS = %w(config/ db/ dist/ features/ node_modules/ script/ spec/ test/ tests/ vendor/).freeze
 
+      EmptyWorkspaceError = Class.new(StandardError)
+
       def self.for(filesystem, engine_registry, upgrade_requested)
         if upgrade_requested && upgrade_needed?(filesystem)
           UpgradeConfigGenerator.new(filesystem, engine_registry)
@@ -78,7 +80,7 @@ module CC
       def workspace_files
         @workspace_files ||= Dir.chdir(filesystem.root) do
           if non_excluded_paths.empty?
-            []
+            raise EmptyWorkspaceError, "Your workspace is empty: there are no files for us to check!"
           else
             find_cmd = "find #{non_excluded_paths.map(&:shellescape).join(' ')} -type f -print0"
             `#{find_cmd}`.strip.split("\0").map do |path|

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -64,6 +64,10 @@ module CC::CLI
 
         expect(generator.eligible_engines.keys).not_to include("eslint")
       end
+
+      it "raises if the workspace is empty" do
+        expect { generator.eligible_engines }.to raise_error(CC::CLI::ConfigGenerator::EmptyWorkspaceError)
+      end
     end
 
     describe "#errors" do


### PR DESCRIPTION
We were just returning an empty set of paths to enable engines on in
init when everything was excluded and/or the dir was empty, but this
strikes me as incorrect. If there's really nothing for us to look at, it
seems more reasonable to call that an error condition & exit
immediately.

:eyes: @codeclimate/review