### PR TITLE
Revert "Remove characters added by docker logging daemon"

### DIFF
--- a/lib/cc/analyzer/engine_output.rb
+++ b/lib/cc/analyzer/engine_output.rb
@@ -1,7 +1,7 @@
 module CC
   module Analyzer
     class EngineOutput
-      delegate :blank?, to: :chomped_output
+      delegate :blank?, to: :raw_output
       delegate :to_json, to: :as_issue
 
       def initialize(raw_output)
@@ -23,17 +23,9 @@ module CC
       attr_accessor :raw_output
 
       def parsed_output
-        JSON.parse(chomped_output)
+        JSON.parse(raw_output)
       rescue JSON::ParserError
         nil
-      end
-
-      # Docker can put start-of-text characters when logging,
-      # which show up as issues. Remove them here if they are at either end
-      # of the output and then check blankness.
-      # https://github.com/docker/docker/issues/7375
-      def chomped_output
-        @chomped_output ||= raw_output.chomp("\u0002")
       end
     end
   end

--- a/spec/cc/analyzer/engine_output_spec.rb
+++ b/spec/cc/analyzer/engine_output_spec.rb
@@ -9,11 +9,5 @@ module CC::Analyzer
         expect(EngineOutput.new(output).issue?).to eq(true)
       end
     end
-
-    it "removes characters from the docker logs" do
-      output = "\u0002"
-
-      expect(EngineOutput.new(output).blank?).to eq(true)
-    end
   end
 end


### PR DESCRIPTION
Reverts codeclimate/codeclimate#332

This seems to have caused more errored builds. Reverting while I investigate to unblock folks.

cc @codeclimate/review @wfleming 