### PR TITLE
Add rustfmt beta engine

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -392,6 +392,15 @@ rubymotion:
   enable_regexps:
   default_ratings_paths:
     - "**.rb"
+rustfmt:
+  channels:
+    beta: codeclimate/codeclimate-rustfmt:beta
+  description: A tool for formatting Rust code according to style guidelines.
+  community: true
+  enable_regexps:
+    - \.rs$
+  default_ratings_paths:
+    - "**.rs"
 scss-lint:
   channels:
     stable: codeclimate/codeclimate-scss-lint


### PR DESCRIPTION
A tool for formatting Rust code according to style guidelines.

engine: https://github.com/aep/codeclimate-rustfmt