### PR TITLE
Don't crash `init` in an empty directory.

### DIFF
--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -64,9 +64,8 @@ module CC
       end
 
       def available_engine_configs
-        engine_names = existing_cc_config.engines.select do |_, config|
-          config.enabled?
-        end.keys
+        engines = existing_cc_config.engines || {}
+        engine_names = engines.select { |_, config| config.enabled? }.keys
 
         all_paths = engine_names.flat_map do |engine_name|
           engine_directory = File.expand_path("../../../../config/#{engine_name}", __FILE__)

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -44,6 +44,21 @@ module CC::CLI
           expect(CC::Yaml.parse(new_content).errors).to be_empty
         end
 
+        it "runs when the directory is empty" do
+          _, _, exit_code = capture_io_and_exit_code do
+            init = Init.new
+            init.run
+          end
+
+          expect(exit_code).to eq(0)
+          config = YAML.safe_load(File.read(".codeclimate.yml"))
+          expect(config).to eq({
+            "engines" => {},
+            "ratings" => { "paths" => [] },
+            "exclude_paths" => []
+          })
+        end
+
         describe 'when default config for engine is available' do
           describe 'when no config file for this engine exists in working directory' do
             it 'creates .engine.yml with default config' do


### PR DESCRIPTION
Running `init` in an empty directory correctly set up an empty config
yml, but then crashed trying to look for engine configs.

cc @codeclimate/review