### PR TITLE
Update Gemfile.lock to include rspec_junit_formatter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    builder (3.2.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     codeclimate-yaml (0.8.0)
@@ -52,6 +53,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rspec_junit_formatter (0.2.3)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
     secure_string (1.3.3)
     simplecov (0.10.0)
       docile (~> 1.1.0)
@@ -72,6 +76,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   rake
   rspec
+  rspec_junit_formatter
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
This PR updates the `Gemfile.lock` file with changes missing from #427.

@codeclimate/review :mag_right: