### PR TITLE
Update to cc-yaml 0.10.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       tzinfo (~> 1.1)
     builder (3.2.2)
     codeclimate-test-reporter (1.0.0.pre.rc2)
-    codeclimate-yaml (0.10.1)
+    codeclimate-yaml (0.10.2)
       activesupport
       secure_string
     coderay (1.1.1)


### PR DESCRIPTION
Brings in a bugfix for less-common config styles using non-scalar values
as values in arrays/hashes