### PR TITLE
Fix README help for `analyze` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ A list of available commands is accessible by running `codeclimate` or
 $ codeclimate help
 
 Available commands:
-    analyze [-f format] [-e engine(:channel)] <path> [--dev]
+    analyze [-f format] [-e engine(:channel)] [--dev] [path]
     console
-    engines:disable engine_name
-    engines:enable engine_name
+    engines:disable <engine_name>
+    engines:enable <engine_name>
     engines:install
     engines:list
     engines:remove
@@ -97,6 +97,12 @@ The following is a brief explanation of each available command.
   the analysis (using `json`, `text`, or `html`). The `--dev` flag lets you run
   engines not known to the CLI, for example if you're an engine author developing
   your own, unreleased image.
+
+  You can optionally provide a specific path to analyze. If not provided, the
+  CLI will analyze your entire repository, except for your configured
+  `exclude_paths`. When you do provide an explicit path to analyze, your
+  configured `exclude_paths` are ignored, and normally excluded files will be
+  analyzed.
 * `console`
   start an interactive session providing access to the classes
   within the CLI. Useful for engine developers and maintainers.

--- a/lib/cc/cli/help.rb
+++ b/lib/cc/cli/help.rb
@@ -14,7 +14,7 @@ module CC
 
       def commands
         [
-          "analyze [-f format] [-e engine(:channel)] <path>",
+          "analyze [-f format] [-e engine(:channel)] [path]",
           "console",
           "engines:disable #{underline("engine_name")}",
           "engines:enable #{underline("engine_name")}",


### PR DESCRIPTION
The docs as written-here were confusing. For one thing, they were incorrectly
implying that `path` is a required argument: it's not, and providing a path like
`.` has suprising behavior for a lot of users.

This updates the short-help to make `path` more obviously optional, and adds a
paragraph to the fuller description below explaining the behavior of `analyze`
more fully both when `path` is provided & when it is not.

cc @codeclimate/review this has come up in a few GH issues, and I realized our docs were misleading.