### PR TITLE
Mount `/code` as `:rw` if `CLI.debug?`.

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -68,6 +68,8 @@ module CC
       end
 
       def container_options
+        mount = CLI.debug? ? "rw" : "ro"
+
         [
           "--cap-drop", "all",
           "--label", "com.codeclimate.label=#{@label}",
@@ -75,7 +77,7 @@ module CC
           "--memory-swap", "-1",
           "--net", "none",
           "--rm",
-          "--volume", "#{@code_path}:/code:ro",
+          "--volume", "#{@code_path}:/code:#{mount}",
           "--volume", "#{config_file.host_path}:/config.json:ro",
           "--user", "9000:9000"
         ]


### PR DESCRIPTION
This allows you to run with extra tooling enabled that might leave
file artifacts that are later used to analyze or report (like
stackprof and other profilers).