### PR TITLE
Fix bug excluding a directory after partially excluding it

### DIFF
--- a/benchmarks/path_tree_benchmark.rb
+++ b/benchmarks/path_tree_benchmark.rb
@@ -16,7 +16,7 @@ class CC::Workspace
         exclude_paths = make_exclude_paths
 
         elapsed = Benchmark.realtime do
-          tree = PathTree.new(".")
+          tree = PathTree.for_path(".")
           tree.exclude_paths(exclude_paths)
           tree.all_paths
         end

--- a/lib/cc/workspace.rb
+++ b/lib/cc/workspace.rb
@@ -3,7 +3,7 @@ module CC
     autoload :Exclusion, "cc/workspace/exclusion"
     autoload :PathTree, "cc/workspace/path_tree"
 
-    def initialize(path_tree = PathTree.new("."))
+    def initialize(path_tree = PathTree.for_path("."))
       @path_tree = path_tree
     end
 

--- a/lib/cc/workspace/path_tree.rb
+++ b/lib/cc/workspace/path_tree.rb
@@ -4,106 +4,45 @@ require "set"
 module CC
   class Workspace
     class PathTree
-      def self.create(pathname)
+      autoload :DirNode, "cc/workspace/path_tree/dir_node"
+      autoload :FileNode, "cc/workspace/path_tree/file_node"
+
+      def self.node_for_pathname(pathname)
         if pathname.directory?
-          new(pathname.to_s)
+          DirNode.new(pathname.to_s)
         else
           FileNode.new(pathname.to_s)
         end
       end
 
-      def initialize(root_path, children = {})
-        @root_path = root_path.dup.freeze
-        @children = children
+      def self.for_path(path)
+        new(node_for_pathname(Pathname.new(path)))
+      end
+
+      def initialize(root_node)
+        @root_node = root_node
       end
 
       def clone
-        self.class.new(root_path, children.dup)
+        self.class.new(root_node.clone)
       end
 
       def exclude_paths(paths)
-        paths.each { |path| remove(*normalized_path_pieces(path)) }
+        paths.each { |path| root_node.remove(*normalized_path_pieces(path)) }
       end
 
       def include_paths(paths)
-        paths.each { |path| add(*normalized_path_pieces(path)) }
+        paths.each { |path| root_node.add(*normalized_path_pieces(path)) }
       end
 
-      def all_paths
-        if populated?
-          children.values.flat_map(&:all_paths)
-        else
-          [File.join(root_path, File::SEPARATOR)]
-        end
-      end
-
-      protected
-
-      def populated?
-        children.present?
-      end
-
-      def remove(head = nil, *tail)
-        return if head.nil? && tail.empty?
-        populate_direct_children
-
-        if (child = children[head])
-          child.remove(*tail)
-          children.delete(head) unless child.populated?
-        end
-      end
-
-      def add(head = nil, *tail)
-        return if head.nil? && tail.empty?
-
-        if (entry = find_direct_child(head))
-          children[entry.basename.to_s] = self.class.create(entry)
-          children[entry.basename.to_s].add(*tail)
-        else
-          CLI.debug("Couldn't include because part of path doesn't exist.", path: File.join(root_path, head))
-        end
-      end
+      delegate :all_paths, to: :root_node
 
       private
 
-      attr_reader :children, :root_path
-
-      def populate_direct_children
-        return if populated?
-
-        Pathname.new(root_path).each_child do |child_path|
-          children[child_path.basename.to_s] = self.class.create(child_path)
-        end
-      end
-
-      def find_direct_child(name)
-        Pathname.new(root_path).children.detect { |c| c.basename.to_s == name }
-      end
+      attr_reader :root_node
 
       def normalized_path_pieces(path)
         Pathname.new(path).cleanpath.to_s.split(File::SEPARATOR).reject(&:blank?)
-      end
-
-      class FileNode
-        def initialize(root_path)
-          @root_path = root_path.dup.freeze
-        end
-
-        def all_paths
-          [@root_path]
-        end
-
-        def populated?
-          false
-        end
-
-        def remove(*)
-          # this space intentionally left blank
-        end
-
-        def add(*)
-          # this space intentionally left blank
-        end
       end
     end
   end

--- a/lib/cc/workspace/path_tree/dir_node.rb
+++ b/lib/cc/workspace/path_tree/dir_node.rb
@@ -1,0 +1,65 @@
+module CC
+  class Workspace
+    class PathTree
+      class DirNode
+        def initialize(root_path, children = {})
+          @root_path = root_path.dup.freeze
+          @children = children
+        end
+
+        def clone
+          self.class.new(root_path, children.dup)
+        end
+
+        def all_paths
+          if populated?
+            children.values.flat_map(&:all_paths)
+          else
+            [File.join(root_path, File::SEPARATOR)]
+          end
+        end
+
+        def populated?
+          children.present?
+        end
+
+        def remove(head = nil, *tail)
+          return if head.nil? && tail.empty?
+          populate_direct_children
+
+          if (child = children[head])
+            child.remove(*tail)
+            children.delete(head) unless child.populated?
+          end
+        end
+
+        def add(head = nil, *tail)
+          return if head.nil? && tail.empty?
+
+          if (entry = find_direct_child(head))
+            children[entry.basename.to_s] = PathTree.node_for_pathname(entry)
+            children[entry.basename.to_s].add(*tail)
+          else
+            CLI.debug("Couldn't include because part of path doesn't exist.", path: File.join(root_path, head))
+          end
+        end
+
+        private
+
+        attr_reader :children, :root_path
+
+        def populate_direct_children
+          return if populated?
+
+          Pathname.new(root_path).each_child do |child_path|
+            children[child_path.basename.to_s] = PathTree.node_for_pathname(child_path)
+          end
+        end
+
+        def find_direct_child(name)
+          Pathname.new(root_path).children.detect { |c| c.basename.to_s == name }
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/workspace/path_tree/dir_node.rb
+++ b/lib/cc/workspace/path_tree/dir_node.rb
@@ -29,7 +29,7 @@ module CC
 
           if (child = children[head])
             child.remove(*tail)
-            children.delete(head) unless child.populated?
+            children.delete(head) if !child.populated? || tail.empty?
           end
         end
 

--- a/lib/cc/workspace/path_tree/file_node.rb
+++ b/lib/cc/workspace/path_tree/file_node.rb
@@ -1,0 +1,31 @@
+module CC
+  class Workspace
+    class PathTree
+      class FileNode
+        def initialize(root_path)
+          @root_path = root_path.dup.freeze
+        end
+
+        def all_paths
+          [root_path]
+        end
+
+        def populated?
+          false
+        end
+
+        def remove(*)
+          # this space intentionally left blank
+        end
+
+        def add(*)
+          # this space intentionally left blank
+        end
+
+        private
+
+        attr_reader :root_path
+      end
+    end
+  end
+end

--- a/spec/cc/workspace/path_tree_spec.rb
+++ b/spec/cc/workspace/path_tree_spec.rb
@@ -44,6 +44,17 @@ class CC::Workspace
       end
     end
 
+    it "excludes directory after excluding only part of it" do
+      within_temp_dir do
+        make_fixture_tree
+
+        tree = PathTree.for_path(".")
+        tree.exclude_paths(["code/a/bar.rb"])
+        tree.exclude_paths(["code/"])
+        expect(tree.all_paths.sort).to eq [".git/", "foo.txt", "lib/"]
+      end
+    end
+
     it "handles including nonexistent files" do
       within_temp_dir do
         make_fixture_tree

--- a/spec/cc/workspace/path_tree_spec.rb
+++ b/spec/cc/workspace/path_tree_spec.rb
@@ -8,7 +8,7 @@ class CC::Workspace
       within_temp_dir do
         make_fixture_tree
 
-        tree = PathTree.new(".")
+        tree = PathTree.for_path(".")
         expect(tree.all_paths).to eq ["./"]
       end
     end
@@ -17,7 +17,7 @@ class CC::Workspace
       within_temp_dir do
         make_fixture_tree
 
-        tree = PathTree.new(".")
+        tree = PathTree.for_path(".")
         tree.exclude_paths([".git/refs", "code/a/bar.rb"])
         expect(tree.all_paths.sort).to eq [".git/FETCH_HEAD", "code/a/baz.rb", "code/foo.rb", "foo.txt", "lib/"]
       end
@@ -27,7 +27,7 @@ class CC::Workspace
       within_temp_dir do
         make_fixture_tree
 
-        tree = PathTree.new(".")
+        tree = PathTree.for_path(".")
         tree.include_paths([".git/refs/", "code/"])
         expect(tree.all_paths.sort).to eq [".git/refs/", "code/"]
       end
@@ -37,7 +37,7 @@ class CC::Workspace
       within_temp_dir do
         make_fixture_tree
 
-        tree = PathTree.new(".")
+        tree = PathTree.for_path(".")
         tree.include_paths([".git/refs/", "code/"])
         tree.exclude_paths([".git/refs/heads/master", "code/a/bar.rb"])
         expect(tree.all_paths.sort).to eq ["code/a/baz.rb", "code/foo.rb"]
@@ -48,7 +48,7 @@ class CC::Workspace
       within_temp_dir do
         make_fixture_tree
 
-        tree = PathTree.new(".")
+        tree = PathTree.for_path(".")
         tree.include_paths(["does-not-exist"])
         expect(tree.all_paths.sort).to eq ["./"]
       end
@@ -58,7 +58,7 @@ class CC::Workspace
       within_temp_dir do
         make_fixture_tree
 
-        tree = PathTree.new(".")
+        tree = PathTree.for_path(".")
         tree.exclude_paths(["code/does-not-exist"])
         expect(tree.all_paths.sort).to eq [".git/", "code/a/", "code/foo.rb", "foo.txt", "lib/"]
       end


### PR DESCRIPTION
There was a bug here where if a directory was populated (probably due to
being partially excluded), and then later completely excluded (such as for
an engine-specific exclude), it would not actually be fully removed.

@codeclimate/review I chose to do a refactor first to (I hope) clarify the
behavior of this code & make it easier to read & understand. It's pretty much
copy-paste & some renaming, so I don't think it will make review terribly
difficult. The actual bug here is quite small: reviewing the two commits
seperately might be easiest.  I'm also happy to split into different PRs.