### PR TITLE
Add Credo engine with beta channel

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -59,6 +59,19 @@ coffeelint:
     - \.coffee$
   default_ratings_paths:
     - "**.coffee"
+credo:
+  channels:
+    beta: codeclimate/codeclimate-credo:beta
+  description: >
+    A static code analysis tool for the Elixir language with a focus on code
+    consistency and teaching.
+  community: true
+  enable_regexps:
+    - \.ex$
+    - \.exs$
+  default_ratings_paths:
+    - "**.ex"
+    - "**.exs"
 duplication:
   channels:
     beta: codeclimate/codeclimate-duplication:beta


### PR DESCRIPTION
This commit adds the Code Climate [credo engine][cc-credo] to the engines manifest.

@codeclimate/review :mag_right:

[cc-credo]: https://github.com/fazibear/codeclimate-credo