### PR TITLE
Add SourceFingerprint based on path, check_name, and source

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -31,6 +31,8 @@ module CC
     autoload :MountedPath, "cc/analyzer/mounted_path"
     autoload :RaisingContainerListener, "cc/analyzer/raising_container_listener"
     autoload :SourceBuffer, "cc/analyzer/source_buffer"
+    autoload :SourceExtractor, "cc/analyzer/source_extractor"
+    autoload :SourceFingerprint, "cc/analyzer/source_fingerprint"
     autoload :StatsdContainerListener, "cc/analyzer/statsd_container_listener"
     autoload :Validation, "cc/analyzer/validation"
 

--- a/lib/cc/analyzer/issue.rb
+++ b/lib/cc/analyzer/issue.rb
@@ -34,24 +34,20 @@ module CC
         end
       end
 
+      def path
+        parsed_output.fetch("location", {}).fetch("path", "")
+      end
+
       private
 
       attr_reader :output
 
       def default_fingerprint
-        digest = Digest::MD5.new
-        digest << path
-        digest << "|"
-        digest << check_name.to_s
-        digest.to_s
+        SourceFingerprint.new(self).compute
       end
 
       def parsed_output
         @parsed_output ||= JSON.parse(output)
-      end
-
-      def path
-        parsed_output.fetch("location", {}).fetch("path", "")
       end
     end
   end

--- a/lib/cc/analyzer/source_extractor.rb
+++ b/lib/cc/analyzer/source_extractor.rb
@@ -1,0 +1,79 @@
+module CC
+  module Analyzer
+    class SourceExtractor
+      InvalidLocationPositions = Class.new(StandardError)
+
+      def initialize(source)
+        @source = source
+      end
+
+      def extract(location)
+        if (lines = location["lines"])
+          extract_from_lines(lines)
+        elsif (positions = location["positions"])
+          extract_from_positions(positions)
+        end
+      end
+
+      private
+
+      attr_reader :location, :source
+
+      def extract_from_lines(lines)
+        begin_index = lines.fetch("begin") - 1
+        end_index = lines.fetch("end") - 1
+        range = (begin_index..end_index)
+
+        source.each_line.with_object("").with_index do |(source_line, memo), index|
+          memo << source_line if range.include?(index)
+        end
+      end
+
+      def extract_from_positions(positions)
+        positions = convert_to_offsets(positions)
+        begin_offset = positions.fetch("begin").fetch("offset")
+        end_offset = positions.fetch("end").fetch("offset")
+        length = end_offset - begin_offset
+
+        source[begin_offset, length + 1]
+      end
+
+      def convert_to_offsets(positions)
+        positions.each do |key, value|
+          next if value["offset"]
+
+          validate_position_format!(value)
+
+          positions[key] = {
+            "offset" => to_offset(value["line"] - 1, value["column"] - 1),
+          }
+        end
+
+        positions
+      end
+
+      def validate_position_format!(position)
+        unless position.key?("line") && position.key?("column")
+          message = "Location positions must have either line/column or offset form"
+
+          raise InvalidLocationPositions, message
+        end
+      end
+
+      def to_offset(line, column, offset = 0)
+        source.each_line.with_index do |source_line, index|
+          offset +=
+            if line == index
+              column
+            else
+              source_line.length
+            end
+
+          break if index >= line
+        end
+
+        offset
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/source_fingerprint.rb
+++ b/lib/cc/analyzer/source_fingerprint.rb
@@ -1,0 +1,32 @@
+require "digest/md5"
+
+module CC
+  module Analyzer
+    class SourceFingerprint
+      def initialize(issue)
+        @issue = issue
+      end
+
+      def compute
+        md5 = Digest::MD5.new
+        md5 << issue.path
+        md5 << issue.check_name.to_s
+        md5 << relevant_source.gsub(/\s+/, "") if relevant_source
+        md5.hexdigest
+      end
+
+      private
+
+      attr_reader :issue
+
+      def relevant_source
+        source = SourceExtractor.new(raw_source).extract(issue.location)
+        source if source && !source.empty?
+      end
+
+      def raw_source
+        @raw_source ||= File.read(issue.path)
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engine_output_filter_spec.rb
+++ b/spec/cc/analyzer/engine_output_filter_spec.rb
@@ -58,7 +58,10 @@ module CC::Analyzer
       issue = EngineOutput.new({
         "type" => "Issue",
         "check_name" => "foo",
-        "fingerprint" => "05a33ac5659c1e90cad1ce32ff8a91c0"
+        "fingerprint" => "05a33ac5659c1e90cad1ce32ff8a91c0",
+        "location" => {
+          "path" => "spec/fixtures/source.rb",
+        },
       }.to_json)
 
       filter = EngineOutputFilter.new(
@@ -76,6 +79,9 @@ module CC::Analyzer
       EngineOutput.new({
         "type" => EngineOutputFilter::ISSUE_TYPE,
         "check_name" => check_name,
+        "location" => {
+          "path" => "spec/fixtures/source.rb",
+        },
       }.to_json)
     end
 

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -80,7 +80,7 @@ module CC::Analyzer
           engine = Engine.new("", {}, "", {}, "")
           engine.run(stdout, ContainerListener.new)
 
-          expect(stdout.string).to eq "{\"type\":\"issue\",\"check_name\":\"foo\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"bf3ef3a12aa392f5c83ee15e2a8f213e\"}{\"type\":\"issue\",\"check_name\":\"bar\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"1db3b65f978773283dc75a6ccca493d9\"}{\"type\":\"issue\",\"check_name\":\"baz\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"e56aefc8514d527dfc2e46d28ada42d6\"}"
+          expect(stdout.string).to eq "{\"type\":\"issue\",\"check_name\":\"foo\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"bdc0c2bb1201c4739118a51481a86fa1\"}{\"type\":\"issue\",\"check_name\":\"bar\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"cbd5b8962eb9e2950fbb02f0ddf6c404\"}{\"type\":\"issue\",\"check_name\":\"baz\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"a08df13d51af2259c425551cb84c135f\"}"
         end
       end
 

--- a/spec/cc/analyzer/issue_spec.rb
+++ b/spec/cc/analyzer/issue_spec.rb
@@ -2,8 +2,8 @@ require "spec_helper"
 
 module CC::Analyzer
   describe Issue do
-    it "allows access to keys as methods" do
-      output = {
+    let(:output) do
+      {
         "categories" => ["Style"],
         "check_name" => "Rubocop/Style/Documentation",
         "description" => "Missing top-level class documentation comment.",
@@ -16,8 +16,11 @@ module CC::Analyzer
         },
         "remediation_points" => 10,
         "type" => "issue",
-      }.to_json
-      issue = Issue.new(output)
+      }
+    end
+
+    it "allows access to keys as methods" do
+      issue = Issue.new(output.to_json)
 
       expect(issue.respond_to?("check_name")).to eq true
       expect(issue.check_name).to eq("Rubocop/Style/Documentation")
