### PR TITLE
Readme cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The following is a brief explanation of each available command.
   (default is 512_000_000 bytes):
 
   ```
-  ENGINE_MEMORY_LIMIT_BYTES=1_000_000_000 codeclimate analyze // 30 minutes
+  ENGINE_MEMORY_LIMIT_BYTES=1_000_000_000 codeclimate analyze // 1_000_000_000 bytes
   ```
 
 ## Copyright

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The following is a brief explanation of each available command.
   CONTAINER_TIMEOUT_SECONDS=1800 codeclimate analyze // 30 minutes
   ```
 
+  Note: CONTAINER_TIMEOUT_SECONDS is not currently honored in the CLI.
+
 * You can also configure the default alotted memory with which each engine runs
   (default is 512_000_000 bytes):
 


### PR DESCRIPTION
* Fix a minor copy/paste typo.
* Clarify CONTAINER_TIMEOUT_SECONDS is not honored in the CLI.

I hope this helps others who may have thought `CONTAINER_TIMEOUT_SECONDS` should work with the CLI container environment.

Note, are there other env variables that are NOT honored?

I do know that `CODECLIMATE_DEBUG` works with the CLI.