### PR TITLE
Update default inferred rubocop config

### DIFF
--- a/config/rubocop/.rubocop.yml
+++ b/config/rubocop/.rubocop.yml
@@ -528,7 +528,7 @@ Style/DefWithParentheses:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
   Enabled: false
 
-Style/DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Description: 'Checks for use of deprecated Hash methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
   Enabled: false


### PR DESCRIPTION
This one was renamed, so it emits a deprecation warning now.

We should do a more thorough audit at some point -- There are some new
cops that have been introduced which are disabled and not listed, so
people don't easily know how to enable them.