### PR TITLE
Update validation to ensure project relative issue paths

### DIFF
--- a/lib/cc/analyzer/issue_relative_path_validation.rb
+++ b/lib/cc/analyzer/issue_relative_path_validation.rb
@@ -10,7 +10,7 @@ module CC
       end
 
       def message
-        "Path must be relative"
+        "Path must be relative to the project directory"
       end
 
       private

--- a/lib/cc/analyzer/issue_relative_path_validation.rb
+++ b/lib/cc/analyzer/issue_relative_path_validation.rb
@@ -1,8 +1,12 @@
+require "pathname"
+
 module CC
   module Analyzer
     class IssueRelativePathValidation < Validation
       def valid?
-        path && !path.start_with?("/")
+        path &&
+          !path.start_with?("/") &&
+          relative_to?(MountedPath.code.container_path)
       end
 
       def message
@@ -10,6 +14,13 @@ module CC
       end
 
       private
+
+      def relative_to?(directory)
+        expanded_base = Pathname.new(directory).expand_path.to_s
+        expanded_path = Pathname.new(path).expand_path.to_s
+
+        expanded_path.start_with?(expanded_base)
+      end
 
       def path
         object.fetch("location", {})["path"]

--- a/spec/cc/analyzer/issue_relative_path_validation_spec.rb
+++ b/spec/cc/analyzer/issue_relative_path_validation_spec.rb
@@ -3,12 +3,26 @@ require "spec_helper"
 module CC::Analyzer
   describe IssueRelativePathValidation do
     describe "#valid?" do
-      it "returns true" do
-        expect(IssueRelativePathValidation.new("location" => { "path" => "foo.rb" })).to be_valid
+      it "returns true if path is relative to the project directory" do
+        expect(IssueRelativePathValidation.new("location" => {
+          "path" => "spec/fixtures/source.rb"
+        })).to be_valid
       end
 
-      it "returns false" do
-        expect(IssueRelativePathValidation.new("location" => { "path" => "/foo.rb" })).not_to be_valid
+      it "returns false if path is absolute" do
+        expect(IssueRelativePathValidation.new("location" => {
+          "path" => "#{MountedPath.code.container_path}/spec/fixtures/source.rb"
+        })).not_to be_valid
+      end
+
+      it "returns false if relative path moves up directories" do
+        expect(IssueRelativePathValidation.new("location" => {
+          "path" => "../../foo.rb"
+        })).not_to be_valid
+
+        expect(IssueRelativePathValidation.new("location" => {
+          "path" => "foo/../../../../bar"
+        })).not_to be_valid
       end
     end
   end

--- a/spec/cc/analyzer/issue_validator_spec.rb
+++ b/spec/cc/analyzer/issue_validator_spec.rb
@@ -27,7 +27,7 @@ module CC::Analyzer
         validator = IssueValidator.new({})
         expect(validator).not_to be_valid
         expect(validator.error).to eq(
-          message: "Category must be at least one of Bug Risk, Clarity, Compatibility, Complexity, Duplication, Performance, Security, Style; Check name must be present; Description must be present; Location is not formatted correctly; File does not exist: ''; Path must be present; Path must be relative; Type must be 'issue' but was '': `{}`.",
+          message: "Category must be at least one of Bug Risk, Clarity, Compatibility, Complexity, Duplication, Performance, Security, Style; Check name must be present; Description must be present; Location is not formatted correctly; File does not exist: ''; Path must be present; Path must be relative to the project directory; Type must be 'issue' but was '': `{}`.",
           issue: {},
         )
       end


### PR DESCRIPTION
This PR updates the `IssueRelativePathValidation` to ensure that issue paths
are relative to the code directory.

Both the issue path and code directory paths are expanded before the relative
check.

@codeclimate/review :mag_right: