### PR TITLE
Add Code Climate Checks

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -50,6 +50,17 @@ checkstyle:
     - \.java$
   default_ratings_paths:
     - "**.java"
+complexity-ruby:
+  channels:
+    beta: codeclimate/codeclimate-complexity-ruby
+  description: Code Climate Complexity Checks for Ruby
+  community: false
+  code_climate_check: true
+  default_ratings_paths:
+    - "**.rb"
+  default_config:
+    languages:
+      - ruby
 csslint:
   channels:
     stable: codeclimate/codeclimate-csslint

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -52,7 +52,7 @@ checkstyle:
     - "**.java"
 complexity-ruby:
   channels:
-    beta: codeclimate/codeclimate-complexity-ruby
+    beta: codeclimate/codeclimate-complexity-ruby:b44
   description: Code Climate Complexity Checks for Ruby
   community: false
   code_climate_check: true

--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -12,7 +12,10 @@ module CC
         # handling.
         def fetch(name, channel)
           metadata = self[name]
-          metadata.merge("image" => metadata["channels"][channel.to_s])
+          metadata.merge(
+            "image" => metadata["channels"][channel.to_s],
+            "code_climate_check" => metadata.fetch("code_climate_check", false),
+          )
         end
       end
 

--- a/lib/cc/cli/config.rb
+++ b/lib/cc/cli/config.rb
@@ -14,6 +14,13 @@ module CC
           config["engines"][engine_name]["config"] = engine_config["default_config"]
         end
 
+        # we may not want this code in the general case.
+        # for now, we need it to test one of our own Maintainability engines
+        # which is in the 'beta' channel
+        if engine_config.key?("channels") && !engine_config["channels"].include?("stable")
+          config["engines"][engine_name]["channel"] = engine_config["channels"].first.first
+        end
+
         config["ratings"]["paths"] |= engine_config["default_ratings_paths"]
       end
 

--- a/lib/cc/cli/config.rb
+++ b/lib/cc/cli/config.rb
@@ -2,11 +2,9 @@ module CC
   module CLI
     class Config
       delegate :to_yaml, to: :config
-      def initialize
-        @config = {
-          "engines" => {},
-          "ratings" => { "paths" => [] },
-        }
+
+      def initialize(config={})
+        @config = default_config.merge(config)
       end
 
       def add_engine(engine_name, engine_config)
@@ -27,6 +25,13 @@ module CC
       private
 
       attr_reader :config
+
+      def default_config
+        {
+          "engines" => {},
+          "ratings" => { "paths" => [] },
+        }
+      end
     end
   end
 end

--- a/lib/cc/cli/config.rb
+++ b/lib/cc/cli/config.rb
@@ -3,7 +3,7 @@ module CC
     class Config
       delegate :to_yaml, to: :config
 
-      def initialize(config={})
+      def initialize(config = {})
         @config = default_config.merge(config)
       end
 

--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -38,10 +38,7 @@ module CC
       end
 
       def codeclimate_checks
-        return @codeclimate_checks if @codeclimate_checks
-
-        engines = engine_registry.list
-        @codeclimate_checks = engines.each_with_object({}) do |(name, config), result|
+        @codeclimate_checks ||= engine_registry.list.each_with_object({}) do |(name, config), result|
           if code_climate_check?(config)
             result[name] = config
           end

--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -37,6 +37,17 @@ module CC
         end
       end
 
+      def codeclimate_checks
+        return @codeclimate_checks if @codeclimate_checks
+
+        engines = engine_registry.list
+        @codeclimate_checks = engines.each_with_object({}) do |(name, config), result|
+          if code_climate_check?(config)
+            result[name] = config
+          end
+        end
+      end
+
       def errors
         []
       end
@@ -61,6 +72,10 @@ module CC
 
       def engine_eligible?(engine)
         !engine["community"] && engine["enable_regexps"].present? && files_exist?(engine)
+      end
+
+      def code_climate_check?(engine)
+        engine["code_climate_check"] && ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] == "true"
       end
 
       def files_exist?(engine)

--- a/lib/cc/cli/config_generator.rb
+++ b/lib/cc/cli/config_generator.rb
@@ -72,7 +72,7 @@ module CC
       end
 
       def code_climate_check?(engine)
-        engine["code_climate_check"] && ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] == "true"
+        engine["code_climate_check"] && ENV["RUN_CODECLIMATE_CHECKS"] == "true"
       end
 
       def files_exist?(engine)

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -23,6 +23,7 @@ module CC
           create_default_engine_configs
         else
           generate_all_config
+          create_codeclimate_checks
         end
       end
 

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -59,7 +59,7 @@ module CC
       end
 
       def create_codeclimate_checks
