### PR TITLE
Correct unit in engine timeout message

### DIFF
--- a/lib/cc/analyzer/raising_container_listener.rb
+++ b/lib/cc/analyzer/raising_container_listener.rb
@@ -8,7 +8,7 @@ module CC
       end
 
       def timed_out(data)
-        message = "engine #{engine_name} ran for #{data.duration} seconds"
+        message = "engine #{engine_name} ran for #{data.duration / 1000} seconds"
         message << " and was killed"
 
         raise timeout_ex, message

--- a/spec/cc/analyzer/raising_container_listener_spec.rb
+++ b/spec/cc/analyzer/raising_container_listener_spec.rb
@@ -7,8 +7,8 @@ module CC::Analyzer
         timeout_ex = Class.new(StandardError)
         listener = RaisingContainerListener.new("engine", nil, timeout_ex)
 
-        expect { listener.timed_out(double(duration: 10)) }.to raise_error(
-          timeout_ex, /engine ran for 10 seconds/
+        expect { listener.timed_out(double(duration: 900000)) }.to raise_error(
+          timeout_ex, /engine ran for 900 seconds/
         )
       end
     end


### PR DESCRIPTION
@codeclimate/review 

alternatively:

```
message = "engine #{engine_name} ran for #{data.duration / 1000} seconds
```

