### PR TITLE
Scan for inferred config target filename alongside alternates

### DIFF
--- a/lib/cc/cli/init.rb
+++ b/lib/cc/cli/init.rb
@@ -79,7 +79,9 @@ module CC
             config_mapping = Hash.new { |_, k| [k] }.merge(engine.fetch("config_files", {}))
 
             config_paths.each do |config_path|
-              generate_config(config_path, config_mapping[File.basename(config_path)])
+              filename = File.basename(config_path)
+              possible_names = config_mapping[filename].concat([filename])
+              generate_config(config_path, possible_names)
             end
           end
         end

--- a/spec/cc/cli/init_spec.rb
+++ b/spec/cc/cli/init_spec.rb
@@ -125,6 +125,22 @@ module CC::CLI
               expect(filesystem.exist?('.rubocop.yml')).to eq(true)
               expect(content_after).to eq(content_before)
             end
+
+            it "skips engine config file generation when target file is present" do
+              File.write("bar.js", "{}")
+
+              filename = ".eslintrc.yml"
+              content = "test content"
+              File.write(filename, content)
+
+              stdout, _, _ = capture_io_and_exit_code do
+                Init.new.run
+              end
+
+              expect(stdout).to include("Skipping generating #{filename}, existing file(s) found: #{filename}")
+              expect(filesystem.exist?(filename)).to eq(true)
+              expect(content).to eq(File.read(filename))
+            end
           end
 
           describe "when an invalid engine is specified" do


### PR DESCRIPTION
We currently set .eslintrc.yml as the desired inferred configuration
filename for ESLint but fail to skip when a file with the same filename
is already present within the workspace.