### PR TITLE
Add eslint-2 channel for eslint engine

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -84,6 +84,7 @@ duplication:
 eslint:
   channels:
     stable: codeclimate/codeclimate-eslint
+    eslint-2: codeclimate/codeclimate-eslint:eslint-2
   description: A JavaScript/JSX linting utility.
   community: false
   upgrade_languages:


### PR DESCRIPTION
/cc @codeclimate/review

I locally built and pushed an image from codeclimate/codeclimate-eslint#79 so
it's now available to try. Consider this a quiet release for wider testing,
it's entirely opt-in.