### PR TITLE
Revert "Install codeclimate-wrapper from image"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,7 @@ install:
 	  awk '/codeclimate\/codeclimate-/ { print $$1 }' | \
 	  xargs -n1 docker pull 2>/dev/null || true
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	docker run --rm \
-	  --volume $(DESTDIR)$(PREFIX)/bin:/host-bin \
-	  --entrypoint /bin/cp codeclimate/codeclimate \
-	    /usr/src/app/codeclimate-wrapper /host-bin/codeclimate
+	install -m 0755 codeclimate-wrapper $(DESTDIR)$(PREFIX)/bin/codeclimate
 
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/codeclimate


### PR DESCRIPTION
This reverts commit e26b09eaa5e57445f63d8aba71dee95cb507a2b0.

This doesn't work on docker-machine because the host path is in the VM and we
need to install locally. We'll have to take the risk of getting the wrapper out
of sync.

/cc @codeclimate/review