### PR TITLE
Don't use --tty unless stdin is also a terminal

### DIFF
--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -58,7 +58,7 @@ docker_run() {
     "$@"
 }
 
-if [ -t 1 ]; then
+if [ -t 0 ] && [ -t 1 ]; then
   docker_run --tty codeclimate/codeclimate "$@"
 else
   docker_run codeclimate/codeclimate "$@"


### PR DESCRIPTION
For context, this mechanism is used to disable colors when piping output. Only
if the wrapper script determines that stdout (fd 1) is connected to a terminal
(-t), does it use the --tty option, which ensures that a similar test used in
the container ($stdout.tty?) returns accurately.

Regardless of all that, the --tty flag cannot be used unless stdin is a
terminal. Therefore, we need to account for that as well.

Unfortunately, this means an invocation like

    yes | codeclimate analyze

won't color its output, even though it probably should.

/cc @codeclimate/review