-        if ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] == "true"
+        if ENV["RUN_CODECLIMATE_CHECKS"] == "true"
           say "Generating codeclimate checks..."
           plain_config_hash = JSON.parse(CC::Yaml::Serializer::Json.serialize(existing_cc_config))
           config = CC::CLI::Config.new(plain_config_hash)

--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -19,6 +19,7 @@ module CC
           create_default_engine_configs if engines_enabled?
         elsif upgrade? && engines_enabled?
           warn "Config file .codeclimate.yml already configured for the Platform.\nTry running 'validate-config' to check configuration."
+          create_codeclimate_checks
           create_default_engine_configs
         else
           generate_all_config
@@ -54,6 +55,20 @@ module CC
 
         config.add_exclude_paths(config_generator.exclude_paths)
         filesystem.write_path(CODECLIMATE_YAML, config.to_yaml)
+      end
+
+      def create_codeclimate_checks
+        if ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] == "true"
+          say "Generating codeclimate checks..."
+          plain_config_hash = JSON.parse(CC::Yaml::Serializer::Json.serialize(existing_cc_config))
+          config = CC::CLI::Config.new(plain_config_hash)
+
+          config_generator.codeclimate_checks.each do |(engine_name, engine_config)|
+            config.add_engine(engine_name, engine_config)
+          end
+
+          filesystem.write_path(CODECLIMATE_YAML, config.to_yaml)
+        end
       end
 
       def create_default_engine_configs

--- a/spec/cc/analyzer/engines_config_builder_spec.rb
+++ b/spec/cc/analyzer/engines_config_builder_spec.rb
@@ -34,6 +34,19 @@ module CC::Analyzer
         result = engines_config_builder.run
         expect(result.size).to eq(1)
         expect(result.first.name).to eq("an_engine")
+        expect(result.first.registry_entry["code_climate_check"]).to eq(false)
+      end
+    end
+
+    describe "with a codeclimate check" do
+      let(:config) { config_with_engine("a_code_climate_check") }
+      let(:registry) { registry_with_engine("a_code_climate_check", code_climate_check: true) }
+
+      it "contains that engine" do
+        result = engines_config_builder.run
+        expect(result.size).to eq(1)
+        expect(result.first.name).to eq("a_code_climate_check")
+        expect(result.first.registry_entry["code_climate_check"]).to eq(true)
       end
     end
 
@@ -204,7 +217,7 @@ module CC::Analyzer
       builder.run
     end
 
-    def registry_with_engine(*names)
+    def registry_with_engine(*names, code_climate_check: false)
       {}.tap do |result|
         names.each do |name|
           result[name] = {
@@ -212,6 +225,8 @@ module CC::Analyzer
               "stable" => "codeclimate/codeclimate-#{name}"
             }
           }
+
+          result[name]["code_climate_check"] = true if code_climate_check
         end
       end
     end

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -84,6 +84,26 @@ module CC::CLI
       end
     end
 
+    describe "#codecliamte_checks" do
+      it "returns codeclimate checks found in the registry" do
+        allow(ENV).to receive(:[]).with("BUILDER_RUN_CODECLIMATE_CHECKS").
+          and_return("true")
+
+        expect(generator.codeclimate_checks.keys).to eq %w(complexity-ruby)
+      end
+
+      it "returns an empty hash when the feature is disabled" do
+        allow(ENV).to receive(:[]).with("BUILDER_RUN_CODECLIMATE_CHECKS").
+          and_return("false")
+
+        expect(generator.codeclimate_checks.keys).to be_empty
+      end
+
+      it "returns an empty hash when the feature is disabled" do
+        expect(generator.codeclimate_checks.keys).to be_empty
+      end
+    end
+
     describe "#errors" do
       it "is empty array" do
         expect(generator.errors).to eq []

--- a/spec/cc/cli/config_generator_spec.rb
+++ b/spec/cc/cli/config_generator_spec.rb
@@ -86,14 +86,14 @@ module CC::CLI
 
     describe "#codecliamte_checks" do
       it "returns codeclimate checks found in the registry" do
-        allow(ENV).to receive(:[]).with("BUILDER_RUN_CODECLIMATE_CHECKS").
+        allow(ENV).to receive(:[]).with("RUN_CODECLIMATE_CHECKS").
           and_return("true")
 
         expect(generator.codeclimate_checks.keys).to eq %w(complexity-ruby)
       end
 
       it "returns an empty hash when the feature is disabled" do
-        allow(ENV).to receive(:[]).with("BUILDER_RUN_CODECLIMATE_CHECKS").
+        allow(ENV).to receive(:[]).with("RUN_CODECLIMATE_CHECKS").
           and_return("false")
 
         expect(generator.codeclimate_checks.keys).to be_empty

