### PR TITLE
Extend help command

### DIFF
--- a/lib/cc/cli.rb
+++ b/lib/cc/cli.rb
@@ -19,7 +19,6 @@ require "cc/cli/version"
 
 module CC
   module CLI
-
     def self.debug?
       ENV["CODECLIMATE_DEBUG"]
     end

--- a/lib/cc/cli.rb
+++ b/lib/cc/cli.rb
@@ -5,19 +5,20 @@ require "cc/analyzer"
 require "cc/workspace"
 require "cc/yaml"
 
+require "cc/cli/analyze"
+require "cc/cli/command"
+require "cc/cli/console"
+require "cc/cli/engines"
+require "cc/cli/help"
+require "cc/cli/init"
+require "cc/cli/prepare"
+require "cc/cli/runner"
+require "cc/cli/test"
+require "cc/cli/validate_config"
+require "cc/cli/version"
+
 module CC
   module CLI
-    autoload :Analyze, "cc/cli/analyze"
-    autoload :Command, "cc/cli/command"
-    autoload :Console, "cc/cli/console"
-    autoload :Engines, "cc/cli/engines"
-    autoload :Help, "cc/cli/help"
-    autoload :Init, "cc/cli/init"
-    autoload :Prepare, "cc/cli/prepare"
-    autoload :Runner, "cc/cli/runner"
-    autoload :Test, "cc/cli/test"
-    autoload :ValidateConfig, "cc/cli/validate_config"
-    autoload :Version, "cc/cli/version"
 
     def self.debug?
       ENV["CODECLIMATE_DEBUG"]

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -1,6 +1,17 @@
+require "cc/cli/command"
+
 module CC
   module CLI
     class Analyze < Command
+      ARGUMENT_LIST = "[-f format] [-e engine[:channel]] [path]".freeze
+      SHORT_HELP = "Run analysis with the given arguments".freeze
+      HELP = "#{SHORT_HELP}\n" \
+        "\n" \
+        "    -f <format>, --format <format>   Format of output. Possible values: #{CC::Analyzer::Formatters::FORMATTERS.keys.join ", "}\n" \
+        "    -e <engine[:channel]>            Engine to run. Can be specified multiple times.\n" \
+        "    --dev                            Run in development mode.\n" \
+        "    path                             Path to check. Can be specified multiple times.".freeze
+
       include CC::Analyzer
 
       def initialize(_args = [])

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -9,7 +9,7 @@ module CC
         "\n" \
         "    -f <format>, --format <format>   Format of output. Possible values: #{CC::Analyzer::Formatters::FORMATTERS.keys.join ", "}\n" \
         "    -e <engine[:channel]>            Engine to run. Can be specified multiple times.\n" \
-        "    --dev                            Run in development mode.\n" \
+        "    --dev                            Run in development mode. Engines installed locally that are not in the manifest will be run.\n" \
         "    path                             Path to check. Can be specified multiple times.".freeze
 
       include CC::Analyzer

--- a/lib/cc/cli/command.rb
+++ b/lib/cc/cli/command.rb
@@ -7,7 +7,7 @@ module CC
   module CLI
     class Command
       CODECLIMATE_YAML = ".codeclimate.yml".freeze
-      NAMESPACE = name.split('::')[0..-2].join("::").freeze
+      NAMESPACE = name.split("::")[0..-2].join("::").freeze
 
       def self.abstract!
         @abstract = true
@@ -25,10 +25,12 @@ module CC
         all.find { |command| command.name == "#{NAMESPACE}::#{name}" || command.command_name == name }
       end
 
+      # rubocop: disable Style/ClassVars
       def self.inherited(subclass)
         @@subclasses ||= []
         @@subclasses << subclass
       end
+      # rubocop: enable Style/ClassVars
 
       def self.synopsis
         "#{command_name} #{self::ARGUMENT_LIST if const_defined?(:ARGUMENT_LIST)}".strip

--- a/lib/cc/cli/command.rb
+++ b/lib/cc/cli/command.rb
@@ -18,7 +18,7 @@ module CC
       end
 
       def self.all
-        @@subclasses.select { |klass| !klass.abstract? }
+        @@subclasses.reject(&:abstract?)
       end
 
       def self.[](name)

