### PR TITLE
Don't update marketing site data on deploy

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -23,13 +23,6 @@ docker tag codeclimate/codeclimate "codeclimate/codeclimate:$version"
 docker push "codeclimate/codeclimate:$version"
 
 (cd ../homebrew-formulae/ && bin/release "$version")
-(cd ../marketingsite/ && bin/set-cli-version "$version" && bin/deploy) || {
-  cat >&2 <<EOF
---------------------------------------------------------------------------------
-- WARNING: Marketing site update failed. Please do this manually.              -
---------------------------------------------------------------------------------
-EOF
-}
 
 echo "Be sure to update release notes:"
 echo ""


### PR DESCRIPTION
New pricing page doesn't show this data. We don't need this anymore.

cc @codeclimate/review