### PR TITLE
Don't warn about a new version after user upgrades

### DIFF
--- a/lib/cc/cli/global_cache.rb
+++ b/lib/cc/cli/global_cache.rb
@@ -31,17 +31,6 @@ module CC
         save
         value
       end
-
-      def outdated
-        data["outdated"] == true
-      end
-      alias outdated? outdated
-
-      def outdated=(value)
-        data["outdated"] = value == true
-        save
-        value
-      end
     end
   end
 end

--- a/lib/cc/cli/version.rb
+++ b/lib/cc/cli/version.rb
@@ -4,12 +4,12 @@ module CC
       SHORT_HELP = "Display the CLI version.".freeze
 
       def run
-        say version
+        say self.class.latest
       end
 
-      def version
+      def self.latest
         path = File.expand_path("../../../../VERSION", __FILE__)
-        @version ||= File.read(path)
+        @version ||= File.read(path).chomp
       end
     end
   end

--- a/lib/cc/cli/version_checker.rb
+++ b/lib/cc/cli/version_checker.rb
@@ -26,11 +26,7 @@ module CC
       end
 
       def outdated?
-        if version_check_is_due?
-          api_response["outdated"] == true
-        else
-          global_cache.outdated?
-        end
+        Gem::Version.new(latest_version) > Gem::Version.new(version)
       end
 
       def latest_version
@@ -55,7 +51,6 @@ module CC
             # try again next time.
             {
               "latest" => global_cache.latest_version || version,
-              "outdated" => global_cache.outdated || false,
             }
           end
       end
@@ -84,13 +79,12 @@ module CC
 
       def cache!(data)
         global_cache.latest_version = data["latest"]
-        global_cache.outdated = data["outdated"] == true
         global_cache.last_version_check = Time.now
         data
       end
 
       def version
-        @version ||= Version.new.version
+        @version ||= Version.latest
       end
 
       def global_config

--- a/spec/cc/cli/global_cache_spec.rb
+++ b/spec/cc/cli/global_cache_spec.rb
@@ -58,30 +58,4 @@ describe CC::CLI::GlobalCache do
       expect(read_cache_file).to include "last-version-check: #{time.strftime "%F %T.%N %:z"}"
     end
   end
-
-  describe "outdated" do
-    it "returns false by default" do
-      expect(cache.outdated).to eq false
-    end
-
-    it "autosaves on assignment" do
-      cache.outdated = true
-      expect(read_cache_file).to include "outdated: true"
-    end
-
-    it "converts assigned value to boolean" do
-      cache.outdated = 42
-      expect(cache.outdated).to eq false
-    end
-
-    it "is aliased as outdated?" do
-      cache.outdated = true
-      expect(cache.outdated).to eq true
-      expect(cache.outdated?).to eq true
-
-      cache.outdated = false
-      expect(cache.outdated).to eq false
-      expect(cache.outdated?).to eq false
-    end
-  end
 end


### PR DESCRIPTION
With this change, the server doesn't need to calculate the outdated
field anymore, but I think we should still leave it for people using an
older version of the CLI.

Fix https://github.com/codeclimate/codeclimate/issues/619