### PR TITLE
Check for all possible config names before generation

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -161,6 +161,12 @@ eslint:
   default_ratings_paths:
     - "**.js"
     - "**.jsx"
+  config_files:
+    .eslintrc:
+      - .eslintrc.js
+      - .eslintrc.json
+      - .eslintrc.yaml
+      - .eslintrc.yml
 flog:
   channels:
     beta: codeclimate/codeclimate-flog:beta


### PR DESCRIPTION
CC CLI has default configs for a few engines it makes sure to not overwrite them but some engines accept a few files for configs (e.g. ESLint). In those cases CC CLI would generate a config even if there's a config for engine with a different name.

Here a new option is introduced in engine registry: `config_names`. It's a hash with keys being names of files in config template directory and values being arrays of possible alternative names.

See [example](https://github.com/pointlessone/codeclimate/blob/1b1580fc48cec93ae3ca310c1bd705bfd22d1526/config/engines.yml#L164-L169).

Template file name is included into a list of collision detection and doesn't need to be included into alternative names list. When the section is missing template file names used for collision detection anyway.

---

⚠️ 
This PR is for the `master` branch as is. There's a somewhat related PR #566. Either this or that PR will need to be updated depending on which is merged first.