### PR TITLE
Exit with a return code of 1 if issues are found

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -38,7 +38,7 @@ module CC
           output = EngineOutput.new(raw_output)
 
           unless output.valid?
-            stdout_io.failed("#{qualified_name} produced invalid output: #{output.error[:message]}")
+            stdout_io.errored("#{qualified_name} produced invalid output: #{output.error[:message]}")
             container.stop
           end
 

--- a/lib/cc/analyzer/formatters/formatter.rb
+++ b/lib/cc/analyzer/formatters/formatter.rb
@@ -40,6 +40,10 @@ module CC
         def failed(_output)
         end
 
+        def empty?
+          issues.empty?
+        end
+
         InvalidFormatterError = Class.new(StandardError)
 
         private

--- a/lib/cc/analyzer/formatters/formatter.rb
+++ b/lib/cc/analyzer/formatters/formatter.rb
@@ -37,7 +37,7 @@ module CC
         def close
         end
 
-        def failed(_output)
+        def errored(_output)
         end
 
         def empty?

--- a/lib/cc/analyzer/formatters/html_formatter.rb
+++ b/lib/cc/analyzer/formatters/html_formatter.rb
@@ -31,8 +31,8 @@ module CC
           puts template.render
         end
 
-        def failed(_)
-          exit 1
+        def errored(_)
+          exit 2
         end
 
         private

--- a/lib/cc/analyzer/formatters/json_formatter.rb
+++ b/lib/cc/analyzer/formatters/json_formatter.rb
@@ -4,7 +4,7 @@ module CC
       class JSONFormatter < Formatter
         def initialize(filesystem)
           @filesystem = filesystem
-          @has_begun = false
+          @emitted = false
         end
 
         def started
@@ -19,18 +19,22 @@ module CC
           document = JSON.parse(data)
           document["engine_name"] = current_engine.name
 
-          if @has_begun
+          if @emitted
             print ",\n"
           end
 
           print document.to_json
-          @has_begun = true
+          @emitted = true
         end
 
         def failed(output)
           $stderr.puts "\nAnalysis failed with the following output:"
           $stderr.puts output
           exit 1
+        end
+
+        def empty?
+          @emitted
         end
       end
     end

--- a/lib/cc/analyzer/formatters/json_formatter.rb
+++ b/lib/cc/analyzer/formatters/json_formatter.rb
@@ -27,8 +27,8 @@ module CC
           @emitted = true
         end
 
-        def failed(output)
-          $stderr.puts "\nAnalysis failed with the following output:"
+        def errored(output)
+          $stderr.puts "\nAnalysis errored with the following output:"
           $stderr.puts output
           exit 1
         end

--- a/lib/cc/analyzer/formatters/plain_text_formatter.rb
+++ b/lib/cc/analyzer/formatters/plain_text_formatter.rb
@@ -42,11 +42,11 @@ module CC
           end
         end
 
-        def failed(output)
-          spinner.stop("Failed")
-          puts colorize("\nAnalysis failed with the following output:", :red)
+        def errored(output)
+          spinner.stop("Errored")
+          puts colorize("\nAnalysis errored with the following output:", :red)
           puts output
-          exit 1
+          exit 2
         end
 
         private

--- a/lib/cc/analyzer/raising_container_listener.rb
+++ b/lib/cc/analyzer/raising_container_listener.rb
@@ -1,9 +1,9 @@
 module CC
   module Analyzer
     class RaisingContainerListener < ContainerListener
-      def initialize(engine_name, failure_ex, timeout_ex)
+      def initialize(engine_name, error_ex, timeout_ex)
         @engine_name = engine_name
-        @failure_ex = failure_ex
+        @error_ex = error_ex
         @timeout_ex = timeout_ex
       end
 
@@ -16,17 +16,17 @@ module CC
 
       def finished(data)
         unless data.status.success?
