### PR TITLE
Fix rubocop channel name

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -293,7 +293,7 @@ requiresafe:
 rubocop:
   channels:
     stable: codeclimate/codeclimate-rubocop
-    channel-support: codeclimate/codeclimate-rubocop:channel-support
+    cache-support: codeclimate/codeclimate-rubocop:cache-support
   description: A Ruby static code analyzer, based on the community Ruby style guide.
   community: false
   upgrade_languages:


### PR DESCRIPTION
Too many cache & channel branches in my head recently, I used the wrong word.

cc @codeclimate/review, I intend to merge on green.