--- a/lib/cc/cli/console.rb
+++ b/lib/cc/cli/console.rb
@@ -1,6 +1,8 @@
 module CC
   module CLI
     class Console < Command
+      SHORT_HELP = "Open a ruby console for the CLI. Only useful for people developing against the CLI".freeze
+
       def run
         require "pry"
         binding.pry(quiet: true, prompt: Pry::SIMPLE_PROMPT, output: $stdout)

--- a/lib/cc/cli/console.rb
+++ b/lib/cc/cli/console.rb
@@ -1,7 +1,7 @@
 module CC
   module CLI
     class Console < Command
-      SHORT_HELP = "Open a ruby console for the CLI. Only useful for people developing against the CLI".freeze
+      SHORT_HELP = "Open a ruby console for the CLI. Useful for developing against the CLI.".freeze
 
       def run
         require "pry"

--- a/lib/cc/cli/engines.rb
+++ b/lib/cc/cli/engines.rb
@@ -1,14 +1,8 @@
 require "cc/analyzer"
 
-module CC
-  module CLI
-    module Engines
-      autoload :Disable, "cc/cli/engines/disable"
-      autoload :Enable, "cc/cli/engines/enable"
-      autoload :EngineCommand, "cc/cli/engines/engine_command"
-      autoload :Install, "cc/cli/engines/install"
-      autoload :List, "cc/cli/engines/list"
-      autoload :Remove, "cc/cli/engines/remove"
-    end
-  end
-end
+require "cc/cli/engines/disable"
+require "cc/cli/engines/enable"
+require "cc/cli/engines/engine_command"
+require "cc/cli/engines/install"
+require "cc/cli/engines/list"
+require "cc/cli/engines/remove"

--- a/lib/cc/cli/engines/disable.rb
+++ b/lib/cc/cli/engines/disable.rb
@@ -1,9 +1,16 @@
 require "cc/analyzer"
+require "cc/cli/engines/engine_command"
 
 module CC
   module CLI
     module Engines
       class Disable < EngineCommand
+        ARGUMENT_LIST = "<engine_name>"
+        SHORT_HELP = "Disable an engine in your codeclimate.yml."
+        HELP = "#{SHORT_HELP}\n" \
+          "\n"\
+          "    <engine_name>    Engine to disable in your codeclimate.yml"
+
         def run
           require_codeclimate_yml
 

--- a/lib/cc/cli/engines/disable.rb
+++ b/lib/cc/cli/engines/disable.rb
@@ -5,11 +5,11 @@ module CC
   module CLI
     module Engines
       class Disable < EngineCommand
-        ARGUMENT_LIST = "<engine_name>"
-        SHORT_HELP = "Disable an engine in your codeclimate.yml."
+        ARGUMENT_LIST = "<engine_name>".freeze
+        SHORT_HELP = "Disable an engine in your codeclimate.yml.".freeze
         HELP = "#{SHORT_HELP}\n" \
           "\n"\
-          "    <engine_name>    Engine to disable in your codeclimate.yml"
+          "    <engine_name>    Engine to disable in your codeclimate.yml".freeze
 
         def run
           require_codeclimate_yml

--- a/lib/cc/cli/engines/enable.rb
+++ b/lib/cc/cli/engines/enable.rb
@@ -4,6 +4,12 @@ module CC
   module CLI
     module Engines
       class Enable < EngineCommand
+        ARGUMENT_LIST = "<engine_name>"
+        SHORT_HELP = "Enable an engine in your codeclimate.yml."
+        HELP = "#{SHORT_HELP}\n" \
+          "\n"\
+          "    <engine_name>    Engine to enable in your codeclimate.yml"
+
         def run
           require_codeclimate_yml
 

--- a/lib/cc/cli/engines/enable.rb
+++ b/lib/cc/cli/engines/enable.rb
@@ -4,11 +4,11 @@ module CC
   module CLI
     module Engines
       class Enable < EngineCommand
-        ARGUMENT_LIST = "<engine_name>"
-        SHORT_HELP = "Enable an engine in your codeclimate.yml."
+        ARGUMENT_LIST = "<engine_name>".freeze
+        SHORT_HELP = "Enable an engine in your codeclimate.yml.".freeze
         HELP = "#{SHORT_HELP}\n" \
           "\n"\
