### PR TITLE
Support a #reload operation on Config objects

### DIFF
--- a/lib/cc/config/default.rb
+++ b/lib/cc/config/default.rb
@@ -18,9 +18,12 @@ module CC
       attr_writer :development
 
       def initialize
-        @development = false
-        @engines = [structure_engine, duplication_engine]
-        @exclude_patterns = EXCLUDE_PATTERNS
+        load_defaults
+      end
+
+      def reload
+        load_defaults
+        self
       end
 
       def analysis_paths
@@ -32,6 +35,12 @@ module CC
       end
 
       private
+
+      def load_defaults
+        @development = false
+        @engines = [structure_engine, duplication_engine]
+        @exclude_patterns = EXCLUDE_PATTERNS
+      end
 
       def structure_engine
         Engine.new(

--- a/lib/cc/config/yaml.rb
+++ b/lib/cc/config/yaml.rb
@@ -14,10 +14,22 @@ module CC
         to: :default
 
       def initialize(path = DEFAULT_PATH)
+        @path = path
         @yaml = SafeYAML.load_file(path) || {}
         @default = Default.new
 
         upconvert_legacy_yaml!
+      end
+
+      def reload
+        # We don't expect or support the YAML itself to have changed on disk,
+        # otherwise users who are calling reload would have to also re-validate
+        # to avoid problems using the result. This just resets the state
+        # determined from the YAML.
+        default.reload
+        @engines = nil
+        @exclude_patterns = nil
+        self
       end
 
       def engines
@@ -33,7 +45,7 @@ module CC
 
       private
 
-      attr_reader :default, :yaml
+      attr_reader :path, :default, :yaml
 
       def plugin_engines
         yaml.fetch("plugins", []).

--- a/spec/cc/config/yaml_spec.rb
+++ b/spec/cc/config/yaml_spec.rb
@@ -16,6 +16,23 @@ describe CC::Config::YAML do
     end
   end
 
+  describe "#reload" do
+    it "re-reads and resets" do
+      yaml = load_cc_yaml(<<-EOYAML)
+      plugins:
+        rubocop: true
+        eslint: true
+      EOYAML
+      expect(yaml.engines.length).to eq(4)
+
+      yaml.engines.pop(2)
+      expect(yaml.engines.length).to eq(2)
+
+      yaml.reload
+      expect(yaml.engines.length).to eq(4)
+    end
+  end
+
   describe "#engines" do
     it "includes default engines" do
       yaml = load_cc_yaml("")


### PR DESCRIPTION
The primary use-case is the prepare.files step and eventual auto-enable
plugins feature. If we load and validate a config, pull in a .rubocop.yml
through prepare.files, we want Config#engines to auto-enable rubocop
because that file is now present. To do this we'll Config#reload after
prepare.

Note: the reload does not re-read the yaml from disk. This is to avoid the
caller forgetting to re-validate a reloaded config, and risking confusing
downstream errors. That means we don't support prepare.files pulling down a
change to codeclimate.yml itself.