### PR TITLE
Exclude files that begin with a dash

### DIFF
--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -73,7 +73,7 @@ module CC
         @non_excluded_paths ||= begin
           excludes = exclude_paths.map { |path| path.chomp("/") }
           filesystem.ls.reject do |path|
-            path.starts_with?(".") || excludes.include?(path)
+            path.starts_with?("-") || path.starts_with?(".") || excludes.include?(path)
           end
         end
       end

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -74,6 +74,14 @@ module CC::CLI
 
         expect { generator.eligible_engines }.to raise_error(CC::CLI::ConfigGenerator::ConfigGeneratorError)
       end
+
+      it "doesn't die on - files" do
+        make_tree <<-EOM
+          -H
+        EOM
+
+        expect { generator.eligible_engines }.not_to raise_error
+      end
     end
 
     describe "#errors" do


### PR DESCRIPTION
These cause problems for the `find` command we run, so it's best we just
exclude them.

@codeclimate/review