-          "    <engine_name>    Engine to enable in your codeclimate.yml"
+          "    <engine_name>    Engine to enable in your codeclimate.yml".freeze
 
         def run
           require_codeclimate_yml

--- a/lib/cc/cli/engines/engine_command.rb
+++ b/lib/cc/cli/engines/engine_command.rb
@@ -6,6 +6,8 @@ module CC
       class EngineCommand < Command
         include CC::Analyzer
 
+        abstract!
+
         private
 
         def engine_name

--- a/lib/cc/cli/engines/install.rb
+++ b/lib/cc/cli/engines/install.rb
@@ -2,7 +2,7 @@ module CC
   module CLI
     module Engines
       class Install < EngineCommand
-        SHORT_HELP = "Pull the latest images for enabled engines in your codeclimate.yml."
+        SHORT_HELP = "Pull the latest images for enabled engines in your codeclimate.yml.".freeze
 
         ImagePullFailure = Class.new(StandardError)
 

--- a/lib/cc/cli/engines/install.rb
+++ b/lib/cc/cli/engines/install.rb
@@ -2,6 +2,8 @@ module CC
   module CLI
     module Engines
       class Install < EngineCommand
+        SHORT_HELP = "Pull the latest images for enabled engines in your codeclimate.yml."
+
         ImagePullFailure = Class.new(StandardError)
 
         def run

--- a/lib/cc/cli/engines/list.rb
+++ b/lib/cc/cli/engines/list.rb
@@ -2,6 +2,8 @@ module CC
   module CLI
     module Engines
       class List < EngineCommand
+        SHORT_HELP = "List all available engines"
+
         def run
           say "Available engines:"
           engine_registry_list.sort_by { |name, _| name }.each do |name, attributes|

--- a/lib/cc/cli/engines/list.rb
+++ b/lib/cc/cli/engines/list.rb
@@ -2,7 +2,7 @@ module CC
   module CLI
     module Engines
       class List < EngineCommand
-        SHORT_HELP = "List all available engines"
+        SHORT_HELP = "List all available engines".freeze
 
         def run
           say "Available engines:"

--- a/lib/cc/cli/engines/remove.rb
+++ b/lib/cc/cli/engines/remove.rb
@@ -4,11 +4,11 @@ module CC
   module CLI
     module Engines
       class Remove < EngineCommand
-        ARGUMENT_LIST = "<engine_name>"
-        SHORT_HELP = "Remove an engine from your codeclimate.yml."
+        ARGUMENT_LIST = "<engine_name>".freeze
+        SHORT_HELP = "Remove an engine from your codeclimate.yml.".freeze
         HELP = "#{SHORT_HELP} This command deletes the config rather than setting it to disabled.\n" \
           "\n"\
-          "    <engine_name>    Engine to remove from your codeclimate.yml"
+          "    <engine_name>    Engine to remove from your codeclimate.yml".freeze
 
         def run
           require_codeclimate_yml

--- a/lib/cc/cli/engines/remove.rb
+++ b/lib/cc/cli/engines/remove.rb
@@ -4,6 +4,12 @@ module CC
   module CLI
     module Engines
       class Remove < EngineCommand
+        ARGUMENT_LIST = "<engine_name>"
+        SHORT_HELP = "Remove an engine from your codeclimate.yml."
+        HELP = "#{SHORT_HELP} This command deletes the config rather than setting it to disabled.\n" \
+          "\n"\
+          "    <engine_name>    Engine to remove from your codeclimate.yml"
+
         def run
           require_codeclimate_yml
 

--- a/lib/cc/cli/help.rb
+++ b/lib/cc/cli/help.rb
@@ -3,30 +3,50 @@ require "rainbow"
 module CC
   module CLI
     class Help < Command
+      ARGUMENT_LIST = "[commad]"
+      SHORT_HELP = "Show help."
+      HELP = "#{SHORT_HELP}\n" \
+        "\n" \
+        "    no arguments   Show help summary for all commands.\n" \
+        "    [command]      Show help for specific commands. Can be scpecified multiple times."
+
       def run
