### PR TITLE
Validate that issue-path is a file

### DIFF
--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -21,6 +21,7 @@ module CC
     autoload :IssueLocationFormatValidation, "cc/analyzer/issue_location_format_validation"
     autoload :IssueOtherLocationsFormatValidation, "cc/analyzer/issue_other_locations_format_validation"
     autoload :IssuePathExistenceValidation, "cc/analyzer/issue_path_existence_validation"
+    autoload :IssuePathIsFileValidation, "cc/analyzer/issue_path_is_file_validation"
     autoload :IssuePathPresenceValidation, "cc/analyzer/issue_path_presence_validation"
     autoload :IssueRelativePathValidation, "cc/analyzer/issue_relative_path_validation"
     autoload :IssueSorter, "cc/analyzer/issue_sorter"

--- a/lib/cc/analyzer/issue_path_is_file_validation.rb
+++ b/lib/cc/analyzer/issue_path_is_file_validation.rb
@@ -1,0 +1,19 @@
+module CC
+  module Analyzer
+    class IssuePathIsFileValidation < Validation
+      def valid?
+        File.file?(path)
+      end
+
+      def message
+        "Path is not a file: '#{path}'"
+      end
+
+      private
+
+      def path
+        object.fetch("location", {}).fetch("path", "")
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/issue_validator.rb
+++ b/lib/cc/analyzer/issue_validator.rb
@@ -8,6 +8,7 @@ module CC
         IssueLocationFormatValidation,
         IssueOtherLocationsFormatValidation,
         IssuePathExistenceValidation,
+        IssuePathIsFileValidation,
         IssuePathPresenceValidation,
         IssueRelativePathValidation,
         IssueTypeValidation,

--- a/spec/cc/analyzer/issue_path_is_file_validation_spec.rb
+++ b/spec/cc/analyzer/issue_path_is_file_validation_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+module CC::Analyzer
+  describe IssuePathIsFileValidation do
+    describe "#valid?" do
+      it "returns true" do
+        within_temp_dir do
+          make_file("foo.rb")
+
+          expect(IssuePathIsFileValidation.new("location" => { "path" => "foo.rb" })).to be_valid
+        end
+      end
+
+      it "returns false" do
+        within_temp_dir do
+          Dir.mkdir("foo.rb")
+
+          expect(IssuePathIsFileValidation.new("location" => { "path" => "foo.rb" })).not_to be_valid
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/issue_validator_spec.rb
+++ b/spec/cc/analyzer/issue_validator_spec.rb
@@ -27,7 +27,7 @@ module CC::Analyzer
         validator = IssueValidator.new({})
         expect(validator).not_to be_valid
         expect(validator.error).to eq(
-          message: "Category must be at least one of Bug Risk, Clarity, Compatibility, Complexity, Duplication, Performance, Security, Style; Check name must be present; Description must be present; Location is not formatted correctly; File does not exist: ''; Path must be present; Path must be relative to the project directory; Type must be 'issue' but was '': `{}`.",
+          message: "Category must be at least one of Bug Risk, Clarity, Compatibility, Complexity, Duplication, Performance, Security, Style; Check name must be present; Description must be present; Location is not formatted correctly; File does not exist: ''; Path is not a file: ''; Path must be present; Path must be relative to the project directory; Type must be 'issue' but was '': `{}`.",
           issue: {},
         )
       end


### PR DESCRIPTION
Emitting issues for directories is not something we currently support. Doing so
was not causing visible problems until we added source-based fingerprinting
which attempts to read the path and errors on directories:

https://bugsnag.com/code-climate/builder/errors/5736508dbe3f29e6a6c1cde8?event_id=573e507dba76e62611aa1445

Note: this still returns true for symlinks; discussion for how to handle those
cases is still open and this patch should not impact that behavior either way.

/cc @codeclimate/review