### PR TITLE
Add old RuboCop engine to manifest

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -207,6 +207,13 @@ rubocop:
     - \.rb$
   default_ratings_paths:
     - "**.rb"
+rubocop-v35:
+  image: codeclimate/codeclimate-rubocop:v35
+  description: A Ruby static code analyzer, based on the community Ruby style guide. Version 0.35.1 of RuboCop.
+  community: false
+  enable_regexps:
+  default_ratings_paths:
+    - "**.rb"
 rubymotion:
   image: codeclimate/codeclimate-rubymotion
   description: Rubymotion-specific rubocop checks.


### PR DESCRIPTION
Since there are many breaking configuration changes between 0.35.1 and
0.37.2, support the previous version of the engine also so that users
who hit blocking issues with the current engine can revert back if
they do not wish to update their RuboCop configuration file.

This change means we will have to tag b165 as
codeclimate/codeclimate-rubocop-old and push it to Docker Hub.

@codeclimate/review