### PR TITLE
Add HTML formatter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       posix-spawn (~> 0.3, >= 0.3.11)
       pry (~> 0.10.1)
       rainbow (~> 2.0, >= 2.0.0)
+      redcarpet (~> 3.2)
       tty-spinner (~> 0.1.0)
 
 GEM
@@ -32,7 +33,7 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     method_source (0.8.2)
-    minitest (5.8.4)
+    minitest (5.9.0)
     posix-spawn (0.3.11)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -40,6 +41,7 @@ GEM
       slop (~> 3.4)
     rainbow (2.1.0)
     rake (10.4.2)
+    redcarpet (3.3.4)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency "posix-spawn", "~> 0.3", ">= 0.3.11"
   s.add_dependency "pry", "~> 0.10.1"
   s.add_dependency "rainbow", "~> 2.0", ">= 2.0.0"
+  s.add_dependency "redcarpet", "~> 3.2"
 end

--- a/lib/cc/analyzer/formatters.rb
+++ b/lib/cc/analyzer/formatters.rb
@@ -2,11 +2,13 @@ module CC
   module Analyzer
     module Formatters
       autoload :Formatter, "cc/analyzer/formatters/formatter"
+      autoload :HTMLFormatter, "cc/analyzer/formatters/html_formatter"
       autoload :JSONFormatter, "cc/analyzer/formatters/json_formatter"
       autoload :PlainTextFormatter, "cc/analyzer/formatters/plain_text_formatter"
       autoload :Spinner, "cc/analyzer/formatters/spinner"
 
       FORMATTERS = {
+        html: HTMLFormatter,
         json: JSONFormatter,
         text: PlainTextFormatter,
       }.freeze

--- a/lib/cc/analyzer/formatters/html_formatter.rb
+++ b/lib/cc/analyzer/formatters/html_formatter.rb
@@ -1,0 +1,82 @@
+require "redcarpet"
+require "active_support/number_helper"
+
+module CC
+  module Analyzer
+    module Formatters
+      class HTMLFormatter < Formatter
+        class ReportTemplate
+          include ERB::Util
+          attr_accessor :template, :issues, :issues_by_path
+
+          TEMPLATE_PATH = File.expand_path(File.join(File.dirname(__FILE__), "templates/html.erb"))
+
+          def initialize(issue_count, issues_by_path)
+            @template = File.read(TEMPLATE_PATH)
+            @issues_by_path = issues_by_path
+            @issue_count = issue_count
+          end
+
+          def render
+            ERB.new(@template).result(binding)
+          end
+
+          def pluralize(number, noun)
+            "#{ActiveSupport::NumberHelper.number_to_delimited(number)} #{noun.pluralize(number)}"
+          end
+        end
+
+        def write(data)
+          json = JSON.parse(data)
+          json["engine_name"] = current_engine.name
+
+          case json["type"].downcase
+          when "issue"
+            issues << json
+          when "warning"
+            warnings << json
+          else
+            raise "Invalid type found: #{json["type"]}"
+          end
+        end
+
+        def finished
+          template = ReportTemplate.new(issues.length, issues_by_path)
+          puts template.render
+        end
+
+        def failed(_)
+          exit 1
+        end
+
+        private
+
+        def issues
+          @issues ||= []
+        end
+
+        def issues_by_path
+          issues.group_by { |i| i["location"]["path"] }.sort.each do |_, file_issues|
+            IssueSorter.new(file_issues).by_location.map do |issue|
+              source_buffer = @filesystem.source_buffer_for(issue["location"]["path"])
+              issue["location"] = LocationDescription.new(source_buffer, issue["location"], "")
+              issue["description"] = render_readup_markdown(issue["description"])
+              if issue["content"]
+                issue["content"]["body"] = render_readup_markdown(issue["content"]["body"])
+              end
+            end
+          end
+        end
+
+        def warnings
+          @warnings ||= []
+        end
+
+        def render_readup_markdown(body)
+          html = Redcarpet::Render::HTML.new(escape_html: false, link_attributes: { target: "_blank" })
+          Redcarpet::Markdown.new(html, autolink: true, fenced_code_blocks: true, tables: true).render(body)
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/analyzer/formatters/templates/html.erb
+++ b/lib/cc/analyzer/formatters/templates/html.erb
@@ -1,0 +1,53 @@
+<html>
+  <head>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+  </head>
+  <body>
+  <div class="container">
+    <h2>Code Climate Analysis</h2>
+
+    <h3><%= pluralize(@issue_count, "issue") %> found in <%= @issues_by_path.size %> files.</h3>
+
+    <% @issues_by_path.each do |path, file_issues| %>
+      <hr>
+      <h4><a name='<%= path %>'><%= path %></a> (<%= pluralize(file_issues.size, "issue") %>)</h4>
+      <hr>
+      <% file_issues.each do |issue| %>
+        <table class="table table-striped">
+          <tr>
+            <td>Description</td><td><%= issue["description"] %></td>
+          </tr>
+          <tr>
+            <td>Location</td><td><%= path %>:<b><%= issue["location"] %></td>
+          </tr>
+          <tr>
+            <td>Engine</td><td><%= issue["engine_name"] %></td>
+          </tr>
+          <tr>
+            <td>Category</td><td><%= issue["categories"].join(",") %></td>
+          </tr>
+          <tr>
+            <td>Remediation points</td><td><%= issue["remediation_points"] %></td>
+          </tr>
+        </table>
+        <% if issue["content"] %>
+          <br/>
+          <button data-toggle="collapse"
+                  data-target='#readup<%= issue['fingerprint'] %>'>
+                  Toggle Readup
+          </button>
+          <div id='readup<%= issue["fingerprint"] %>' class='collapse'>
+            <hr>
+            <%= issue["content"]["body"] %>
+            <hr>
+          </div>
+        <% end %>
+        <hr>
+      <% end %>
+    <% end %>
+  </div>
+  </body>
+</html>

--- a/spec/cc/analyzer/formatters/html_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/html_formatter_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+module CC::Analyzer::Formatters
+  describe HTMLFormatter do
+    include Factory
+
+    let(:formatter) do
+      HTMLFormatter.new(CC::Analyzer::Filesystem.new(
+        CC::Analyzer::MountedPath.code.container_path
+      ))
+    end
+
+    describe "#finished" do
+      it "outputs an HTML report" do
+        engine = double(name: "cool_engine")
+
+        stdout, _ = capture_io do
+          issue = sample_issue({
+            "content"=> {
+              "body" => "### Sample Issue\n\n*Sample*"
+            }
+          })
+          write_from_engine(formatter, engine, issue)
+          formatter.finished
+        end
+
+        expect(stdout).to include("1 issue found in 1 files.")
+        expect(stdout).to include("<a name='lib/cc/analyzer/config.rb'>lib/cc/analyzer/config.rb</a> (1 issue)")
+        expect(stdout).to include("<h3>Sample Issue</h3>")
+      end
+    end
+
+    def write_from_engine(formatter, engine, issue)
+      formatter.engine_running(engine) do
+        formatter.write(issue.to_json)
+      end
+    end
+  end
+end

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -83,7 +83,7 @@ module Factory
     }
   end
 
-  def sample_issue
+  def sample_issue(options = {})
     {
       "type" => "issue",
       "check" => "Rubocop/Style/Documentation",
@@ -97,7 +97,7 @@ module Factory
           "end" => 40
         }
       }
-    }
+    }.merge(options)
   end
 end
 


### PR DESCRIPTION
This is going to be very helpful for engine developers, primarily because it gives them a chance to see HTML rendered output versions of their description and content body.

<img width="975" alt="screenshot 2016-05-20 18 02 19" src="https://cloud.githubusercontent.com/assets/2878/15443284/16354ad6-1eb5-11e6-84da-5a7bdd21a9a3.png">

