### PR TITLE
Fix explicit docker example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker pull codeclimate/codeclimate
 ```console
 docker run \
   --interactive --tty --rm \
-  --env CODECLIMATE_CODE="/code" \
+  --env CODECLIMATE_CODE="$PWD" \
   --volume "$PWD":/code \
   --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume /tmp/cc:/tmp/cc \


### PR DESCRIPTION
The example value given for `CODECLIMATE_CODE` in the explicit `docker run` example is wrong & won't work (unless you actually happen to be editing a project located at `/code` on your computer.) This ENV var needs to be the code path *on the host*, because it's used to construct the mount paths for sub-containers like engines.

cc @codeclimate/review 