### PR TITLE
Ensure Workspace#clone clones everything

### DIFF
--- a/lib/cc/workspace/path_tree/dir_node.rb
+++ b/lib/cc/workspace/path_tree/dir_node.rb
@@ -4,11 +4,13 @@ module CC
       class DirNode
         def initialize(root_path, children = {})
           @root_path = root_path.dup.freeze
-          @children = children
+          @children = children.each_with_object({}) do |(k, v), memo|
+            memo[k.clone] = v.clone
+          end
         end
 
         def clone
-          self.class.new(root_path, children.dup)
+          self.class.new(root_path, children)
         end
 
         def all_paths
@@ -37,8 +39,8 @@ module CC
           return if head.nil? && tail.empty?
 
           if (entry = find_direct_child(head))
-            children[entry.basename.to_s] = PathTree.node_for_pathname(entry)
-            children[entry.basename.to_s].add(*tail)
+            children[entry.basename.to_s.dup.freeze] = PathTree.node_for_pathname(entry)
+            children[entry.basename.to_s.dup.freeze].add(*tail)
           else
             CLI.debug("Couldn't include because part of path doesn't exist.", path: File.join(root_path, head))
           end

--- a/spec/cc/workspace_spec.rb
+++ b/spec/cc/workspace_spec.rb
@@ -90,6 +90,8 @@ module CC
           lib/foo/baz.rb
           lib/quix/a.rb
           lib/quix/b.rb
+          skeleton/torso/ribcage/heart.rb
+          skeleton/torso/belly/liver.rb
           spec/foo/bar_spec.rb
           spec/foo/baz_spec.rb
           spec/foo_spec.rb
@@ -100,12 +102,13 @@ module CC
         workspace = Workspace.new
         workspace.remove(%w[.node_modules])
         workspace2 = workspace.clone
-        workspace2.remove(%w[vendor])
+        workspace2.remove(%w[vendor **/ribcage/**])
 
         expect(workspace.paths.sort).to eq %w[
           Gemfile
           Gemfile.lock
           lib/
+          skeleton/
           spec/
           vendor/
         ]
@@ -113,6 +116,7 @@ module CC
           Gemfile
           Gemfile.lock
           lib/
+          skeleton/torso/belly/
           spec/
         ]
       end


### PR DESCRIPTION
`Hash#dup` does not `dup` values: I don't know why I thought it did. As a
result, excluding files deeper than 1 level in the workspace would apply
to the global workspace copy, not only the engine-specific workspace copy.

The fix here manually deep-clones the `children` hash, and `freezes`
some keys for good measure.

cc @codeclimate/review. This is intended to fix #397.