### PR TITLE
Loose activesupport dependency requirement

### DIFF
--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.bindir = "bin"
   s.executables = %w(codeclimate-init)
 
-  s.add_dependency "activesupport", "~> 4.2", ">= 4.2.1"
+  s.add_dependency "activesupport", ">= 4.2.1", "< 5.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
   s.add_dependency "codeclimate-yaml", "~> 0.9.0"
   s.add_dependency "highline", "~> 1.7", ">= 1.7.2"


### PR DESCRIPTION
Before this, codeclimate was requiring activesupport ~>4.2. This was
leading to conflicts with Rails 5, which requires activesupport 5.0.0.1.

5.0.x has passed the unit tests and seems to work locally with the
current codeclimate's code.

This was discussed on issue #477.

Signed-off-by: Rafael Reggiani Manzo <rr.manzo@protonmail.com>