### PR TITLE
Update Readme fixing code Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker pull codeclimate/codeclimate
 ```console
 docker run \
   --interactive --tty --rm \
-  --env CODECLIMATE_CODE="$PWD" \
+  --env CODECLIMATE_CODE="/code" \
   --volume "$PWD":/code \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume /tmp/cc:/tmp/cc \


### PR DESCRIPTION
The standard readme proposes the environment variable to define where is the code to analyse (for the docker machine) as $PWD. In reality the code, internal to the docker, is into the */code* folder which is mounted on $PWD.
I think leaving it in that way can bring to confusion...