### PR TITLE
Update default fingerprinting

### DIFF
--- a/lib/cc/analyzer/issue.rb
+++ b/lib/cc/analyzer/issue.rb
@@ -24,7 +24,7 @@ module CC
       end
 
       def fingerprint
-        parsed_output.fetch("fingerprint", default_fingerprint)
+        parsed_output.fetch("fingerprint") { default_fingerprint }
       end
 
       # Allow access to hash keys as methods

--- a/lib/cc/analyzer/issue_location_format_validation.rb
+++ b/lib/cc/analyzer/issue_location_format_validation.rb
@@ -30,13 +30,13 @@ module CC
       def valid_position?(position)
         position &&
           (
-            (position["line"] && position["column"]) ||
-            position["offset"]
+            [position["line"], position["column"]].all? { |value| value.is_a?(Integer) } ||
+            position["offset"].is_a?(Integer)
           )
       end
 
       def valid_lines?(lines)
-        lines.is_a?(Hash) && lines.key?("begin") && lines.key?("end")
+        lines.is_a?(Hash) && [lines["begin"], lines["end"]].all? { |value| value.is_a?(Integer) }
       end
     end
   end

--- a/lib/cc/analyzer/source_fingerprint.rb
+++ b/lib/cc/analyzer/source_fingerprint.rb
@@ -21,7 +21,10 @@ module CC
 
       def relevant_source
         source = SourceExtractor.new(raw_source).extract(issue.location)
-        source if source && !source.empty?
+
+        if source && !source.empty?
+          source.encode(Encoding::UTF_8, "binary", invalid: :replace, undef: :replace, replace: "")
+        end
       end
 
       def raw_source

--- a/spec/cc/analyzer/issue_location_format_validation_spec.rb
+++ b/spec/cc/analyzer/issue_location_format_validation_spec.rb
@@ -58,6 +58,37 @@ module CC::Analyzer
           }
         })).not_to be_valid
       end
+
+      it "returns false if the location line values are not integers" do
+        location = {
+          "lines" => {
+            "begin" => "1",
+            "end" => "2"
+          }
+        }
+
+        validation = IssueLocationFormatValidation.new("location" => location)
+
+        expect(validation).not_to be_valid
+      end
+
+      it "returns false if the location position values are not integers" do
+        location = {
+          "positions" => {
+            "begin" => {
+              "line" => "1",
+              "column" => "2"
+            },
+            "end" => {
+              "offset" => "20"
+            }
+          }
+        }
+
+        validation = IssueLocationFormatValidation.new("location" => location)
+
+        expect(validation).not_to be_valid
+      end
     end
   end
 end

--- a/spec/cc/analyzer/source_fingerprint_spec.rb
+++ b/spec/cc/analyzer/source_fingerprint_spec.rb
@@ -61,6 +61,23 @@ module CC::Analyzer
 
         expect(fingerprint.compute).to eq("eef541a28f83417a45808139d58b631d")
       end
+
+      it "clears out invalid UTF-8 bytes" do
+        output["location"] = {
+          "lines" => {
+            "begin" => 1,
+            "end" => 1
+          },
+          "path" => "spec/fixtures/stub.rb"
+        }
+
+        allow(File).to receive(:read).and_return("hi \255".force_encoding(Encoding::UTF_8))
+
+        issue = Issue.new(output.to_json)
+        fingerprint = SourceFingerprint.new(issue)
+
+        expect(fingerprint.compute).to eq("717ddedd698e51037903bad1d2b06c1b")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR introduces a few fixes based on testing the new default fingerprinting:

- Validate that issue line or position values are integers
- Lazily compute the default fingerprint
- Handle invalid UTF-8 bytes

 @codeclimate/review :mag_right: