### PR TITLE
Remove fixme issues from default .rubocop.yml

### DIFF
--- a/config/rubocop/.rubocop.yml
+++ b/config/rubocop/.rubocop.yml
@@ -510,9 +510,7 @@ Style/CommandLiteral:
   Enabled: false
 
 Style/CommentAnnotation:
-  Description: >-
-                 Checks formatting of special comments
-                 (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
+  Description: 'Checks formatting of annotation comments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#annotate-keywords'
   Enabled: false
 


### PR DESCRIPTION
This fixes a weird experience where users with an autogenerated
.rubocop.yml had fixme issues reported.

@codeclimate/review 

Note: an alternative I considered was changing the fixme examples to lower case (which our Fixme engine ignores). Didn't go that route because I thought the dashes were more intention revealing and better convey the original example words intended. 