### PR TITLE
Remove check as gem executable

### DIFF
--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files         = Dir["lib/**/*.rb"] + Dir["bin/*"] + Dir.glob("config/**/*", File::FNM_DOTMATCH)
   s.require_paths = ["lib"]
   s.bindir        = "bin"
-  s.executables   = %w(check codeclimate-init)
+  s.executables   = %w(codeclimate-init)
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"


### PR DESCRIPTION
Executables should only be ruby scripts as per
http://guides.rubygems.org/specification-reference/#executables

Fixes #381

@codeclimate/review