@@ -25,65 +28,30 @@ module CC::Analyzer
 
     describe "#fingerprint" do
       it "adds a fingerprint when it is missing" do
-        output = {
-          "categories" => ["Style"],
-          "check_name" => "Rubocop/Style/Documentation",
-          "description" => "Missing top-level class documentation comment.",
-          "location"=> {
-            "lines" => {
-              "begin" => 32,
-              "end" => 40,
-            },
-            "path" => "lib/cc/analyzer/config.rb",
-          },
-          "remediation_points" => 10,
-          "type" => "issue",
-        }.to_json
-        issue = Issue.new(output)
+        issue = Issue.new(output.to_json)
 
-        expect(issue.fingerprint).to eq "9d20301efe0bbb8f87fb4eb15a71fc81"
+        expect(issue.fingerprint).to eq "433fae1189b03bcd9153dc8dce209fa5"
       end
 
       it "doesn't overwrite fingerprints within output" do
-        output = {
-          "categories" => ["Style"],
-          "check_name" => "Rubocop/Style/Documentation",
-          "description" => "Missing top-level class documentation comment.",
-          "fingerprint" => "foo",
-          "location"=> {
-            "lines" => {
-              "begin" => 32,
-              "end" => 40,
-            },
-            "path" => "lib/cc/analyzer/config.rb",
-          },
-          "remediation_points" => 10,
-          "type" => "issue",
-        }.to_json
-        issue = Issue.new(output)
+        output["fingerprint"] = "foo"
+
+        issue = Issue.new(output.to_json)
 
         expect(issue.fingerprint).to eq "foo"
+      end
+
+      it "uses the source fingerprint if env variable is present" do
+        issue = Issue.new(output.to_json)
+
+        expect(issue.fingerprint).to eq "433fae1189b03bcd9153dc8dce209fa5"
       end
     end
 
     describe "#as_json" do
       it "merges in defaulted attributes" do
-        output = {
-          "categories" => ["Style"],
-          "check_name" => "Rubocop/Style/Documentation",
-          "description" => "Missing top-level class documentation comment.",
-          "location"=> {
-            "lines" => {
-              "begin" => 32,
-              "end" => 40,
-            },
-            "path" => "lib/cc/analyzer/config.rb",
-          },
-          "remediation_points" => 10,
-          "type" => "issue",
-        }
         expected_additions = {
-          "fingerprint" => "9d20301efe0bbb8f87fb4eb15a71fc81",
+          "fingerprint" => "433fae1189b03bcd9153dc8dce209fa5",
         }
         issue = Issue.new(output.to_json)
 

--- a/spec/cc/analyzer/source_extractor_spec.rb
+++ b/spec/cc/analyzer/source_extractor_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+module CC::Analyzer
+  describe SourceExtractor do
+    describe "#extract" do
+      let(:source) { source = "class\n  def foo\n    p 'bar'\n  end\nend\n" }
+      let(:extractor) { SourceExtractor.new(source) }
+
+      it "extracts the source relavant to lines" do
+        location = {
+          "lines" => {
+            "begin" => 2,
+            "end" => 4,
+          },
+        }
+
+        expect(extractor.extract(location)).to eq("  def foo\n    p 'bar'\n  end\n")
+      end
+
+      it "extracts the source relavant to position offsets" do
+        location = {
+          "positions" => {
+            "begin" => { "offset" => 8 },
+            "end" => { "offset" => 14 }
+          },
+        }
+
+        expect(extractor.extract(location)).to eq("def foo")
+      end
+
+      it "extracts the source relavant to position coordinates" do
+        location = {
+          "positions" => {
+            "begin" => { "line" => 2, "column" => 3 },
+            "end" => { "line" => 3, "column" => 11 }
+          },
+        }
+
+        expect(extractor.extract(location)).to eq("def foo\n    p 'bar'")
+      end
+
+      it "raises an exception if position format is invalid" do
+        location = {
+          "positions" => {
+            "begin" => { "wrong" => 2, "key" => 3 },
+            "end" => { "wrong" => 3, "key" => 11 }
+          },
+        }
+
+        expect{ extractor.extract(location) }.to raise_error(
+          SourceExtractor::InvalidLocationPositions
+        )
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/source_fingerprint_spec.rb
+++ b/spec/cc/analyzer/source_fingerprint_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+
+module CC::Analyzer
+  describe SourceFingerprint do
+    describe "#compute" do
+      let(:output) do
+        output = {
+          "check_name" => "Check/Name",
+          "location" => {
+            "path" => "spec/fixtures/source.rb"
+          },
+        }
+      end
+
+      it "computes a fingerprint by path, check_name, and source" do
+        output["location"]["lines"] = {
+          "begin" => 2,
+          "end" => 4
+        }
+        issue = Issue.new(output.to_json)
+        fingerprint = SourceFingerprint.new(issue)
+
+        expect(fingerprint.compute).to eq("30f53a688723a198cd83d3e3377da7d0")
+      end
+
+      it "supports positions syntax" do
+        output["location"]["positions"] = {
+          "begin" => {
+            "line" => 2,
+            "column" => 7,
+          },
+          "end" => {
+            "offset" => 43,
+          },
+        }
+
+        issue = Issue.new(output.to_json)
+        fingerprint = SourceFingerprint.new(issue)
+
+        expect(fingerprint.compute).to eq("a3429245fd5f37cfddc9f1a6c7fd31b3")
+      end
+
+      it "incorporates partially available source in the fingerprint" do
+        output["location"]["lines"] = {
+          "begin" => 5,
+          "end" => 100
+        }
+        issue = Issue.new(output.to_json)
+        fingerprint = SourceFingerprint.new(issue)
+
+        expect(fingerprint.compute).to eq("84fbb18391c45d63ddc6f8d528d18ae6")
+      end
+
+      it "only incorporates source if source is available" do
+        output["location"]["lines"] = {
+          "begin" => 1000,
+          "end" => 1000
+        }
+        issue = Issue.new(output.to_json)
+        fingerprint = SourceFingerprint.new(issue)
+
+        expect(fingerprint.compute).to eq("eef541a28f83417a45808139d58b631d")
+      end
+    end
+  end
+end

--- a/spec/fixtures/source.rb
+++ b/spec/fixtures/source.rb
@@ -1,0 +1,5 @@
+class Source
+  def run
+    p "Run run run!"
+  end
+end


### PR DESCRIPTION
Currently, the default fingerprint for an issue is computed by creating an MD5 digest based on the path of the file which introduced the issue and the check name for the issue emitted.

The result of this fingerprint for many engines is that issues emitted with the same check name for the same file are given the same fingerprint. On codeclimate.com, we only show issues with unique fingerprints, so even if 100 issues were emitted for a file, if all issues share the same check name and thus the same fingerprint, we only show one issue.

Additionally, a fixed or introduced issue is often ignored if there are current issues with the same fingerprint already on the default branch.

This PR introduces new fingerprinting behavior to address these issues, first added to a [couple][markdownlint] [engines][shellcheck], that incorporates relevant source code into the fingerprint. ~~This implementation allows us to enable the new fingerprinting behavior with an environment variable so we can roll it out gradually.~~ Eventually, this will become the new default fingerprinting method for engines.

@codeclimate/review :mag_right:

[markdownlint]: https://github.com/jpignata/codeclimate-markdownlint
[shellcheck]: https://github.com/filib/codeclimate-shellcheck