### PR TITLE
Add the rubocop  cache-support channel

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -293,6 +293,7 @@ requiresafe:
 rubocop:
   channels:
     stable: codeclimate/codeclimate-rubocop
+    chanenel-support: codeclimate/codeclimate-rubocop:channel-support
   description: A Ruby static code analyzer, based on the community Ruby style guide.
   community: false
   upgrade_languages:

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -293,7 +293,7 @@ requiresafe:
 rubocop:
   channels:
     stable: codeclimate/codeclimate-rubocop
-    chanenel-support: codeclimate/codeclimate-rubocop:channel-support
+    channel-support: codeclimate/codeclimate-rubocop:channel-support
   description: A Ruby static code analyzer, based on the community Ruby style guide.
   community: false
   upgrade_languages:


### PR DESCRIPTION
For parity with builder & using the CLI with projects configured to use this channel.

cc @codeclimate/review 