### PR TITLE
Don't try to show spinner when debug is on

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -34,7 +34,7 @@ module CC
         )
 
         container.on_output("\0") do |raw_output|
-          CLI.debug "engine output: #{raw_output.inspect}"
+          CLI.debug "#{name} engine output: #{raw_output.inspect}"
           output = EngineOutput.new(raw_output)
 
           unless output_filter.filter?(output)
@@ -43,7 +43,7 @@ module CC
         end
 
         write_config_file
-        CLI.debug "engine config: #{config_file.read.inspect}"
+        CLI.debug "#{name} engine config: #{config_file.read.inspect}"
         container.run(container_options)
       ensure
         delete_config_file

--- a/lib/cc/analyzer/formatters/spinner.rb
+++ b/lib/cc/analyzer/formatters/spinner.rb
@@ -7,7 +7,7 @@ module CC
         end
 
         def start
-          return unless $stdout.tty?
+          return unless $stdout.tty? && !CLI.debug?
           @thread = Thread.new do
             loop do
               @spinning = true

--- a/lib/cc/cli.rb
+++ b/lib/cc/cli.rb
@@ -18,8 +18,12 @@ module CC
     autoload :ValidateConfig, "cc/cli/validate_config"
     autoload :Version, "cc/cli/version"
 
+    def self.debug?
+      ENV["CODECLIMATE_DEBUG"]
+    end
+
     def self.debug(message, values = {})
-      if ENV["CODECLIMATE_DEBUG"]
+      if debug?
         if values.any?
           message << " "
           message << values.map { |k, v| "#{k}=#{v.inspect}" }.join(" ")


### PR DESCRIPTION
The TTY spinner doesn't play well with debug output, and can create some odd interspersing of text.

Skipping the spinner results in the "Running..." status line not being output at all, so
I added the engine name to the relevant debug lines for clarity.

cc @codeclimate/review