### PR TITLE
Add eslint-3 channel to engines manifest

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -90,6 +90,7 @@ eslint:
   channels:
     stable: codeclimate/codeclimate-eslint
     eslint-2: codeclimate/codeclimate-eslint:eslint-2
+    eslint-3: codeclimate/codeclimate-eslint:eslint-3
   description: A JavaScript/JSX linting utility.
   community: false
   upgrade_languages:


### PR DESCRIPTION
This commit configures an eslint-3 channel for the codeclimate-eslint
engine, wrapping [ESLint 3][]:

[ESLint 3]: http://eslint.org/blog/2016/07/eslint-v3.0.0-released

```yaml
engines:
  eslint:
    enabled: true
    channel: "eslint-3"
```

@codeclimate/review :mag_right: