### PR TITLE
Allow gem callers to disable container cleanup (docker run --rm)

### DIFF
--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -97,7 +97,6 @@ module CC
       def docker_run_command(options)
         [
           "docker", "run",
-          "--rm",
           "--name", @name,
           options,
           @image,

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -56,6 +56,7 @@ module CC
           "--memory", memory_limit,
           "--memory-swap", "-1",
           "--net", "none",
+          "--rm",
           "--volume", "#{@code_path}:/code:ro",
           "--volume", "#{config_file}:/config.json:ro",
           "--user", "9000:9000"

--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -6,7 +6,7 @@ module CC::Analyzer
       it "spawns docker run with the image, name, and options given" do
         container = Container.new(image: "codeclimate/foo", name: "name")
 
-        expect_spawn(%w[ docker run --rm --name name -i -t codeclimate/foo ])
+        expect_spawn(%w[ docker run --name name -i -t codeclimate/foo ])
 
         container.run(%w[ -i -t ])
       end
@@ -14,7 +14,7 @@ module CC::Analyzer
       it "spawns the command if present" do
         container = Container.new(image: "codeclimate/foo", command: "bar", name: "name")
 
-        expect_spawn(%w[ docker run --rm --name name codeclimate/foo bar ])
+        expect_spawn(%w[ docker run --name name codeclimate/foo bar ])
 
         container.run
       end
@@ -22,7 +22,7 @@ module CC::Analyzer
       it "spawns an array command if given" do
         container = Container.new(image: "codeclimate/foo", command: %w[ bar baz ], name: "name")
 
-        expect_spawn(%w[ docker run --rm --name name codeclimate/foo bar baz ])
+        expect_spawn(%w[ docker run --name name codeclimate/foo bar baz ])
 
         container.run
       end
@@ -34,7 +34,7 @@ module CC::Analyzer
           name: "name",
         )
 
-        expect_spawn(%w[ docker run --rm --name name codeclimate/foo bar baz\ bat ])
+        expect_spawn(%w[ docker run --name name codeclimate/foo bar baz\ bat ])
 
         container.run
       end

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -33,6 +33,7 @@ module CC::Analyzer
           "--memory", "512000000",
           "--memory-swap", "-1",
           "--net", "none",
+          "--rm",
           "--volume", "/code:/code:ro",
           "--user", "9000:9000",
         ))


### PR DESCRIPTION
This PR moves the `--rm` docker run option up a level to allow callers of
`CC::Analyzer::Container` to specify whether docker should automatically
cleanup engine containers after they exit. The CLI will still pass the `--rm`
option during engine runs, so this will be a transparent change for CLI users.

This update benefits Code Climate debugging efforts, giving us the option to
inspect a docker container after it triggered an errored build.

@codeclimate/review :mag_right: