### PR TITLE
Fix type error in channel lookup

### DIFF
--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -12,7 +12,7 @@ module CC
         # handling.
         def fetch(name, channel)
           metadata = self[name]
-          metadata.merge("image" => metadata["channels"][channel])
+          metadata.merge("image" => metadata["channels"][channel.to_s])
         end
       end
 

--- a/spec/cc/analyzer/engines_config_builder_spec.rb
+++ b/spec/cc/analyzer/engines_config_builder_spec.rb
@@ -67,6 +67,7 @@ module CC::Analyzer
           engines:
             rubocop:
               enabled: true
+              channel: stable
               config:
                 file: rubocop.yml
         EOYAML
@@ -76,6 +77,7 @@ module CC::Analyzer
       it "keeps that config and adds some entries" do
         expected_config = {
           "enabled" => true,
+          "channel" => "stable",
           "config" => "rubocop.yml",
           :include_paths => ["./"]
         }


### PR DESCRIPTION
A channel read via CC::Yaml will be a Yaml::Nodes::Scalar, not a String, so
(even though printing things looks like it'd all work), looking up into the
registry Hash always fails: Scalar("stable") != "stable".

When there's no channel in the config, CC::Yaml defaults to the String "stable"
(not a Scalar representing "stable"), so the behavior for a defaulted channel
was tested and worked, and the behavior for an invalid channel was tested and
worked. However, the behavior for a non-defaulted, and valid channel doesn't
work without this fix.

/cc @codeclimate/review