### PR TITLE
Require YAML in Analyzer and CLI

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module CC
   module Analyzer
     autoload :CompositeContainerListener, "cc/analyzer/composite_container_listener"

--- a/lib/cc/analyzer/config.rb
+++ b/lib/cc/analyzer/config.rb
@@ -1,5 +1,3 @@
-require "yaml"
-
 module CC
   module Analyzer
     # TODO: replace each use of this with CC::Yaml and remove it

--- a/lib/cc/cli.rb
+++ b/lib/cc/cli.rb
@@ -1,5 +1,6 @@
 require "active_support"
 require "active_support/core_ext"
+require "yaml"
 require "cc/analyzer"
 require "cc/workspace"
 require "cc/yaml"


### PR DESCRIPTION
YAML is not loaded by default and now that we're using `.safe_load` from Psych
instead of the `safe_yaml` gem, we have load it explicitly.

```console
$ codeclimate analyze
error: (NameError) uninitialized constant CC::Analyzer::EngineRegistry::YAML
```