### PR TITLE
Don't error creating the fingerprint when the file doesn't exist

### DIFF
--- a/lib/cc/analyzer/source_fingerprint.rb
+++ b/lib/cc/analyzer/source_fingerprint.rb
@@ -28,7 +28,12 @@ module CC
       end
 
       def raw_source
-        @raw_source ||= File.read(issue.path)
+        @raw_source ||=
+          if File.file?(issue.path)
+            File.read(issue.path)
+          else
+            ""
+          end
       end
     end
   end

--- a/spec/cc/analyzer/source_fingerprint_spec.rb
+++ b/spec/cc/analyzer/source_fingerprint_spec.rb
@@ -71,12 +71,28 @@ module CC::Analyzer
           "path" => "spec/fixtures/stub.rb"
         }
 
+        allow(File).to receive(:file?).and_return(true)
         allow(File).to receive(:read).and_return("hi \255".force_encoding(Encoding::UTF_8))
 
         issue = Issue.new(output.to_json)
         fingerprint = SourceFingerprint.new(issue)
 
         expect(fingerprint.compute).to eq("717ddedd698e51037903bad1d2b06c1b")
+      end
+
+      it "excludes the source when the file doesn't exist" do
+        output["location"] = {
+          "lines" => {
+            "begin" => 1,
+            "end" => 1
+          },
+          "path" => "doesnotexist"
+        }
+
+        issue = Issue.new(output.to_json)
+        fingerprint = SourceFingerprint.new(issue)
+
+        expect(fingerprint.compute).to eq("8b425ee5d6c63f873d62d9985676b2d9")
       end
     end
   end


### PR DESCRIPTION
This is sometimes run before issue validations, so it should correctly
handle a missing file

@codeclimate/review 