### PR TITLE
Don't error if an unknown engine is encountered in `init`.

### DIFF
--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -75,11 +75,12 @@ module CC
       def create_default_engine_configs
         say "Generating default configuration for engines..."
         available_engine_configs.each do |(engine_name, config_paths)|
-          engine = engine_registry[engine_name]
-          config_mapping = Hash.new { |_, k| [k] }.merge(engine.fetch("config_files", {}))
+          if (engine = engine_registry[engine_name])
+            config_mapping = Hash.new { |_, k| [k] }.merge(engine.fetch("config_files", {}))
 
-          config_paths.each do |config_path|
-            generate_config(config_path, config_mapping[File.basename(config_path)])
+            config_paths.each do |config_path|
+              generate_config(config_path, config_mapping[File.basename(config_path)])
+            end
           end
         end
       end

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -126,6 +126,24 @@ module CC::CLI
               expect(content_after).to eq(content_before)
             end
           end
+
+          describe "when an invalid engine is specified" do
+            it "does not error" do
+              config = <<-EOF
+                engines:
+                  hal9000:
+                    enabled: true
+              EOF
+              File.write(".codeclimate.yml", config)
+
+              _, _, exit_code = capture_io_and_exit_code do
+                init = Init.new
+                init.run
+              end
+
+              expect(exit_code).to eq(0)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
This can error when in dev mode or when using engines not available in
the CLI