### PR TITLE
Refactor handling of mounted code and tmp paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,5 @@ RUN chmod +x /bin/docker
 
 COPY . /usr/src/app
 
-ENV FILESYSTEM_DIR /code
-
+ENV CODECLIMATE_DOCKER 1
 ENTRYPOINT ["/usr/src/app/bin/codeclimate"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker pull codeclimate/codeclimate
 ```console
 docker run \
   --interactive --tty --rm \
-  --env CODE_PATH="$PWD" \
+  --env CODECLIMATE_CODE="$PWD" \
   --volume "$PWD":/code \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume /tmp/cc:/tmp/cc \

--- a/bin/codeclimate
+++ b/bin/codeclimate
@@ -3,7 +3,4 @@ $LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), "../lib"))
 
 require "cc/cli"
 
-ENV["FILESYSTEM_DIR"] ||= "."
-ENV["CODE_PATH"] ||= ENV["PWD"]
-
 CC::CLI::Runner.run(ARGV)

--- a/bin/codeclimate-init
+++ b/bin/codeclimate-init
@@ -3,6 +3,4 @@ $LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(__FILE__), "../lib"))
 
 require "cc/cli"
 
-ENV["FILESYSTEM_DIR"] ||= "."
-
 CC::CLI::Init.new(ARGV).execute

--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -51,13 +51,17 @@ fi
 docker_run() {
   exec docker run \
     --interactive --rm \
-    --env CODE_PATH="$PWD" \
+    --env CODECLIMATE_CODE \
+    --env CODECLIMATE_TMP \
     --env CODECLIMATE_DEBUG \
-    --volume "$PWD":/code \
-    --volume /tmp/cc:/tmp/cc \
+    --volume "$CODECLIMATE_CODE":/code \
+    --volume "$CODECLIMATE_TMP":/tmp/cc \
     --volume /var/run/docker.sock:/var/run/docker.sock \
     "$@"
 }
+
+: ${CODECLIMATE_CODE:=$PWD}
+: ${CODECLIMATE_TMP:=/tmp/cc}
 
 if [ -t 0 ] && [ -t 1 ]; then
   docker_run --tty codeclimate/codeclimate "$@"

--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -16,6 +16,7 @@ module CC
     autoload :IssueSorter, "cc/analyzer/issue_sorter"
     autoload :LocationDescription, "cc/analyzer/location_description"
     autoload :LoggingContainerListener, "cc/analyzer/logging_container_listener"
+    autoload :MountedPath, "cc/analyzer/mounted_path"
     autoload :RaisingContainerListener, "cc/analyzer/raising_container_listener"
     autoload :SourceBuffer, "cc/analyzer/source_buffer"
     autoload :StatsdContainerListener, "cc/analyzer/statsd_container_listener"

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -43,7 +43,7 @@ module CC
         end
 
         write_config_file
-        CLI.debug "engine config: #{File.read(config_file).inspect}"
+        CLI.debug "engine config: #{config_file.read.inspect}"
         container.run(container_options)
       ensure
         delete_config_file
@@ -60,7 +60,7 @@ module CC
           "--net", "none",
           "--rm",
           "--volume", "#{@code_path}:/code:ro",
-          "--volume", "#{config_file}:/config.json:ro",
+          "--volume", "#{config_file.host_path}:/config.json:ro",
           "--user", "9000:9000"
         ]
       end
@@ -70,16 +70,15 @@ module CC
       end
 
       def write_config_file
-        FileUtils.mkdir_p(File.dirname(config_file))
-        File.write(config_file, @config.to_json)
+        config_file.write(@config.to_json)
       end
 
       def delete_config_file
-        File.delete(config_file) if File.file?(config_file)
+        config_file.delete if config_file.file?
       end
 
       def config_file
-        @config_file ||= File.join("/tmp/cc", SecureRandom.uuid)
+        @config_file ||= MountedPath.tmp.join(SecureRandom.uuid)
       end
 
       def output_filter

--- a/lib/cc/analyzer/mounted_path.rb
+++ b/lib/cc/analyzer/mounted_path.rb
@@ -1,0 +1,80 @@
+module CC
+  module Analyzer
+    class MountedPath
+      DEFAULT_CODECLIMATE_TMP = "/tmp/cc".freeze
+
+      def self.code
+        host_prefix = ENV["CODECLIMATE_CODE"]
+        host_prefix ||= ENV["CODE_PATH"] # deprecated
+
+        if ENV["CODECLIMATE_DOCKER"]
+          new(host_prefix, "/code")
+        else
+          host_prefix ||= Dir.pwd
+
+          new(host_prefix, host_prefix)
+        end
+      end
+
+      def self.tmp
+        host_prefix = ENV["CODECLIMATE_TMP"]
+        host_prefix ||= DEFAULT_CODECLIMATE_TMP
+
+        if ENV["CODECLIMATE_DOCKER"]
+          new(host_prefix, "/tmp/cc")
+        else
+          new(host_prefix, host_prefix)
+        end
+      end
+
+      def initialize(host_prefix, container_prefix, path = nil)
+        @host_prefix = host_prefix
+        @container_prefix = container_prefix
+        @path = path
+      end
+
+      def host_path
+        if path
+          File.join(host_prefix, path)
+        else
+          host_prefix
+        end
+      end
+
+      def container_path
+        if path
+          File.join(container_prefix, path)
+        else
+          container_prefix
+        end
+      end
+
+      def join(path)
+        @path = path
+
+        self
+      end
+
+      def file?
+        File.file?(container_path)
+      end
+
+      def read
+        File.read(container_path)
+      end
+
+      def write(content)
+        FileUtils.mkdir_p(File.dirname(container_path))
+        File.write(container_path, content)
+      end
+
+      def delete
+        File.delete(container_path)
+      end
+
+      private
+
+      attr_reader :host_prefix, :container_prefix, :path
+    end
+  end
+end

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -15,7 +15,7 @@ module CC
       def run
         require_codeclimate_yml
 
-        Dir.chdir(ENV["FILESYSTEM_DIR"]) do
+        Dir.chdir(MountedPath.code.container_path) do
           runner = EnginesRunner.new(registry, formatter, source_dir, config, path_options)
           runner.run
         end
@@ -57,7 +57,7 @@ module CC
       end
 
       def source_dir
-        ENV["CODE_PATH"]
+        MountedPath.code.host_path
       end
 
       def config

--- a/lib/cc/cli/command.rb
+++ b/lib/cc/cli/command.rb
@@ -58,7 +58,9 @@ module CC
       end
 
       def filesystem
-        @filesystem ||= CC::Analyzer::Filesystem.new(ENV["FILESYSTEM_DIR"])
+        @filesystem ||= CC::Analyzer::Filesystem.new(
+          CC::Analyzer::MountedPath.code.container_path
+        )
       end
 
       def terminal

--- a/lib/cc/cli/test.rb
+++ b/lib/cc/cli/test.rb
@@ -89,14 +89,8 @@ module CC
         remove_null_container
       end
 
-      def within_tempdir
-        tmpdir = create_tmpdir
-
-        Dir.chdir(tmpdir) do
-          yield
-        end
-      ensure
-        FileUtils.rm_rf(tmpdir)
+      def within_tempdir(&block)
+        Dir.mktmpdir { |tmp| Dir.chdir(tmp, &block) }
       end
 
       def unpack_tests
@@ -219,12 +213,6 @@ module CC
             end
           end
         end
-      end
-
-      def create_tmpdir
-        tmpdir = File.join("/tmp/cc", SecureRandom.uuid)
-        FileUtils.mkdir_p(tmpdir)
-        tmpdir
       end
 
       def unpack(path)

--- a/lib/cc/cli/test.rb
+++ b/lib/cc/cli/test.rb
@@ -1,4 +1,3 @@
-require "shellwords"
 require "cc/yaml"
 
 module CC
@@ -181,15 +180,12 @@ module CC
       def codeclimate_analyze(relative_path)
         codeclimate_path = File.expand_path(File.join(File.dirname(__FILE__), "../../../bin/codeclimate"))
 
-        system([
-          "unset CODE_PATH &&",
-          "unset FILESYSTEM_DIR &&",
-          Shellwords.escape(codeclimate_path),
-          "analyze",
-          "--engine", Shellwords.escape(@engine_name),
+        system(
+          codeclimate_path, "analyze",
+          "--engine", @engine_name,
           "-f", "json",
-          Shellwords.escape(relative_path)
-        ].join(" "))
+          relative_path
+        )
       end
 
       def prepare_working_dir

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -2,10 +2,6 @@ require "spec_helper"
 
 module CC::Analyzer
   describe Engine do
-    before do
-      FileUtils.mkdir_p("/tmp/cc")
-    end
-
     describe "#run" do
       it "passes the correct options to Container" do
         container = double

--- a/spec/cc/analyzer/formatters/json_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/json_formatter_spec.rb
@@ -5,7 +5,9 @@ module CC::Analyzer::Formatters
     include Factory
 
     let(:formatter) do
-      filesystem ||= CC::Analyzer::Filesystem.new(ENV['FILESYSTEM_DIR'])
+      filesystem ||= CC::Analyzer::Filesystem.new(
+        CC::Analyzer::MountedPath.code.container_path
+      )
       JSONFormatter.new(filesystem)
     end
 

--- a/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
@@ -5,7 +5,9 @@ module CC::Analyzer::Formatters
     include Factory
 
     let(:formatter) do
-      filesystem ||= CC::Analyzer::Filesystem.new(ENV['FILESYSTEM_DIR'])
+      filesystem ||= CC::Analyzer::Filesystem.new(
+        CC::Analyzer::MountedPath.code.container_path
+      )
       PlainTextFormatter.new(filesystem)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,4 +9,5 @@ Dir.glob("spec/support/**/*.rb").each(&method(:load))
 
 SafeYAML::OPTIONS[:default_mode] = :safe
 
-ENV["FILESYSTEM_DIR"] = "."
+ENV.delete("CODECLIMATE_DOCKER")
+ENV["CODECLIMATE_TMP"] = Dir.mktmpdir


### PR DESCRIPTION
This was some work I did on a plane ride a few weeks ago and forgot to PR until
now. The main driver for this change is that is allows users to stop us from
creating a root-owned `/tmp/cc` on their systems. As part of doing so, I was
able to (I think) clean up the code a bit and solve an issue where our test
suite would also create (or be impaired by) the root-owned temp directory.

I've tested local analysis, changing the temp location, and even changing the
code location to analyze some other, non-current directory. I still need to
test that builder can use this interface as-is.

/cc @codeclimate/review

---

Adds a "MountedPath" abstraction that provides a single identity for the case
where we have an in-container path and need to know the on-host path it
represents for the purpose of re-mounting into other containers.

Removes the hap-hazard FILESYSTEM_DIR and inconsistently-named CODE_PATH
environment variables. FILESYSTEM_DIR goes away as MountedPath can maintain
that functionality itself. CODE_PATH is replaced with CODECLIMATE_CODE to be
consistent with the new CODECLIMATE_TMP and existing CODECLIMATE_DEBUG.

We continue to read CODE_PATH if CODECLIMATE_CODE is unspecified. This is to
support any existing users with their own wrapper scripts in the wild
(interestingly, Builder fits in this category).

MountedPath internally makes use of a CODECLIMATE_DOCKER variable to set the
local and in-container paths as equal if not being run in a container. This
makes local development and testing more convenient.

Having CODECLIMATE_TMP means we don't have to force a root-owned /tmp/cc on our
users' machines. Users can set this variable to whatever they want. We make use
of this in the specs.

Builder should work as-is. It assumes /tmp/cc, but that was maintained as the
default when CODECLIMATE_TEMP is not set. We would now be free to use that
variable to make a build-specific temporary directory though.

One unknown: the test subcommand was messing with the CODE_PATH and
FILESYSTEM_DIR variables as part of running its analysis. This code is untested
(ha) and I don't understand it, so I'm not sure what needs to change to support
the MountedPath approach.