### PR TITLE
Use Analyzer.logger within Analyzer classes

### DIFF
--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -49,7 +49,7 @@ module CC
         @listener.started(container_data)
 
         command = docker_run_command(options)
-        CLI.debug("docker run: #{command.inspect}")
+        Analyzer.logger.debug("docker run: #{command.inspect}")
         pid, _, out, err = POSIX::Spawn.popen4(*command)
 
         @t_out = read_stdout(out)

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -34,7 +34,7 @@ module CC
         )
 
         container.on_output("\0") do |raw_output|
-          CLI.debug "engine output: #{raw_output.inspect}"
+          Analyzer.logger.debug "engine output: #{raw_output.inspect}"
           output = EngineOutput.new(raw_output)
 
           unless output_filter.filter?(output)
@@ -43,7 +43,7 @@ module CC
         end
 
         write_config_file
-        CLI.debug "engine config: #{config_file.read.inspect}"
+        Analyzer.logger.debug "engine config: #{config_file.read.inspect}"
         container.run(container_options)
       ensure
         delete_config_file

--- a/lib/cc/cli.rb
+++ b/lib/cc/cli.rb
@@ -17,15 +17,25 @@ module CC
     autoload :ValidateConfig, "cc/cli/validate_config"
     autoload :Version, "cc/cli/version"
 
-    def self.debug(message, values = {})
-      if ENV["CODECLIMATE_DEBUG"]
-        if values.any?
-          message << " "
-          message << values.map { |k, v| "#{k}=#{v.inspect}" }.join(" ")
-        end
+    class Logger
+      def debug(message, values = {})
+        if ENV["CODECLIMATE_DEBUG"]
+          if values.any?
+            message << " "
+            message << values.map { |k, v| "#{k}=#{v.inspect}" }.join(" ")
+          end
 
-        $stderr.puts("[DEBUG] #{message}")
+          # Leading and trailing newlines to prevent mangling
+          $stderr.print("\n[DEBUG] #{message}\n")
+        end
+      end
+
+      # Any non-DEBUG output is handled not via logging
+      def method_missing(*)
+        yield if block_given?
       end
     end
+
+    CC::Analyzer.logger = Logger.new
   end
 end

--- a/lib/cc/cli/runner.rb
+++ b/lib/cc/cli/runner.rb
@@ -10,7 +10,7 @@ module CC
       rescue => ex
         $stderr.puts("error: (#{ex.class}) #{ex.message}")
 
-        CLI.debug("backtrace: #{ex.backtrace.join("\n\t")}")
+        Analyzer.logger.debug("backtrace: #{ex.backtrace.join("\n\t")}")
       end
 
       def initialize(args)

--- a/lib/cc/workspace/path_tree/dir_node.rb
+++ b/lib/cc/workspace/path_tree/dir_node.rb
@@ -40,7 +40,7 @@ module CC
             children[entry.basename.to_s] = PathTree.node_for_pathname(entry)
             children[entry.basename.to_s].add(*tail)
           else
-            CLI.debug("Couldn't include because part of path doesn't exist.", path: File.join(root_path, head))
+            Analyzer.logger.debug("Couldn't include because part of path doesn't exist.", path: File.join(root_path, head))
           end
         end
 


### PR DESCRIPTION
Using CLI.debug caused an awkward scenario where Builder had to require cc/cli
to bring it into scope when using Analyzer classes. This change uses the
existing Analyzer.logger interface to provide the debug functionality. Said
functionality now also uses print and bookends messages with newlines to avoid
mangling due to threading with the analysis spinner.

Note: The CLI logger only provides debug, because in the context of CLI any
non-DEBUG output should be displayed via normal, user-friendly channels.

/cc @codeclimate/review