-        say "Usage: codeclimate COMMAND ...\n\nAvailable commands:\n"
-        commands.each do |command|
-          say "    #{command}"
+        if @args.any?
+          @args.each do |command|
+            show_help(command)
+          end
+        else
+          show_help_summary
         end
       end
 
       private
 
-      def commands
-        [
-          "analyze [-f format] [-e engine(:channel)] [path]",
-          "console",
-          "engines:disable #{underline("engine_name")}",
-          "engines:enable #{underline("engine_name")}",
-          "engines:install",
-          "engines:list",
-          "engines:remove #{underline("engine_name")}",
-          "prepare",
-          "help",
-          "init",
-          "validate-config",
-          "version",
-        ].freeze
+      def show_help(command_name)
+        command = Command[command_name]
+        say "Usage: #{$PROGRAM_NAME} #{command.synopsis}\n"
+        say "\n"
+        say "#{command.help}\n"
+        say "\n\n"
+      end
+
+      def show_help_summary
+        short_helps =
+          Command.all
+          .sort_by(&:command_name)
+          .map do |command|
+            [
+              command.synopsis,
+              command.short_help
+            ]
+          end.compact.to_h
+
+        longest_command_length = short_helps.keys.map(&:length).max
+
+        say "Usage: codeclimate COMMAND ...\n\nAvailable commands:\n"
+        short_helps.each do |command, help|
+          say format("    %-#{longest_command_length}s    %s\n", command, help)
+        end
       end
 
       def underline(string)

--- a/lib/cc/cli/help.rb
+++ b/lib/cc/cli/help.rb
@@ -43,10 +43,6 @@ module CC
           say format("    %-#{longest_command_length}s    %s\n", command, help)
         end
       end
-
-      def underline(string)
-        Rainbow.new.wrap(string).underline
-      end
     end
   end
 end

--- a/lib/cc/cli/help.rb
+++ b/lib/cc/cli/help.rb
@@ -3,12 +3,12 @@ require "rainbow"
 module CC
   module CLI
     class Help < Command
-      ARGUMENT_LIST = "[commad]"
-      SHORT_HELP = "Show help."
+      ARGUMENT_LIST = "[commad]".freeze
+      SHORT_HELP = "Show help.".freeze
       HELP = "#{SHORT_HELP}\n" \
         "\n" \
         "    no arguments   Show help summary for all commands.\n" \
-        "    [command]      Show help for specific commands. Can be scpecified multiple times."
+        "    [command]      Show help for specific commands. Can be scpecified multiple times.".freeze
 
       def run
         if @args.any?
@@ -32,13 +32,8 @@ module CC
 
       def show_help_summary
         short_helps =
-          Command.all
-          .sort_by(&:command_name)
-          .map do |command|
-            [
-              command.synopsis,
-              command.short_help
-            ]
+          Command.all.sort_by(&:command_name).map do |command|
+            [command.synopsis, command.short_help]
           end.compact.to_h
 
         longest_command_length = short_helps.keys.map(&:length).max

--- a/lib/cc/cli/help.rb
+++ b/lib/cc/cli/help.rb
@@ -3,12 +3,12 @@ require "rainbow"
 module CC
   module CLI
     class Help < Command
-      ARGUMENT_LIST = "[commad]".freeze
-      SHORT_HELP = "Show help.".freeze
+      ARGUMENT_LIST = "[command]".freeze
+      SHORT_HELP = "Display help information.".freeze
       HELP = "#{SHORT_HELP}\n" \
         "\n" \
         "    no arguments   Show help summary for all commands.\n" \
-        "    [command]      Show help for specific commands. Can be scpecified multiple times.".freeze
+        "    [command]      Show help for specific commands. Can be specified multiple times.".freeze
 
       def run
         if @args.any?
@@ -24,7 +24,7 @@ module CC
 
       def show_help(command_name)
         command = Command[command_name]
-        say "Usage: #{$PROGRAM_NAME} #{command.synopsis}\n"
+        say "Usage: codeclimate #{command.synopsis}\n"
         say "\n"
         say "#{command.help}\n"
         say "\n\n"

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -8,10 +8,10 @@ module CC
       include CC::Analyzer
 
       ARGUMENT_LIST = "[--upgrade]".freeze
-      SHORT_HELP = "Generate a configuration and install the right images based on the contents of your repo.".freeze
+      SHORT_HELP = "Generate a configuration based on the contents of your repo.".freeze
       HELP = "#{SHORT_HELP}\n" \
         "\n" \
-        "    --upgrade    Upgrade existing configuration".freeze
+        "    --upgrade    Upgrade a Code Climate Classic configuration".freeze
 
       def run
         if !upgrade? && filesystem.exist?(CODECLIMATE_YAML)

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -7,11 +7,11 @@ module CC
     class Init < Command
       include CC::Analyzer
 
-      ARGUMENT_LIST = "[--upgrade]"
-      SHORT_HELP = "Generate a configuration and install the right images based on the contents of your repo."
+      ARGUMENT_LIST = "[--upgrade]".freeze
+      SHORT_HELP = "Generate a configuration and install the right images based on the contents of your repo.".freeze
       HELP = "#{SHORT_HELP}\n" \
         "\n" \
-        "    --upgrade    Upgrade existing configuration"
+        "    --upgrade    Upgrade existing configuration".freeze
 
       def run
         if !upgrade? && filesystem.exist?(CODECLIMATE_YAML)

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -7,6 +7,12 @@ module CC
     class Init < Command
       include CC::Analyzer
 
+      ARGUMENT_LIST = "[--upgrade]"
+      SHORT_HELP = "Generate a configuration and install the right images based on the contents of your repo."
+      HELP = "#{SHORT_HELP}\n" \
+        "\n" \
+        "    --upgrade    Upgrade existing configuration"
+
       def run
         if !upgrade? && filesystem.exist?(CODECLIMATE_YAML)
           warn "Config file .codeclimate.yml already present.\nTry running 'validate-config' to check configuration."

--- a/lib/cc/cli/prepare.rb
+++ b/lib/cc/cli/prepare.rb
@@ -10,11 +10,11 @@ require "uri"
 module CC
   module CLI
     class Prepare < Command
-      ARGUMENT_LIST = "[--allow-internal-ips]"
-      SHORT_HELP = "Run the commands in your prepare step."
+      ARGUMENT_LIST = "[--allow-internal-ips]".freeze
+      SHORT_HELP = "Run the commands in your prepare step.".freeze
       HELP = "#{SHORT_HELP}\n" \
         "\n" \
-        "    --allow-internal-ips    Allow fetching from internal IPs."
+        "    --allow-internal-ips    Allow fetching from internal IPs.".freeze
 
       InternalHostError = Class.new(StandardError)
       FetchError = Class.new(StandardError)

--- a/lib/cc/cli/prepare.rb
+++ b/lib/cc/cli/prepare.rb
@@ -10,6 +10,12 @@ require "uri"
 module CC
   module CLI
     class Prepare < Command
+      ARGUMENT_LIST = "[--allow-internal-ips]"
+      SHORT_HELP = "Run the commands in your prepare step."
+      HELP = "#{SHORT_HELP}\n" \
+        "\n" \
+        "    --allow-internal-ips    Allow fetching from internal IPs."
+
       InternalHostError = Class.new(StandardError)
       FetchError = Class.new(StandardError)
 

--- a/lib/cc/cli/runner.rb
+++ b/lib/cc/cli/runner.rb
@@ -31,17 +31,14 @@ module CC
       end
 
       def command_class
-        CLI.const_get(command_name)
+        command_const = Command[command]
+        if command_const.abstract?
+          nil
+        else
+          command_const
+        end
       rescue NameError
         nil
-      end
-
-      def command_name
-        case command
-        when nil, "-h", "-?", "--help" then "Help"
-        when "-v", "--version" then "Version"
-        else command.sub(":", "::").underscore.camelize
-        end
       end
 
       def command_arguments
@@ -49,7 +46,15 @@ module CC
       end
 
       def command
-        @args.first
+        command_name = @args.first
+        case command_name
+        when nil, "-h", "-?", "--help"
+          "help"
+        when "-v", "--version"
+          "version"
+        else
+          command_name
+        end
       end
     end
   end

--- a/lib/cc/cli/test.rb
+++ b/lib/cc/cli/test.rb
@@ -1,4 +1,5 @@
 require "cc/yaml"
+require "tmpdir"
 
 module CC
   module CLI
@@ -68,6 +69,12 @@ module CC
     end
 
     class Test < Command
+      ARGUMENT_LIST = "<engine_name>"
+      SHORT_HELP = "Test engine"
+      HELP = "#{SHORT_HELP}\n" \
+        "\n"\
+        "    <engine_name>    Engine to test"
+
       def run
         @engine_name = @args.first
 

--- a/lib/cc/cli/test.rb
+++ b/lib/cc/cli/test.rb
@@ -70,8 +70,8 @@ module CC
 
     class Test < Command
       ARGUMENT_LIST = "<engine_name>".freeze
-      SHORT_HELP = "Test engine".freeze
-      HELP = "#{SHORT_HELP}\n" \
+      SHORT_HELP = "Test an engine.".freeze
+      HELP = "Validate that an engine is behaving correctly.\n" \
         "\n"\
         "    <engine_name>    Engine to test".freeze
 

--- a/lib/cc/cli/test.rb
+++ b/lib/cc/cli/test.rb
@@ -69,11 +69,11 @@ module CC
     end
 
     class Test < Command
-      ARGUMENT_LIST = "<engine_name>"
-      SHORT_HELP = "Test engine"
+      ARGUMENT_LIST = "<engine_name>".freeze
+      SHORT_HELP = "Test engine".freeze
       HELP = "#{SHORT_HELP}\n" \
         "\n"\
-        "    <engine_name>    Engine to test"
+        "    <engine_name>    Engine to test".freeze
 
       def run
         @engine_name = @args.first

--- a/lib/cc/cli/validate_config.rb
+++ b/lib/cc/cli/validate_config.rb
@@ -3,7 +3,7 @@ require "cc/yaml"
 module CC
   module CLI
     class ValidateConfig < Command
-      SHORT_HELP = "Make sure your codeclimate.yml is valid."
+      SHORT_HELP = "Make sure your codeclimate.yml is valid.".freeze
 
       include CC::Analyzer
       include CC::Yaml

--- a/lib/cc/cli/validate_config.rb
+++ b/lib/cc/cli/validate_config.rb
@@ -3,6 +3,8 @@ require "cc/yaml"
 module CC
   module CLI
     class ValidateConfig < Command
+      SHORT_HELP = "Make sure your codeclimate.yml is valid."
+
       include CC::Analyzer
       include CC::Yaml
 

--- a/lib/cc/cli/validate_config.rb
+++ b/lib/cc/cli/validate_config.rb
@@ -3,7 +3,7 @@ require "cc/yaml"
 module CC
   module CLI
     class ValidateConfig < Command
-      SHORT_HELP = "Make sure your codeclimate.yml is valid.".freeze
+      SHORT_HELP = "Validate your .codeclimate.yml.".freeze
 
       include CC::Analyzer
       include CC::Yaml

--- a/lib/cc/cli/version.rb
+++ b/lib/cc/cli/version.rb
@@ -1,6 +1,8 @@
 module CC
   module CLI
     class Version < Command
+      SHORT_HELP = "Display the CLI version."
+
       def run
         say version
       end

--- a/lib/cc/cli/version.rb
+++ b/lib/cc/cli/version.rb
@@ -1,7 +1,7 @@
 module CC
   module CLI
     class Version < Command
-      SHORT_HELP = "Display the CLI version."
+      SHORT_HELP = "Display the CLI version.".freeze
 
       def run
         say version

--- a/spec/cc/cli/command_spec.rb
+++ b/spec/cc/cli/command_spec.rb
@@ -2,6 +2,69 @@ require "spec_helper"
 
 module CC::CLI
   describe Command do
