### PR TITLE
Generate engine configuration even when there is a platform yml

### DIFF
--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -12,7 +12,8 @@ module CC
           warn "Config file .codeclimate.yml already present.\nTry running 'validate-config' to check configuration."
           create_default_engine_configs if engines_enabled?
         elsif upgrade? && engines_enabled?
-          fatal "--upgrade should not be used on a .codeclimate.yml configured for the Platform.\nTry running 'validate-config' to check configuration."
+          warn "Config file .codeclimate.yml already configured for the Platform.\nTry running 'validate-config' to check configuration."
+          create_default_engine_configs
         else
           generate_all_config
         end

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -138,7 +138,7 @@ module CC::CLI
       end
 
       describe "when --upgrade flag is on" do
-        it "refuses to upgrade a platform config" do
+        it "generates engine configs for a platform .codeclimate.yml" do
           expect(filesystem.exist?(".codeclimate.yml")).to eq(false)
 
           yaml_content_before = yaml_with_rubocop_enabled
@@ -146,8 +146,12 @@ module CC::CLI
 
           expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
 
-          _, stderr, exit_code = capture_io_and_exit_code do
-            Init.new(["--upgrade"]).run
+          init = Init.new(["--upgrade"])
+
+          expect(init).to receive(:create_default_engine_configs)
+
+          stdout, _, exit_code = capture_io_and_exit_code do
+            init.run
           end
 
           content_after = File.read(".codeclimate.yml")
@@ -155,8 +159,8 @@ module CC::CLI
           expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
           expect(content_after).to eq(yaml_content_before)
 
-          expect(stderr).to include("--upgrade should not be used on a .codeclimate.yml configured for the Platform")
-          expect(exit_code).to eq 1
+          expect(stdout).to include("configured for the Platform")
+          expect(exit_code).to eq 0
         end
 
         it "behaves normally if no .codeclimate.yml present" do


### PR DESCRIPTION
This better matches the behavior of `init` without the `--upgrade` flag.

![screen shot 2016-02-12 at 2 29 53 pm](https://cloud.githubusercontent.com/assets/245083/13018006/65cd9372-d195-11e5-89c3-49684ba14186.png)

@codeclimate/review 