### PR TITLE
ConfigGenerator: Catch & report `find` failure

### DIFF
--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -64,6 +64,16 @@ module CC::CLI
 
         expect(generator.eligible_engines.keys).not_to include("eslint")
       end
+
+      it "raises if `find` fails" do
+        make_tree <<-EOM
+          foo.rb
+        EOM
+
+        allow(POSIX::Spawn::Child).to receive(:new).and_return(double(status: double(success?: false, to_i: 1), err: "error message"))
+
+        expect { generator.eligible_engines }.to raise_error(CC::CLI::ConfigGenerator::ConfigGeneratorError)
+      end
     end
 
     describe "#errors" do


### PR DESCRIPTION
Our usage of `find` to get files to enable engines against is too
naive: there are some unusual local configurations that lead to an
invalid find invocation. The old code was effectively ignoring this,
leading to more confusing failures further down the line.

This replaces the naive execution with usage of `POSIX::Spawn` that
should 1) be more tolerant of weird file names anyway and 2) if find
does fail, will properly catch & report so at least the user gets an
error message pointing them in a useful direction.

@codeclimate/review this is in direct response to some builder errors we saw on
.com. It's only affected 2 repos I've seen, but this should result in a more
informative view on the build page, and should result in more informative
errors for us on the backend to improve this further.