+    describe ".all" do
+      it "includes Command subclasses" do
+        class Test1 < Command; end
+
+        expect(Command.all).to include(Test1)
+      end
+    end
+
+    describe "abstract comand classes" do
+      it "does not include absctract Command subclasses" do
+        class Test2 < Command
+          abstract!
+        end
+
+        expect(Command.all).to_not include(Test2)
+      end
+
+      it "includes subclasses of absctract Command subclasses" do
+        class Test3 < Command
+          abstract!
+        end
+        class Test4 < Test3; end
+
+        expect(Command.all).to include(Test4)
+      end
+
+      it "indicates whether Command subclasses is abstract" do
+        class Test5 < Command
+          abstract!
+        end
+
+        expect(Test5).to be_abstract
+      end
+    end
+
+    describe "command lookup" do
+      it "returns a command by its name" do
+        class Test6 < Command; end
+
+        expect(Command["test6"]).to eq Test6
+      end
+
+      it "returns a namespaced command by its name" do
+        module Namespace
+          class Test7 < Command; end
+        end
+
+        expect(Command["namespace:test7"]).to eq Namespace::Test7
+      end
+
+      it "returns `nil` when command is not found" do
+        expect(Command["no-such-command"]).to be_nil
+      end
+
+      it "returns `nil` for abstract commands" do
+        class Test8 < Command
+          abstract!
+        end
+
+        expect(Command["test8"]).to be_nil
+      end
+    end
+
     describe "#require_codeclimate_yml" do
       it "exits if the file doesn't exist" do
         Dir.chdir(Dir.mktmpdir) do
@@ -11,6 +74,62 @@ module CC::CLI
 
           expect(stderr).to match("No '.codeclimate.yml' file found. Run 'codeclimate init' to generate a config file.")
         end
+      end
+    end
+
+    describe ".synopsys" do
+      it "returns just a command name when no argumes are defined" do
+        class Test9 < Command; end
+
+        expect(Test9.synopsis).to eq "test9"
+      end
+
+      it "includes argumens when defined" do
+        class Test10 < Command
+          ARGUMENT_LIST = "<argument list>"
+        end
+
+        expect(Test10.synopsis).to eq "test10 <argument list>"
+      end
+    end
+
+    describe ".short_help" do
+      it "returns short help when defined" do
+        class Test11 < Command
+          SHORT_HELP = "short help"
+        end
+
+        expect(Test11.short_help).to eq "short help"
+      end
+
+      it "returns empty string when no short help is defined" do
+        class Test12 < Command; end
+
+        expect(Test12.short_help).to eq ""
+      end
+    end
+
+    describe ".help" do
+      it "returns help when defined" do
+        class Test13 < Command
+          HELP = "help"
+        end
+
+        expect(Test13.help).to eq "help"
+      end
+
+      it "returns short help as a fallback" do
+        class Test14 < Command
+          SHORT_HELP = "short help"
+        end
+
+        expect(Test14.help).to eq "short help"
+      end
+
+      it "returns empty string when no help is defined" do
+        class Test15 < Command; end
+
+        expect(Test15.short_help).to eq ""
       end
     end
   end

--- a/spec/cc/cli/runner_spec.rb
+++ b/spec/cc/cli/runner_spec.rb
@@ -18,13 +18,33 @@ module CC::CLI
       end
     end
 
-    describe "#command_name" do
-      it "parses subclasses" do
-        expect(Runner.new(["analyze:this"]).command_name).to eq("Analyze::This")
+    describe "#command_class" do
+      it "resolves command class from arguments" do
+        Hello = Class.new(Command)
+
+        expect(Runner.new(["hello"]).command_class).to eq ::CC::CLI::Hello
       end
 
-      it "returns class names" do
-        expect(Runner.new(["analyze"]).command_name).to eq("Analyze")
+      it "resolves namespaced command class from arguments" do
+        module World
+          Hello = Class.new(Command)
+        end
+
+        expect(Runner.new(["world:hello"]).command_class)
+          .to eq ::CC::CLI::World::Hello
+      end
+    end
+
+    describe "#command" do
+      {
+        [nil, "-h", "-?", "--help"] => "help",
+        ["-v", "--version"] => "version"
+      }.each do |args, command|
+        args.each do |arg|
+          it "maps #{arg} to #{command}" do
+            expect(Runner.new([arg]).command).to eq command
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Adds `codeclimate help command` which displays extended help for a command. It's possible to pass multiple arguments to `help` subcommand.

Help summary also shows short help for each of available commands.