### PR TITLE
Debug mode improvements

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -34,7 +34,7 @@ module CC
         )
 
         container.on_output("\0") do |raw_output|
-          CLI.debug "#{name} engine output: #{raw_output.inspect}"
+          CLI.debug("#{name} engine output: #{raw_output.strip}")
           output = EngineOutput.new(raw_output)
 
           unless output_filter.filter?(output)
@@ -43,8 +43,10 @@ module CC
         end
 
         write_config_file
-        CLI.debug "#{name} engine config: #{config_file.read.inspect}"
-        container.run(container_options)
+        CLI.debug("#{name} engine config: #{config_file.read}")
+        container.run(container_options).tap do |result|
+          CLI.debug("#{name} engine stderr: #{result.stderr}")
+        end
       ensure
         delete_config_file
       end

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -6,7 +6,9 @@ module CC::Analyzer
       it "passes the correct options to Container" do
         container = double
         allow(container).to receive(:on_output).and_yield("")
-        allow(container).to receive(:run)
+        allow(container).to receive(:run).and_return(
+          Container::Result.new(0, false, 1, false, 10, ""),
+        )
 
         expect(Container).to receive(:new) do |args|
           expect(args[:image]).to eq "codeclimate/foo"
@@ -32,7 +34,7 @@ module CC::Analyzer
           "--rm",
           "--volume", "/code:/code:ro",
           "--user", "9000:9000",
-        ))
+        )).and_return(Container::Result.new(0, false, 1, false, 10, ""))
 
         expect(Container).to receive(:new).and_return(container)
         engine = Engine.new("", {}, "/code", {}, "a-label")
@@ -42,7 +44,9 @@ module CC::Analyzer
       it "passes a composite container listener wrapping the given one" do
         container = double
         allow(container).to receive(:on_output).and_yield("")
-        allow(container).to receive(:run)
+        allow(container).to receive(:run).and_return(
+          Container::Result.new(0, false, 1, false, 10, "")
+        )
 
         given_listener = double
         container_listener = double

--- a/spec/support/test_container.rb
+++ b/spec/support/test_container.rb
@@ -10,5 +10,6 @@ class TestContainer
 
   def run(*)
     @outputs.each { |output| @on_output.call(output) }
+    ::CC::Analyzer::Container::Result.new(0, false, 1, false, 10, "")
   end
 end


### PR DESCRIPTION
The stderr here is a straight feature addition that I think will be important for the usefulness of the debug output.

The changes to string-escaping are a bit trickier, and probably merit some discussion. When all the output was escaped using `#inspect`, I personally found it difficult to read directly in the terminal.
It also made it harder to copy-paste directly into a JSON file. I recognize that the probable intent was to make it very easy to copy into a REPL, but since Ruby allows using `%[]` instead of quotes for literal strings, I don't think making the output easier to read/use elsewhere blocks that use case. The current choice of manually-escaping newlines/tabs might not be quite right, though. Thoughts, @codeclimate/review?