### PR TITLE
Validate when creating an IssueValidator object

### DIFF
--- a/lib/cc/analyzer/issue_validator.rb
+++ b/lib/cc/analyzer/issue_validator.rb
@@ -15,9 +15,10 @@ module CC
 
       def initialize(issue)
         @issue = issue
+        validate
       end
 
-      def valid?
+      def validate
         return @valid unless @valid.nil?
 
         if issue && invalid_messages.any?
@@ -30,6 +31,7 @@ module CC
           @valid = true
         end
       end
+      alias valid? validate
 
       private
 


### PR DESCRIPTION
This makes it so that you can call `error` without necessarily checking
`valid?` first.

Fixes #413 

@codeclimate/review 