--- a/spec/cc/cli/config_spec.rb
+++ b/spec/cc/cli/config_spec.rb
@@ -33,6 +33,25 @@ module CC::CLI
           }
         )
       end
+
+      it "supports engines in non-stable channels by selecting the first entry" do
+        config = CC::CLI::Config.new()
+        engine_config = {
+          "default_ratings_paths" => ["foo"],
+          "channels" => [
+            [ "beta", "some/path" ],
+            [ "gamma", "some/other-path" ],
+          ],
+        }
+
+        config.add_engine("foo", engine_config)
+
+        engine = YAML.load(config.to_yaml)["engines"]["foo"]
+        expect(engine).to eq(
+          "enabled" => true,
+          "channel" => "beta",
+        )
+      end
     end
 
     describe "#add_exclude_paths" do

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -46,12 +46,12 @@ module CC::CLI
 
         describe "generating codeclimate checks" do
           before do
-            @original_env = ENV["BUILDER_RUN_CODECLIMATE_CHECKS"]
-            ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] = "true"
+            @original_env = ENV["RUN_CODECLIMATE_CHECKS"]
+            ENV["RUN_CODECLIMATE_CHECKS"] = "true"
           end
 
           after do
-            ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] = @original_env
+            ENV["RUN_CODECLIMATE_CHECKS"] = @original_env
           end
 
           it "adds codeclimate checks when the feature is enabled" do
@@ -209,12 +209,12 @@ module CC::CLI
 
         describe "generating codeclimate checks" do
           before do
-            @original_env = ENV["BUILDER_RUN_CODECLIMATE_CHECKS"]
-            ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] = "true"
+            @original_env = ENV["RUN_CODECLIMATE_CHECKS"]
+            ENV["RUN_CODECLIMATE_CHECKS"] = "true"
           end
 
           after do
-            ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] = @original_env
+            ENV["RUN_CODECLIMATE_CHECKS"] = @original_env
           end
 
           it "adds codeclimate checks when the feature is enabled" do

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -44,6 +44,35 @@ module CC::CLI
           expect(CC::Yaml.parse(new_content).errors).to be_empty
         end
 
+        describe "generating codeclimate checks" do
+          before do
+            @original_env = ENV["BUILDER_RUN_CODECLIMATE_CHECKS"]
+            ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] = "true"
+          end
+
+          after do
+            ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] = @original_env
+          end
+
+          it "adds codeclimate checks when the feature is enabled" do
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(false)
+
+            init = Init.new
+
+            stdout, _, exit_code = capture_io_and_exit_code do
+              init.run
+            end
+
+            content_after = CC::Yaml.parse(File.read(".codeclimate.yml"))
+
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
+
+            engine_names = content_after.engines.keys
+            expect(engine_names).to include("complexity-ruby")
+            expect(exit_code).to eq 0
+          end
+        end
+
         it "runs when the directory is empty" do
           _, _, exit_code = capture_io_and_exit_code do
             init = Init.new

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -178,6 +178,42 @@ module CC::CLI
           expect(exit_code).to eq 0
         end
 
+        describe "generating codeclimate checks" do
+          before do
+            @original_env = ENV["BUILDER_RUN_CODECLIMATE_CHECKS"]
+            ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] = "true"
+          end
+
+          after do
+            ENV["BUILDER_RUN_CODECLIMATE_CHECKS"] = @original_env
+          end
+
+          it "adds codeclimate checks when the feature is enabled" do
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(false)
+
+            yaml_content_before = yaml_with_rubocop_enabled
+            File.write(".codeclimate.yml", yaml_content_before)
+
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
+
+            init = Init.new(["--upgrade"])
+
+            expect(init).to receive(:create_default_engine_configs)
+
+            stdout, _, exit_code = capture_io_and_exit_code do
+              init.run
+            end
+
+            content_after = CC::Yaml.parse(File.read(".codeclimate.yml"))
+
+            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
+
+            engine_names = content_after.engines.keys
+            expect(engine_names).to include("complexity-ruby")
+            expect(exit_code).to eq 0
+          end
+        end
+
         it "behaves normally if no .codeclimate.yml present" do
           expect(filesystem.exist?(".codeclimate.yml")).to eq(false)
           write_fixture_source_files


### PR DESCRIPTION
(assume the feature is enabled)
With no existing `.codeclimate.yml` file:
- Running `codeclimate init` will generate a config file complete with _codeclimate checks_

With an existing `.codeclimate.yml` file
- Running `codeclimate init --upgrade` will add any missing _codeclimate checks_ to yer yahmal.

This an idempotent operation, so multiple upgrades will behave as expected (re: no dupes)

---

Holy smokes. It was suuuuuuuuper hard to figure out where the best place to make this change was. In the end I'm pretty happy with how it came out. Hi-fives to @pbrisbin for letting me torture him about this for several days.