### PR TITLE
Allow running flog stable

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -170,7 +170,7 @@ eslint:
 flog:
   channels:
     beta: codeclimate/codeclimate-flog:beta
-    stable: codeclimate/codeclimate-flog:beta
+    stable: codeclimate/codeclimate-flog
   description: Easy to read reporting of complexity/pain for Ruby code.
   community: true
   enable_regexps:


### PR DESCRIPTION
We've shipped flog as a stable engine, so we should unpin the stable
channel locally.