### PR TITLE
Don't use the cached version if we are not checking for a new version

### DIFF
--- a/lib/cc/cli/version_checker.rb
+++ b/lib/cc/cli/version_checker.rb
@@ -10,7 +10,7 @@ module CC
       DEFAULT_VERSIONS_URL = "https://versions.codeclimate.com".freeze
 
       def check
-        return unless global_config.check_version?
+        return unless global_config.check_version? && version_check_is_due?
 
         print_new_version_message if outdated?
 
@@ -26,19 +26,11 @@ module CC
       end
 
       def outdated?
-        if version_check_is_due?
-          api_response["outdated"] == true
-        else
-          global_cache.outdated?
-        end
+        api_response["outdated"]
       end
 
       def latest_version
-        if version_check_is_due?
-          api_response["latest"]
-        else
-          global_cache.latest_version
-        end
+        api_response["latest"]
       end
 
       def print_new_version_message
@@ -51,11 +43,8 @@ module CC
             cache! JSON.parse(api_response_body)
           rescue JSON::ParserError => error
             CLI.debug(error)
-            # We don't know so use cached values or pretend all is peachy. We'll
-            # try again next time.
             {
-              "latest" => global_cache.latest_version || version,
-              "outdated" => global_cache.outdated || false,
+              "outdated" => false,
             }
           end
       end

--- a/spec/cc/cli/version_checker_spec.rb
+++ b/spec/cc/cli/version_checker_spec.rb
@@ -79,7 +79,7 @@ describe CC::CLI::VersionChecker do
     expect(stderr).to eq ""
   end
 
-  it "uses cached values when API is unavailable" do
+  it "does nothing when API is unavailable" do
     stub_resolv("versions.codeclimate.com", "255.255.255.255")
     allow(Net::HTTP).to receive(:start).and_return(Net::HTTPServerError.new(500, "Nope", "Nope Nope"))
 
@@ -91,10 +91,10 @@ describe CC::CLI::VersionChecker do
       checker.check
     end
 
-    expect(stderr).to include "A new version (v0.1.1) is available"
+    expect(stderr).to eq ""
   end
 
-  it "uses cached values if checked recently" do
+  it "does nothing if checked recently" do
     cache = CC::CLI::GlobalCache.new
     cache.last_version_check = Time.now
     cache.latest_version = "0.1.1"
@@ -104,6 +104,6 @@ describe CC::CLI::VersionChecker do
       checker.check
     end
 
-    expect(stderr).to include "A new version (v0.1.1) is available"
+    expect(stderr).to eq ""
   end
 end


### PR DESCRIPTION
Issue #619

Rather than using the cached version when we're not hitting the API, we
should skip the outdated check entirely.