### PR TITLE
Assign minor severity by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ image:
 	docker build -t codeclimate/codeclimate .
 
 test: image
-	docker run --rm \
+	docker run --rm -it \
 	  --entrypoint bundle \
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  codeclimate/codeclimate exec rake spec:all spec:benchmark

--- a/lib/cc/analyzer/issue.rb
+++ b/lib/cc/analyzer/issue.rb
@@ -1,6 +1,7 @@
 module CC
   module Analyzer
     class Issue
+      DEFAULT_SEVERITY = "minor".freeze
       SPEC_ISSUE_ATTRIBUTES = %w[
         categories
         check_name
@@ -20,6 +21,7 @@ module CC
       def as_json(*)
         parsed_output.reverse_merge!(
           "fingerprint" => fingerprint,
+          "severity" => severity,
         )
       end
 
@@ -44,6 +46,10 @@ module CC
 
       def default_fingerprint
         SourceFingerprint.new(self).compute
+      end
+
+      def severity
+        parsed_output.fetch("severity", DEFAULT_SEVERITY)
       end
 
       def parsed_output

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -80,7 +80,9 @@ module CC::Analyzer
           engine = Engine.new("", {}, "", {}, "")
           engine.run(stdout, ContainerListener.new)
 
-          expect(stdout.string).to eq "{\"type\":\"issue\",\"check_name\":\"foo\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"bdc0c2bb1201c4739118a51481a86fa1\"}{\"type\":\"issue\",\"check_name\":\"bar\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"cbd5b8962eb9e2950fbb02f0ddf6c404\"}{\"type\":\"issue\",\"check_name\":\"baz\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"a08df13d51af2259c425551cb84c135f\"}"
+          expected = "{\"type\":\"issue\",\"check_name\":\"foo\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"bdc0c2bb1201c4739118a51481a86fa1\",\"severity\":\"minor\"}{\"type\":\"issue\",\"check_name\":\"bar\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"cbd5b8962eb9e2950fbb02f0ddf6c404\",\"severity\":\"minor\"}{\"type\":\"issue\",\"check_name\":\"baz\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"fingerprint\":\"a08df13d51af2259c425551cb84c135f\",\"severity\":\"minor\"}"
+
+          expect(stdout.string).to eq expected
         end
       end
 

--- a/spec/cc/analyzer/issue_spec.rb
+++ b/spec/cc/analyzer/issue_spec.rb
@@ -52,10 +52,24 @@ module CC::Analyzer
       it "merges in defaulted attributes" do
         expected_additions = {
           "fingerprint" => "433fae1189b03bcd9153dc8dce209fa5",
+          "severity" => Issue::DEFAULT_SEVERITY,
         }
         issue = Issue.new(output.to_json)
 
         expect(issue.as_json).to eq(output.merge(expected_additions))
+      end
+
+      it "doesn't overwrite defaulted attrs when present" do
+        optional_attrs = {
+          "fingerprint" => "433fae1189b03bcd9153dc8dce209fa5",
+          "severity" => "major",
+        }
+
+        unchanged = output.merge(optional_attrs)
+
+        issue = Issue.new(unchanged.to_json)
+
+        expect(issue.as_json).to eq(unchanged)
       end
     end
   end


### PR DESCRIPTION
According to the Code Climate
[SPEC](https://github.com/codeclimate/spec/blob/master/SPEC.md#issues)
today, issue severities are optional.

The SPEC was recently updated to include a list of five severity types:
info, minor, major, critical, blocker.

When an engine emits no severity, by default we'll report a severity of "minor".