### PR TITLE
Support config and cache file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       rainbow (~> 2.0, >= 2.0.0)
       redcarpet (~> 3.2)
       tty-spinner (~> 0.1.0)
+      uuid (~> 2.3)
 
 GEM
   remote: https://rubygems.org/
@@ -32,6 +33,8 @@ GEM
     highline (1.7.8)
     i18n (0.8.1)
     json (2.0.3)
+    macaddr (1.7.1)
+      systemu (~> 2.6.2)
     method_source (0.8.2)
     minitest (5.10.1)
     posix-spawn (0.3.13)
@@ -65,10 +68,13 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
+    systemu (2.6.5)
     thread_safe (0.3.6)
     tty-spinner (0.1.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    uuid (2.3.8)
+      macaddr (~> 1.0)
 
 PLATFORMS
   ruby

--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -41,17 +41,31 @@ else
     && invalid_docker_host "$DOCKER_HOST"
 fi
 
+: ${XDG_CONFIG_HOME:=$HOME/.config/}
+CC_CONFIG="${CODECLIMATE_CONFIG:-$XDG_CONFIG_HOME/codeclimate/config.yml}"
+
+: ${XDG_CACHE_HOME:=$HOME/.cache/}
+CC_CACHE="${CODECLIMATE_CACHE:-$XDG_CACHE_HOME/codeclimate/cache.yml}"
+
+for f in "$CC_CONFIG" "$CC_CACHE"; do
+  mkdir -p "$(dirname "$f")"
+  touch "$f"
+done
+
 docker_run() {
   exec docker run \
     --interactive --rm \
     --env CODECLIMATE_CODE \
     --env CODECLIMATE_TMP \
     --env CODECLIMATE_DEBUG \
+    --env CODECLIMATE_VERSIONS_URL \
     --env CONTAINER_MAXIMUM_OUTPUT_BYTES \
     --env CONTAINER_TIMEOUT_SECONDS \
     --env ENGINE_MEMORY_LIMIT_BYTES \
     --volume "$CODECLIMATE_CODE":/code \
     --volume "$CODECLIMATE_TMP":/tmp/cc \
+    --volume "$CC_CONFIG":/config.yml \
+    --volume "$CC_CACHE":/cache.yml \
     --volume /var/run/docker.sock:/var/run/docker.sock \
     "$@"
 }

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency "pry", "~> 0.10.1"
   s.add_dependency "rainbow", "~> 2.0", ">= 2.0.0"
   s.add_dependency "redcarpet", "~> 3.2"
+  s.add_dependency "uuid", "~> 2.3"
 end

--- a/lib/cc/cli/file_store.rb
+++ b/lib/cc/cli/file_store.rb
@@ -1,0 +1,42 @@
+require "fileutils"
+require "yaml"
+
+module CC
+  module CLI
+    class FileStore
+      # This class is not supposed to be directly used. It should be sublcassed
+      # and a few constants need to be defined on the sublass to be usable.
+      #
+      # FILE_NAME is the name of the file this class wraps.
+
+      def initialize
+        load_data
+      end
+
+      def save
+        return false unless File.exist? self.class::FILE_NAME
+
+        File.open(self.class::FILE_NAME, "w") do |f|
+          YAML.dump data, f
+        end
+
+        true
+      end
+
+      private
+
+      attr_reader :data
+
+      def load_data
+        @data =
+          if File.exist? self.class::FILE_NAME
+            File.open(self.class::FILE_NAME, "r:bom|utf-8") do |f|
+              YAML.safe_load(f, [Time], [], false, self.class::FILE_NAME) || {}
+            end
+          else
+            {}
+          end
+      end
+    end
+  end
+end

--- a/lib/cc/cli/global_cache.rb
+++ b/lib/cc/cli/global_cache.rb
@@ -1,0 +1,47 @@
+require "cc/cli/file_store"
+
+module CC
+  module CLI
+    class GlobalCache < FileStore
+      FILE_NAME = "/cache.yml".freeze
+
+      # Cache entries
+
+      def last_version_check
+        data["last-version-check"] || Time.at(0)
+      end
+
+      def last_version_check=(value)
+        data["last-version-check"] =
+          if value.is_a? Time
+            value
+          else
+            Time.at(0)
+          end
+        save
+        value
+      end
+
+      def latest_version
+        data["latest-version"]
+      end
+
+      def latest_version=(value)
+        data["latest-version"] = value
+        save
+        value
+      end
+
+      def outdated
+        data["outdated"] == true
+      end
+      alias outdated? outdated
+
+      def outdated=(value)
+        data["outdated"] = value == true
+        save
+        value
+      end
+    end
+  end
+end

--- a/lib/cc/cli/global_config.rb
+++ b/lib/cc/cli/global_config.rb
@@ -1,0 +1,35 @@
+require "cc/cli/file_store"
+require "uuid"
+
+module CC
+  module CLI
+    class GlobalConfig < FileStore
+      FILE_NAME = "/config.yml".freeze
+
+      DEFAULT_CONFIG = {
+        "check-version" => true,
+      }.freeze
+
+      # Config entries
+
+      def check_version
+        data["check-version"]
+      end
+      alias check_version? check_version
+
+      def check_version=(value)
+        data["check-version"] = value == true
+      end
+
+      def uuid
+        data["uuid"] ||= UUID.new.generate
+      end
+
+      private
+
+      def load_data
+        @data = DEFAULT_CONFIG.merge(super)
+      end
+    end
+  end
+end

--- a/lib/cc/cli/runner.rb
+++ b/lib/cc/cli/runner.rb
@@ -63,12 +63,11 @@ module CC
       private
 
       def check_version?
-        first_arg = ARGV.first
-        if %w[--check-version].include? first_arg
+        if ARGV.first == "--no-check-version"
           ARGV.shift
-          true
-        else
           false
+        else
+          true
         end
       end
     end

--- a/lib/cc/cli/version_checker.rb
+++ b/lib/cc/cli/version_checker.rb
@@ -1,3 +1,6 @@
+require "cc/cli/global_config"
+require "cc/cli/global_cache"
+
 module CC
   module CLI
     class VersionChecker
@@ -7,6 +10,8 @@ module CC
       DEFAULT_VERSIONS_URL = "https://versions.codeclimate.com".freeze
 
       def check
+        return unless global_config.check_version?
+
         print_new_version_message if outdated?
       rescue => error
         CLI.debug(error)
@@ -14,12 +19,24 @@ module CC
 
       private
 
+      def version_check_is_due?
+        Time.now > global_cache.last_version_check + VERSION_CHECK_TIMEOUT
+      end
+
       def outdated?
-        api_response["outdated"] == true
+        if version_check_is_due?
+          api_response["outdated"] == true
+        else
+          global_cache.outdated?
+        end
       end
 
       def latest_version
-        api_response["latest"]
+        if version_check_is_due?
+          api_response["latest"]
+        else
+          global_cache.latest_version
+        end
       end
 
       def print_new_version_message
@@ -29,13 +46,14 @@ module CC
       def api_response
         @api_response ||=
           begin
-            JSON.parse(api_response_body)
+            cache! JSON.parse(api_response_body)
           rescue JSON::ParserError => error
             CLI.debug(error)
-            # We don't know so pretend all is peachy. We'll try again next time.
+            # We don't know so use cached values or pretend all is peachy. We'll
+            # try again next time.
             {
-              "latest" => version,
-              "outdated" => false,
+              "latest" => global_cache.latest_version || version,
+              "outdated" => global_cache.outdated || false,
             }
           end
       end
@@ -55,15 +73,30 @@ module CC
         @http_response ||=
           begin
             uri = URI.parse(ENV.fetch("CODECLIMATE_VERSIONS_URL", DEFAULT_VERSIONS_URL))
-            uri.query = { version: version }.to_query
+            uri.query = { version: version, uid: global_config.uuid }.to_query
             Net::HTTP.start(uri.host, uri.port, open_timeout: 5, read_timeout: 5, ssl_timeout: 5, use_ssl: uri.scheme == "https") do |http|
               http.request_get(uri)
             end
           end
       end
 
+      def cache!(data)
+        global_cache.latest_version = data["latest"]
+        global_cache.outdated = data["outdated"] == true
+        global_cache.last_version_check = Time.now
+        data
+      end
+
       def version
         @version ||= Version.new.version
+      end
+
+      def global_config
+        @global_config ||= GlobalConfig.new
+      end
+
+      def global_cache
+        @global_cache ||= GlobalCache.new
       end
     end
   end

--- a/lib/cc/cli/version_checker.rb
+++ b/lib/cc/cli/version_checker.rb
@@ -13,6 +13,8 @@ module CC
         return unless global_config.check_version?
 
         print_new_version_message if outdated?
+
+        global_config.save
       rescue => error
         CLI.debug(error)
       end

--- a/spec/cc/cli/file_store_spec.rb
+++ b/spec/cc/cli/file_store_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe CC::CLI::FileStore do
+  def test_file_class(file_name)
+    Class.new(described_class).tap do |c|
+      c.const_set :FILE_NAME, file_name
+      c.send :public, :data
+    end
+  end
+
+  def write_test_file(content, fn = file_name)
+    File.write(fn, content)
+  end
+
+  let(:dir) { Dir.mktmpdir }
+  let(:file_name) { File.join dir, "idk.yml" }
+  after(:each) do
+    FileUtils.remove_entry dir
+  end
+
+  it "loads data on instantiation" do
+    write_test_file("---\ntest: instantiation")
+
+    test_file = test_file_class(file_name).new
+
+    expect(test_file.data).to eq("test" => "instantiation")
+  end
+
+  it "doesn't fail when there's no file" do
+    expect do
+      test_file_class(file_name).new
+    end.to_not raise_error
+  end
+
+  it "has empty data when there's no file" do
+    test_file = test_file_class(file_name).new
+
+    expect(test_file.data).to eq({})
+  end
+
+  it "doesn't saves data to a non-existent file" do
+    test_file = test_file_class(file_name).new
+    expect(test_file.save).to eq false
+
+    expect(File.exist?(file_name)).to eq false
+  end
+
+  it "saves data to the file" do
+    FileUtils.touch file_name
+    test_file = test_file_class(file_name).new
+    test_file.data["test"] = "save"
+    expect(test_file.save).to eq true
+
+    expect(File.exist?(file_name)).to eq true
+    expect(File.read(file_name)).to eq "---\ntest: save\n"
+  end
+end

--- a/spec/cc/cli/global_cache_spec.rb
+++ b/spec/cc/cli/global_cache_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+
+describe CC::CLI::GlobalCache do
+  around(:each) do |example|
+    Dir.mktmpdir do |dir|
+      original_file_name = described_class.send :remove_const, :FILE_NAME
+      described_class.const_set :FILE_NAME, File.join(dir, "cache.yml")
+      example.run
+      described_class.send :remove_const, :FILE_NAME
+      described_class.const_set :FILE_NAME, original_file_name
+    end
+  end
+
+  def write_cache_file(content)
+    File.write(described_class::FILE_NAME, content)
+  end
+
+  def read_cache_file
+    File.read described_class::FILE_NAME
+  end
+
+  let(:cache) { described_class.new }
+
+  it "loads cache" do
+    write_cache_file("---\nlatest-version: 42")
+
+    expect(cache.latest_version).to eq 42
+  end
+
+  describe "latest_version" do
+    it "autosaves cache on assignment" do
+      cache.latest_version = 42
+
+      expect(read_cache_file).to include "latest-version: 42"
+    end
+
+    it "return epoch start by default" do
+      expect(cache.last_version_check).to eq Time.at(0)
+    end
+  end
+
+  describe "last_version_check" do
+    it "resets to epoch start when non-time vallue is assigned" do
+      time = Time.now
+
+      cache.last_version_check = time
+      expect(cache.last_version_check).to eq time
+
+      cache.last_version_check = "nope"
+      expect(cache.last_version_check).to eq Time.at(0)
+    end
+
+    it "autosaves on assignment" do
+      time = Time.now
+
+      cache.last_version_check = time
+      expect(read_cache_file).to include "last-version-check: #{time.strftime "%F %T.%N %:z"}"
+    end
+  end
+
+  describe "outdated" do
+    it "returns false by default" do
+      expect(cache.outdated).to eq false
+    end
+
+    it "autosaves on assignment" do
+      cache.outdated = true
+      expect(read_cache_file).to include "outdated: true"
+    end
+
+    it "converts assigned value to boolean" do
+      cache.outdated = 42
+      expect(cache.outdated).to eq false
+    end
+
+    it "is aliased as outdated?" do
+      cache.outdated = true
+      expect(cache.outdated).to eq true
+      expect(cache.outdated?).to eq true
+
+      cache.outdated = false
+      expect(cache.outdated).to eq false
+      expect(cache.outdated?).to eq false
+    end
+  end
+end

--- a/spec/cc/cli/global_cache_spec.rb
+++ b/spec/cc/cli/global_cache_spec.rb
@@ -5,6 +5,7 @@ describe CC::CLI::GlobalCache do
     Dir.mktmpdir do |dir|
       original_file_name = described_class.send :remove_const, :FILE_NAME
       described_class.const_set :FILE_NAME, File.join(dir, "cache.yml")
+      write_cache_file "---"
       example.run
       described_class.send :remove_const, :FILE_NAME
       described_class.const_set :FILE_NAME, original_file_name

--- a/spec/cc/cli/global_config_spec.rb
+++ b/spec/cc/cli/global_config_spec.rb
@@ -50,6 +50,7 @@ describe CC::CLI::GlobalConfig do
   end
 
   it "saves config" do
+    write_config_file("---")
     config.check_version = false
     config.uuid
     config.save

--- a/spec/cc/cli/global_config_spec.rb
+++ b/spec/cc/cli/global_config_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+describe CC::CLI::GlobalConfig do
+  around(:each) do |example|
+    Dir.mktmpdir do |dir|
+      original_file_name = described_class.send :remove_const, :FILE_NAME
+      described_class.const_set :FILE_NAME, File.join(dir, "config.yml")
+      example.run
+      described_class.send :remove_const, :FILE_NAME
+      described_class.const_set :FILE_NAME, original_file_name
+    end
+  end
+
+  def write_config_file(content)
+    File.write described_class::FILE_NAME, content
+  end
+
+  def read_config_file
+    File.read described_class::FILE_NAME
+  end
+
+  let(:config) { described_class.new }
+
+  it "generates a UUID for you" do
+    allow(UUID).to receive(:new).
+      and_return(instance_double("UUID", generate: "definitely-a-uuid"))
+
+    expect(config.uuid).to eq "definitely-a-uuid"
+  end
+
+  it "check_version is true by default" do
+    expect(config.check_version).to eq true
+  end
+
+  it "check_version? is an alias to check_version" do
+    expect(config.check_version).to eq true
+    expect(config.check_version?).to eq true
+
+    config.check_version = false
+
+    expect(config.check_version).to eq false
+    expect(config.check_version?).to eq false
+  end
+
+  it "loads config" do
+    write_config_file("---\ncheck-version: false\nuuid: uuid")
+
+    expect(config.check_version?).to eq false
+    expect(config.uuid).to eq "uuid"
+  end
+
+  it "saves config" do
+    config.check_version = false
+    config.uuid
+    config.save
+
+    expect(read_config_file).to eq "---\ncheck-version: false\nuuid: #{config.uuid}\n"
+  end
+end

--- a/spec/cc/cli/runner_spec.rb
+++ b/spec/cc/cli/runner_spec.rb
@@ -10,6 +10,10 @@ module CC::CLI
 
     describe ".run" do
       it "rescues exceptions and prints a friendlier message" do
+        checker = instance_double("Version checker")
+        allow(VersionChecker).to receive(:new).and_return(checker)
+        allow(checker).to receive(:check)
+
         Explode = Class.new(Command) do
           def run
             raise StandardError, "boom"
@@ -23,11 +27,12 @@ module CC::CLI
         expect(stderr).to match(/error: \(StandardError\) boom/)
       end
 
-      it "doesn't check checks for new version by default" do
+      it "doesn't check for new version when --no-check-version is passed" do
         checker = instance_double("Version checker")
         allow(VersionChecker).to receive(:new).and_return(checker)
         allow(checker).to receive(:check)
 
+        ARGV.unshift("--no-check-version")
         capture_io do
           Runner.run([])
         end
@@ -35,12 +40,11 @@ module CC::CLI
         expect(checker).to_not have_received(:check)
       end
 
-      it "check for new version when --check-version is passed" do
+      it "checks for new version by default" do
         checker = instance_double("Version checker")
         allow(VersionChecker).to receive(:new).and_return(checker)
         allow(checker).to receive(:check)
 
-        ARGV.unshift("--check-version")
         capture_io do
           Runner.run([])
         end

--- a/spec/cc/cli/version_checker_spec.rb
+++ b/spec/cc/cli/version_checker_spec.rb
@@ -1,6 +1,24 @@
 require "spec_helper"
 
 describe CC::CLI::VersionChecker do
+  around(:each) do |example|
+    Dir.mktmpdir do |dir|
+      original_config = CC::CLI::GlobalConfig.send :remove_const, :FILE_NAME
+      CC::CLI::GlobalConfig.const_set :FILE_NAME, File.join(dir, "config.yml")
+
+      original_cache = CC::CLI::GlobalCache.send :remove_const, :FILE_NAME
+      CC::CLI::GlobalCache.const_set :FILE_NAME, File.join(dir, "cache.yml")
+
+      example.run
+
+      CC::CLI::GlobalConfig.send :remove_const, :FILE_NAME
+      CC::CLI::GlobalConfig.const_set :FILE_NAME, original_config
+
+      CC::CLI::GlobalCache.send :remove_const, :FILE_NAME
+      CC::CLI::GlobalCache.const_set :FILE_NAME, original_cache
+    end
+  end
+
   let(:checker) { described_class.new }
 
   def stub_version_request(versions_resp)
@@ -9,6 +27,18 @@ describe CC::CLI::VersionChecker do
     resp = Net::HTTPOK.new("1.1", 200, "OK")
     allow(resp).to receive(:body).and_return(versions_resp.to_json)
     allow(Net::HTTP).to receive(:start).and_return(resp)
+  end
+
+  it "doesn't do anything when disabled in global config" do
+    config = CC::CLI::GlobalConfig.new
+    config.check_version = false
+    config.save
+
+    allow(checker).to receive(:outdated?)
+
+    checker.check
+
+    expect(checker).to_not have_received(:outdated?)
   end
 
   it "checks version against the API" do
@@ -31,14 +61,31 @@ describe CC::CLI::VersionChecker do
     expect(out).to eq ""
   end
 
-  it "uses default values when API is unavailable" do
+  it "uses cached values when API is unavailable" do
     stub_resolv("versions.codeclimate.com", "255.255.255.255")
     allow(Net::HTTP).to receive(:start).and_return(Net::HTTPServerError.new(500, "Nope", "Nope Nope"))
+
+    cache = CC::CLI::GlobalCache.new
+    cache.latest_version = "0.1.1"
+    cache.outdated = true
 
     out, = capture_io do
       checker.check
     end
 
-    expect(out).to eq ""
+    expect(out).to include "A new version (v0.1.1) is available"
+  end
+
+  it "uses cached values if checked recently" do
+    cache = CC::CLI::GlobalCache.new
+    cache.last_version_check = Time.now
+    cache.latest_version = "0.1.1"
+    cache.outdated = true
+
+    out, = capture_io do
+      checker.check
+    end
+
+    expect(out).to include "A new version (v0.1.1) is available"
   end
 end


### PR DESCRIPTION
If using codeclimate-wrapper, manage config.yml and cache.yml files in the
user's home directory (following the XDG spec). These files are currently used
to manage the recently introduced version check feature.

Just re-opening #587 against master.