-          message = "engine #{engine_name} failed"
+          message = "engine #{engine_name} errored"
           message << " with status #{data.status.exitstatus}"
           message << " and stderr \n#{data.stderr}"
 
-          raise failure_ex, message
+          raise error_ex, message
         end
       end
 
       private
 
-      attr_reader :engine_name, :failure_ex, :timeout_ex
+      attr_reader :engine_name, :error_ex, :timeout_ex
     end
   end
 end

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -20,6 +20,9 @@ module CC
           runner.run
         end
 
+        unless formatter.empty?
+          exit 1
+        end
       rescue EnginesRunner::InvalidEngineName => ex
         fatal(ex.message)
       rescue EnginesRunner::NoEnabledEngines

--- a/spec/cc/analyzer/raising_container_listener_spec.rb
+++ b/spec/cc/analyzer/raising_container_listener_spec.rb
@@ -13,22 +13,23 @@ module CC::Analyzer
       end
     end
 
-    describe "#failure" do
+    describe "#error" do
       it "does nothing on success" do
         listener = RaisingContainerListener.new("engine", nil, nil)
         listener.finished(double(status: double(success?: true), stderr: ""))
       end
 
-      it "raises the given failure exception on error" do
-        failure_ex = Class.new(StandardError)
-        listener = RaisingContainerListener.new("engine", failure_ex, nil)
+      it "raises the given error exception on error" do
+        error_ex = Class.new(StandardError)
+        listener = RaisingContainerListener.new("engine", error_ex, nil)
         data = double(
           status: double(success?: false, exitstatus: 1),
           stderr: "some error",
         )
 
         expect { listener.finished(data) }.to raise_error(
-          failure_ex, /engine failed.*status 1.*some error/m
+          error_ex, /engine errored.*status 1.*some error/m
+
         )
       end
     end

--- a/spec/cc/analyzer/statsd_container_listener_spec.rb
+++ b/spec/cc/analyzer/statsd_container_listener_spec.rb
@@ -36,7 +36,7 @@ module CC::Analyzer
         listener.finished(double(duration: 10, status: double(success?: true)))
       end
 
-      it "increments a metric for failure" do
+      it "increments a metric for error" do
         statsd = double(timing: nil, increment: nil)
         expect(statsd).to receive(:timing).with("engines.time", 10)
         expect(statsd).to receive(:increment).with("engines.finished")

--- a/spec/cc/cli/analyze_spec.rb
+++ b/spec/cc/cli/analyze_spec.rb
@@ -7,6 +7,28 @@ module CC::CLI
         allow_any_instance_of(CC::Analyzer::Engine).to receive(:run)
       end
 
+      it "exits with a return code of 0 when no issues are emitted" do
+        allow_any_instance_of(CC::Analyzer::Formatters::PlainTextFormatter).to receive(:empty?)
+          .and_return(true)
+
+        _, _, exit_code = capture_io_and_exit_code do
+          Analyze.new.run
+        end
+
+        expect(exit_code).to eq(0)
+      end
+
+      it "exits with a return code of 1 when issues are emitted" do
+        allow_any_instance_of(CC::Analyzer::Formatters::PlainTextFormatter).to receive(:empty?)
+          .and_return(false)
+
+      _, _, exit_code = capture_io_and_exit_code do
+          Analyze.new.run
+        end
+
+        expect(exit_code).to eq(1)
+      end
+
       describe "when no engines are specified" do
         it "exits and reports no engines are enabled" do
           within_temp_dir do

--- a/spec/support/test_formatter.rb
+++ b/spec/support/test_formatter.rb
@@ -9,7 +9,7 @@ class TestFormatter
     string << data
   end
 
-  def failed(output)
+  def errored(output)
     output
   end
 end


### PR DESCRIPTION
Most CI processes are expected to exit with a return code of 0 in the
success mode and with a return code of 1 in the failure mode.

This commit leverages the formatter's knowledge of issues emitted to
determine the appropriate return code.

Addresses #422 

@codeclimate/review :mag_right:
