### PR TITLE
Output test results in JUnit XML for CircleCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 coverage
+spec/reports

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gemspec
 group :test do
   gem "rake"
   gem "rspec"
+  gem "rspec_junit_formatter"
   gem "codeclimate-test-reporter", require: nil
 end

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ citest:
 	  --entrypoint bundle \
 	  --volume $(PWD)/.git:/usr/src/app/.git:ro \
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
+	  --volume $(CIRCLE_TEST_REPORTS):/usr/src/app/spec/reports \
 	  codeclimate/codeclimate exec rake spec:all spec:benchmark
 
 install:

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,9 @@ RSpec::Core::RakeTask.new(:spec) do |task|
 end
 
 desc "Run all specs, including slow ones"
-RSpec::Core::RakeTask.new("spec:all")
+RSpec::Core::RakeTask.new("spec:all") do |task|
+  task.rspec_opts = "--format progress --format RspecJunitFormatter --out spec/reports/junit.xml"
+end
 
 desc "Run benchmark specs"
 RSpec::Core::RakeTask.new("spec:benchmark") do |task|


### PR DESCRIPTION
💁  These changes add an extra output format for tests to enable CircleCI to consume them.

> CircleCI can collect test metadata from JUnit XML files and Cucumber JSON
> files. We’ll use the test metadata to give you better insight into your build.
> For our inferred steps that use parallelism, we’ll use the timing information
> to get you better test splits and finish your builds faster.

https://circleci.com/docs/test-metadata/