### PR TITLE
make install breaks because filter is invalid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ citest:
 install:
 	bin/check
 	docker pull codeclimate/codeclimate:latest
-	docker images | awk '/codeclimate\/codeclimate-/ { print $$1 }' | xargs -n1 docker pull || true
+	docker images | awk '/codeclimate\/codeclimate/ { print $$1 }' | xargs -n1 docker pull || true
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	install -m 0755 codeclimate-wrapper $(DESTDIR)$(PREFIX)/bin/codeclimate
 


### PR DESCRIPTION
I got an error trying to run on my localhost following the readme:

    $ docker pull curl -L https://github.com/codeclimate/codeclimate/archive/master.tar.gz | tar xvz
docker: "pull" requires 1 argument.


```
jonatas@davi:~/codeclimate-master$ docker images | awk '/codeclimate\/codeclimate-/ { print $$1 }' | xargs -n1 docker pull || true
Cannot connect to the Docker daemon. Is the docker daemon running on this host?
docker: "pull" requires 1 argument.
See 'docker pull --help'.
```

So, I fixed it only removing the `-` from awk parameter.

