### PR TITLE
Validate Issue Content key

### DIFF
--- a/lib/cc/analyzer/issue_validations.rb
+++ b/lib/cc/analyzer/issue_validations.rb
@@ -3,6 +3,7 @@ module CC
     module IssueValidations
       autoload :CategoryValidation, "cc/analyzer/issue_validations/category_validation"
       autoload :CheckNamePresenceValidation, "cc/analyzer/issue_validations/check_name_presence_validation"
+      autoload :ContentValidation, "cc/analyzer/issue_validations/content_validation"
       autoload :DescriptionPresenceValidation, "cc/analyzer/issue_validations/description_presence_validation"
       autoload :LocationFormatValidation, "cc/analyzer/issue_validations/location_format_validation"
       autoload :OtherLocationsFormatValidation, "cc/analyzer/issue_validations/other_locations_format_validation"

--- a/lib/cc/analyzer/issue_validations/content_validation.rb
+++ b/lib/cc/analyzer/issue_validations/content_validation.rb
@@ -1,0 +1,25 @@
+module CC
+  module Analyzer
+    module IssueValidations
+      class ContentValidation < Validation
+        def valid?
+          !has_content? || (content.is_a?(Hash) && content["body"].is_a?(String))
+        end
+
+        def message
+          "Content must be a hash containing a 'body' key with string contents"
+        end
+
+        private
+
+        def has_content?
+          object.key?("content")
+        end
+
+        def content
+          object["content"]
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/issue_validations/content_validation_spec.rb
+++ b/spec/cc/analyzer/issue_validations/content_validation_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+module CC::Analyzer::IssueValidations
+  describe ContentValidation do
+    describe "#valid?" do
+      it "is valid without any content" do
+        expect(ContentValidation.new({})).to be_valid
+      end
+
+      it "is valid with content with body" do
+        expect(ContentValidation.new("content" => { "body" => "hi"})).to be_valid
+      end
+
+      it "is not valid with content as string" do
+        expect(ContentValidation.new("content" => "hi")).not_to be_valid
+      end
+
+      it "is not valid with content as nil" do
+        expect(ContentValidation.new("content" => nil)).not_to be_valid
+      end
+
+      it "is not valid with content without body" do
+        expect(ContentValidation.new("content" => {})).not_to be_valid
+      end
+
+      it "is not valid with content with nil body" do
+        expect(ContentValidation.new("content" => { "body" => nil })).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/issue_validations_spec.rb
+++ b/spec/cc/analyzer/issue_validations_spec.rb
@@ -7,6 +7,7 @@ module CC::Analyzer
         expected = [
           IssueValidations::CategoryValidation,
           IssueValidations::CheckNamePresenceValidation,
+          IssueValidations::ContentValidation,
           IssueValidations::DescriptionPresenceValidation,
           IssueValidations::LocationFormatValidation,
           IssueValidations::OtherLocationsFormatValidation,


### PR DESCRIPTION
We occassionally see invalid contents emited that will blow things up
further down the line (like a `null` body, for example). This adds a
validation to catch these things earlier.

cc @codeclimate/review