### PR TITLE
Support engine channels in dev mode

### DIFF
--- a/lib/cc/analyzer/engine_registry.rb
+++ b/lib/cc/analyzer/engine_registry.rb
@@ -9,7 +9,7 @@ module CC
 
       def [](engine_name)
         if dev_mode?
-          { "image" => "codeclimate/codeclimate-#{engine_name}:latest" }
+          { "channels" => { "stable" => "codeclimate/codeclimate-#{engine_name}:latest" } }
         else
           @config[engine_name]
         end

--- a/spec/cc/analyzer/engine_registry_spec.rb
+++ b/spec/cc/analyzer/engine_registry_spec.rb
@@ -14,7 +14,7 @@ module CC::Analyzer
         registry = EngineRegistry.new(true)
 
         expect(registry["madeup"]).to eq(
-          "image" => "codeclimate/codeclimate-madeup:latest"
+          "channels" => { "stable" => "codeclimate/codeclimate-madeup:latest" }
         )
       end
     end


### PR DESCRIPTION
`--dev` mode broke following our introduction of engine channels. This PR updates the registry to produce a structure compatible with the new `RegistryAdapter` when in dev mode.

@codeclimate/review :mag_right: