### PR TITLE
Validate severity on issues

### DIFF
--- a/lib/cc/analyzer/issue_validations.rb
+++ b/lib/cc/analyzer/issue_validations.rb
@@ -11,6 +11,7 @@ module CC
       autoload :PathIsFileValidation, "cc/analyzer/issue_validations/path_is_file_validation"
       autoload :PathPresenceValidation, "cc/analyzer/issue_validations/path_presence_validation"
       autoload :RelativePathValidation, "cc/analyzer/issue_validations/relative_path_validation"
+      autoload :SeverityValidation, "cc/analyzer/issue_validations/severity_validation"
       autoload :TypeValidation, "cc/analyzer/issue_validations/type_validation"
       autoload :Validation, "cc/analyzer/issue_validations/validation"
 

--- a/lib/cc/analyzer/issue_validations/severity_validation.rb
+++ b/lib/cc/analyzer/issue_validations/severity_validation.rb
@@ -1,0 +1,39 @@
+module CC
+  module Analyzer
+    module IssueValidations
+      class SeverityValidation < Validation
+        INFO = "info".freeze
+        MINOR = "minor".freeze
+        MAJOR = "major".freeze
+        CRITICAL = "critical".freeze
+        BLOCKER = "blocker".freeze
+
+        DEPRECATED_SEVERITIES = [
+          NORMAL = "normal".freeze,
+        ].freeze
+
+        VALID_SEVERITIES = ([
+          INFO,
+          MINOR,
+          MAJOR,
+          CRITICAL,
+          BLOCKER,
+        ] + DEPRECATED_SEVERITIES).freeze
+
+        def valid?
+          severity.nil? || VALID_SEVERITIES.include?(severity)
+        end
+
+        def message
+          "Permitted severities include #{VALID_SEVERITIES.join(", ")}"
+        end
+
+        private
+
+        def severity
+          @severity ||= object["severity"]
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/issue_validations/severity_validation_spec.rb
+++ b/spec/cc/analyzer/issue_validations/severity_validation_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+module CC::Analyzer::IssueValidations
+  describe SeverityValidation do
+    describe "#valid?" do
+      let(:valid) { SeverityValidation::MINOR }
+      let(:deprecated) { SeverityValidation::DEPRECATED_SEVERITIES.first }
+
+      context "when severity present and valid" do
+        it "returns true" do
+          expect(SeverityValidation.new("severity" => valid)).to be_valid
+        end
+      end
+
+      context "when severity is absent" do
+        it "returns true" do
+          expect(SeverityValidation.new("severity" => nil)).to be_valid
+        end
+      end
+
+      context "when severity is valid but deprecated" do
+        it "returns true" do
+          expect(SeverityValidation.new("severity" => deprecated)).to be_valid
+        end
+      end
+
+      context "when severity present and invalid" do
+        it " returns false" do
+          expect(SeverityValidation.new("severity" => "9000")).not_to be_valid
+        end
+      end
+    end
+
+    describe "#message" do
+      it "returns a list of permitted severities" do
+        expect(SeverityValidation.new("severity" => "9000").message)
+          .to match("Permitted severities include")
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/issue_validations_spec.rb
+++ b/spec/cc/analyzer/issue_validations_spec.rb
@@ -15,6 +15,7 @@ module CC::Analyzer
           IssueValidations::PathIsFileValidation,
           IssueValidations::PathPresenceValidation,
           IssueValidations::RelativePathValidation,
+          IssueValidations::SeverityValidation,
           IssueValidations::TypeValidation,
         ]
 


### PR DESCRIPTION
Although severity continues to be an optional attribute for an engine to
emit, we now default to MINOR severity, and only permit 6 options: info,
minor, major, critical, blocker and normal (deprecated).

This validation enforces that restriction to ensure compliance with the
[CC
SPEC](https://github.com/codeclimate/spec/blob/master/SPEC.md#issues).