### PR TITLE
Dockerignore some common swap files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@ bin/release
 circle.yml
 pkg
 tags
+*.sw*
+*~


### PR DESCRIPTION
I noticed in our latest CLI release, we accidentally included a file
config/eslint/.eslintrc.yml.swp, and so this gets included when people
run `codeclimate init --upgrade` in their javascript repos.