### PR TITLE
Fix analyzer path bug

### DIFF
--- a/lib/cc/workspace/path_tree/dir_node.rb
+++ b/lib/cc/workspace/path_tree/dir_node.rb
@@ -39,7 +39,7 @@ module CC
           return if head.nil? && tail.empty?
 
           if (entry = find_direct_child(head))
-            children[entry.basename.to_s.dup.freeze] = PathTree.node_for_pathname(entry)
+            children[entry.basename.to_s.dup.freeze] ||= PathTree.node_for_pathname(entry)
             children[entry.basename.to_s.dup.freeze].add(*tail)
           else
             CLI.debug("Couldn't include because part of path doesn't exist.", path: File.join(root_path, head))

--- a/spec/cc/workspace/path_tree_spec.rb
+++ b/spec/cc/workspace/path_tree_spec.rb
@@ -28,8 +28,8 @@ class CC::Workspace
         make_fixture_tree
 
         tree = PathTree.for_path(".")
-        tree.include_paths([".git/refs/", "code/"])
-        expect(tree.all_paths.sort).to eq [".git/refs/", "code/"]
+        tree.include_paths([".git/refs/", "code/foo.rb", "code/a/bar.rb"])
+        expect(tree.all_paths.sort).to eq [".git/refs/", "code/a/bar.rb", "code/foo.rb"]
       end
     end
 


### PR DESCRIPTION
When trying to add multiple paths with common parent, somehow some of
the paths are not added correctly. This is because the parent node is
always initialized even if it has been initialized before.

Example:
I have these files:
````
.git/FETCH_HEAD
.git/refs/heads/master
code/a/bar.rb
code/a/baz.rb
code/foo.rb
foo.txt
lib/thing.rb
````
Then run:
````
codeclimate analyze code/foo.rb code/a/bar.rb
````
It only evaluates `code/a/bar.rb`