### PR TITLE
Support engine image channels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.29.0)
       activesupport (~> 4.2, >= 4.2.1)
-      codeclimate-yaml (~> 0.8.0)
+      codeclimate-yaml (~> 0.9.0)
       highline (~> 1.7, >= 1.7.2)
       posix-spawn (~> 0.3, >= 0.3.11)
       pry (~> 0.10.1)
@@ -23,7 +23,7 @@ GEM
     builder (3.2.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
-    codeclimate-yaml (0.8.0)
+    codeclimate-yaml (0.9.0)
       activesupport
       secure_string
     coderay (1.1.1)

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.8.0"
+  s.add_dependency "codeclimate-yaml", "~> 0.9.0"
   s.add_dependency "highline", "~> 1.7", ">= 1.7.2"
   s.add_dependency "posix-spawn", "~> 0.3", ">= 0.3.11"
   s.add_dependency "pry", "~> 0.10.1"

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -1,8 +1,8 @@
 # This file lists all the engines available to be run for analysis.
 #
-# Each engine must have an `image` and `description`. The value in `image` will
-# be passed to `docker run` and so may be any value appropriate for that
-# (repo/name:tag, image id, etc).
+# Each engine must have `channels` (with a `stable` key) and `description`. The
+# values in `channels` will be passed to `docker run` and so may be any value
+# appropriate for that (repo/name:tag, image id, etc).
 #
 # When a repo has files that match the `enable_regexps`, that engine will be
 # enabled by default in the codeclimate.yml file. That file will also have in it
@@ -10,7 +10,8 @@
 # which files should be rated.
 #
 brakeman:
-  image: codeclimate/codeclimate-brakeman
+  channels:
+    stable: codeclimate/codeclimate-brakeman
   description: Static analysis tool which checks Ruby on Rails applications for security vulnerabilities.
   community: false
   upgrade_languages:
@@ -25,7 +26,8 @@ brakeman:
     - "**.rhtml"
     - "**.slim"
 bundler-audit:
-  image: codeclimate/codeclimate-bundler-audit
+  channels:
+    stable: codeclimate/codeclimate-bundler-audit
   description: Patch-level verification for Bundler.
   community: false
   upgrade_languages:
@@ -35,7 +37,8 @@ bundler-audit:
   default_ratings_paths:
     - Gemfile.lock
 csslint:
-  image: codeclimate/codeclimate-csslint
+  channels:
+    stable: codeclimate/codeclimate-csslint
   description: Automated linting of Cascading Stylesheets.
   community: false
   enable_regexps:
@@ -43,7 +46,8 @@ csslint:
   default_ratings_paths:
     - "**.css"
 coffeelint:
-  image: codeclimate/codeclimate-coffeelint
+  channels:
+    stable: codeclimate/codeclimate-coffeelint
   description: A style checker for CoffeeScript.
   community: false
   enable_regexps:
@@ -51,7 +55,8 @@ coffeelint:
   default_ratings_paths:
     - "**.coffee"
 duplication:
-  image: codeclimate/codeclimate-duplication
+  channels:
+    stable: codeclimate/codeclimate-duplication
   description: Structural duplication detection for Ruby, Python, JavaScript, and PHP.
   community: false
   enable_regexps:
@@ -77,7 +82,8 @@ duplication:
       - python
       - php
 eslint:
-  image: codeclimate/codeclimate-eslint
+  channels:
+    stable: codeclimate/codeclimate-eslint
   description: A JavaScript/JSX linting utility.
   community: false
   upgrade_languages:
@@ -89,7 +95,8 @@ eslint:
     - "**.js"
     - "**.jsx"
 gofmt:
-  image: codeclimate/codeclimate-gofmt
+  channels:
+    stable: codeclimate/codeclimate-gofmt
   description: Checks the formatting of Go programs.
   community: true
   enable_regexps:
@@ -97,7 +104,8 @@ gofmt:
   default_ratings_paths:
     - "**.go"
 golint:
-  image: codeclimate/codeclimate-golint
+  channels:
+    stable: codeclimate/codeclimate-golint
   description: A linter for Go.
   community: true
   enable_regexps:
@@ -105,7 +113,8 @@ golint:
   default_ratings_paths:
     - "**.go"
 govet:
-  image: codeclimate/codeclimate-govet
+  channels:
+    stable: codeclimate/codeclimate-govet
   description: Reports suspicious constructs in Go programs.
   community: true
   enable_regexps:
@@ -113,20 +122,23 @@ govet:
   default_ratings_paths:
     - "**.go"
 fixme:
-  image: codeclimate/codeclimate-fixme
+  channels:
+    stable: codeclimate/codeclimate-fixme
   description: Finds FIXME, TODO, HACK, etc. comments.
   community: false
   enable_regexps:
     - .+
   default_ratings_paths: []
 foodcritic:
-  image: codeclimate/codeclimate-foodcritic
+  channels:
+    stable: codeclimate/codeclimate-foodcritic
   description: Lint tool for Chef cookbooks.
   community: true
   enable_regexps:
   default_ratings_paths:
 gnu-complexity:
-  image: codeclimate/codeclimate-gnu-complexity
+  channels:
+    stable: codeclimate/codeclimate-gnu-complexity
   description: Checks complexity of C code
   community: true
   enable_regexps:
@@ -134,7 +146,8 @@ gnu-complexity:
   default_ratings_paths:
     - "**.c"
 haxe-checkstyle:
-  image: codeclimate/codeclimate-haxe-checkstyle
+  channels:
+    stable: codeclimate/codeclimate-haxe-checkstyle
   description: Checkstyle is a development library to help developers write Haxe code that adheres to a coding standard.
   community: true
   enable_regexps:
@@ -142,7 +155,8 @@ haxe-checkstyle:
   default_ratings_paths:
     - "**.hx"
 hlint:
-  image: codeclimate/codeclimate-hlint
+  channels:
+    stable: codeclimate/codeclimate-hlint
   description: Linter for Haskell programs.
   community: true
   enable_regexps:
@@ -150,7 +164,8 @@ hlint:
   default_ratings_paths:
     - "**.hs"
 kibit:
-  image: codeclimate/codeclimate-kibit
+  channels:
+    stable: codeclimate/codeclimate-kibit
   description: Static code analyzer for Clojure, ClojureScript, cljx and other Clojure variants.
   community: true
   enable_regexps:
@@ -162,7 +177,8 @@ kibit:
     - "**.cljc"
     - "**.cljs"
 markdownlint:
-  image: codeclimate/codeclimate-markdownlint
+  channels:
+    stable: codeclimate/codeclimate-markdownlint
   description: Flags style issues within Markdown files.
   community: true
   enable_regexps:
@@ -172,20 +188,23 @@ markdownlint:
     - "**.markdown"
     - "**.md"
 nodesecurity:
-  image: codeclimate/codeclimate-nodesecurity
+  channels:
+    stable: codeclimate/codeclimate-nodesecurity
   description: Security tool for Node.js dependencies.
   community: true
   enable_regexps:
   default_ratings_paths:
 pep8:
-  image: codeclimate/codeclimate-pep8
+  channels:
+    stable: codeclimate/codeclimate-pep8
   description: Static analysis tool to check Python code against the style conventions outlined in PEP-8.
   community: false
   enable_regexps:
   default_ratings_paths:
     - "**.py"
 phan:
-  image: codeclimate/codeclimate-phan
+  channels:
+    stable: codeclimate/codeclimate-phan
   description: Phan is a static analyzer for PHP.
   community: true
   enable_regexps:
@@ -197,7 +216,8 @@ phan:
     - "**.module"
     - "**.inc"
 phpcodesniffer:
-  image: codeclimate/codeclimate-phpcodesniffer
+  channels:
+    stable: codeclimate/codeclimate-phpcodesniffer
   description: Detects violations of a defined set of coding standards in PHP.
   community: false
   enable_regexps:
@@ -206,7 +226,8 @@ phpcodesniffer:
     - "**.module"
     - "**.inc"
 phpmd:
-  image: codeclimate/codeclimate-phpmd
+  channels:
+    stable: codeclimate/codeclimate-phpmd
   description: A PHP static analysis tool.
   community: false
   upgrade_languages:
@@ -220,7 +241,8 @@ phpmd:
     - "**.module"
     - "**.inc"
 radon:
-  image: codeclimate/codeclimate-radon
+  channels:
+    stable: codeclimate/codeclimate-radon
   description: Python tool used to compute Cyclomatic Complexity.
   community: false
   upgrade_languages:
@@ -230,7 +252,8 @@ radon:
   default_ratings_paths:
     - "**.py"
 reek:
-  image: codeclimate/codeclimate-reek
+  channels:
+    stable: codeclimate/codeclimate-reek
   description: "Reek examines Ruby classes, modules, and methods and reports any code smells it finds."
   community: true
   upgrade_languages:
@@ -240,13 +263,15 @@ reek:
   default_ratings_paths:
     - "**.rb"
 requiresafe:
-  image: codeclimate/codeclimate-nodesecurity
+  channels:
+    stable: codeclimate/codeclimate-nodesecurity
   description: Security tool for Node.js dependencies.
   community: true
   enable_regexps:
   default_ratings_paths:
 rubocop:
-  image: codeclimate/codeclimate-rubocop
+  channels:
+    stable: codeclimate/codeclimate-rubocop
   description: A Ruby static code analyzer, based on the community Ruby style guide.
   community: false
   upgrade_languages:
@@ -256,28 +281,32 @@ rubocop:
   default_ratings_paths:
     - "**.rb"
 rubocop-v35:
-  image: codeclimate/codeclimate-rubocop:v35
+  channels:
+    stable: codeclimate/codeclimate-rubocop:v35
   description: A Ruby static code analyzer, based on the community Ruby style guide. Version 0.35.1 of RuboCop.
   community: false
   enable_regexps:
   default_ratings_paths:
     - "**.rb"
 rubymotion:
-  image: codeclimate/codeclimate-rubymotion
+  channels:
+    stable: codeclimate/codeclimate-rubymotion
   description: Rubymotion-specific rubocop checks.
   community: true
   enable_regexps:
   default_ratings_paths:
     - "**.rb"
 scss-lint:
-  image: codeclimate/codeclimate-scss-lint
+  channels:
+    stable: codeclimate/codeclimate-scss-lint
   description: Configurable tool for writing clean and consistent SCSS.
   community: true
   enable_regexps:
   default_ratings_paths:
     - "**.scss"
 shellcheck:
-  image: codeclimate/codeclimate-shellcheck
+  channels:
+    stable: codeclimate/codeclimate-shellcheck
   description: A static analysis tool for shell scripts.
   community: true
   enable_regexps:
@@ -285,7 +314,8 @@ shellcheck:
   default_ratings_paths:
     - "**.sh"
 tailor:
-  image: codeclimate/codeclimate-tailor
+  channels:
+    stable: codeclimate/codeclimate-tailor
   description: Cross-platform static analyzer and linter for Swift.
   community: true
   enable_regexps:
@@ -293,14 +323,16 @@ tailor:
   default_ratings_paths:
     - "**.swift"
 watson:
-  image: codeclimate/codeclimate-watson
+  channels:
+    stable: codeclimate/codeclimate-watson
   description: A young Ember Doctor to help you fix your code.
   community: true
   enable_regexps:
   default_ratings_paths:
     - "app/**"
 vint:
-  image: codeclimate/codeclimate-vint
+  channels:
+    stable: codeclimate/codeclimate-vint
   description: Fast and Highly Extensible Vim script Language Lint implemented by Python.
   community: true
   enable_regexps:

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -52,6 +52,11 @@ module CC
         container.run(container_options).tap do |result|
           CLI.debug("#{name} engine stderr: #{result.stderr}")
         end
+      rescue Container::ImageRequired
+        # Provide a clearer message given the context we have
+        message = "Unable to find an image for #{name}:#{@config["channel"]}."
+        message << " Available channels: #{@metadata["channels"].keys.inspect}."
+        raise Container::ImageRequired, message
       ensure
         delete_config_file
       end

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -83,10 +83,15 @@ module CC
 
       def add_engine_options
         engine_options.each do |engine|
+          name, channel = engine.split(":", 2)
+
           if config.engines.include?(engine)
-            config.engines[engine].enabled = true
+            config.engines[name].enabled = true
+            config.engines[name].channel = channel if channel
           else
-            config.engines[engine] = CC::Yaml::Nodes::Engine.new(config.engines).with_value("enabled" => true)
+            value = { "enabled" => true }
+            value["channel"] = channel if channel
+            config.engines[name] = CC::Yaml::Nodes::Engine.new(config.engines).with_value(value)
           end
         end
       end

--- a/lib/cc/cli/engines/install.rb
+++ b/lib/cc/cli/engines/install.rb
@@ -16,8 +16,8 @@ module CC
         def pull_docker_images
           engine_names.each do |name|
             if engine_registry.exists?(name)
-              image = engine_image(name)
-              pull_engine_image(image)
+              images = engine_registry[name]["channels"].values
+              images.each { |image| pull_engine_image(image) }
             else
               warn("unknown engine name: #{name}")
             end
@@ -26,10 +26,6 @@ module CC
 
         def engine_names
           @engine_names ||= parsed_yaml.engine_names
-        end
-
-        def engine_image(engine_name)
-          engine_registry_list[engine_name]["image"]
         end
 
         def pull_engine_image(engine_image)

--- a/lib/cc/cli/help.rb
+++ b/lib/cc/cli/help.rb
@@ -14,7 +14,7 @@ module CC
 
       def commands
         [
-          "analyze [-f format] [-e engine] <path>",
+          "analyze [-f format] [-e engine(:channel)] <path>",
           "console",
           "engines:disable #{underline("engine_name")}",
           "engines:enable #{underline("engine_name")}",

--- a/lib/cc/cli/test.rb
+++ b/lib/cc/cli/test.rb
@@ -234,7 +234,7 @@ module CC
       end
 
       def engine_image
-        engine_registry[@engine_name]["image"]
+        engine_registry[@engine_name]["channels"]["stable"]
       end
 
       # Stolen from ActiveSupport (where it was deprecated)

--- a/spec/cc/analyzer/engine_registry_spec.rb
+++ b/spec/cc/analyzer/engine_registry_spec.rb
@@ -7,7 +7,7 @@ module CC::Analyzer
         registry = EngineRegistry.new
 
         expect(registry["madeup"]).to eq nil
-        expect(registry["rubocop"]["image"]).to eq "codeclimate/codeclimate-rubocop"
+        expect(registry["rubocop"]["channels"]["stable"]).to eq "codeclimate/codeclimate-rubocop"
       end
 
       it "returns a fake registry entry if in dev mode" do

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -45,7 +45,13 @@ module CC::Analyzer
     end
 
     def registry_with_engine(name)
-      { name => { "image" => "codeclimate/codeclimate-#{name}" } }
+      {
+        name => {
+          "channels" => {
+            "stable" => "codeclimate/codeclimate-#{name}"
+          }
+        }
+      }
     end
 
     def config_with_engine(name)

--- a/spec/cc/cli/engines/install_spec.rb
+++ b/spec/cc/cli/engines/install_spec.rb
@@ -52,8 +52,8 @@ module CC::CLI::Engines
     end
 
     def stub_engine_image(engine)
-      allow_any_instance_of(EngineCommand).to receive(:engine_registry_list).
-        and_return("#{engine}" => { "image" => "#{engine}_img" })
+      allow_any_instance_of(CC::Analyzer::EngineRegistry).to receive(:[]).with(engine).
+        and_return("channels" => { "stable" => "#{engine}_img" })
     end
   end
 end


### PR DESCRIPTION
- Rewrite registry to replace image:x with channels[stable]:x
- Update engines-config-builder to look for channels.stable
- Improve error messaging for ImageRequired errors to indicate the cause may be
  an invalid channel
- Support -e engine:channel on the command line

Individual commits have more details.

This is a fully backwards compatible change. Builder should pick up the new
logic in engines-config-builder, but it'll need to rewrite its own manifest to
support channels as well as add its own error handling for ImageRequired.

Here in CLI, we specify that tag-less images on Docker Hub are for the stable
channel. When we have non-stable channel images, those will likely be tagged as
the channel on Docker Hub. In Builder, the channel keys will always specify
"fully qualified" (i.e. :b123) images. Changes to our tooling will happen
elsewhere later to ensure the correct images are in the correct places as part
of releasing an engine with multiple channels.

/cc @codeclimate/review