### PR TITLE
Fix bugs related to running engines

### DIFF
--- a/lib/cc/config/default.rb
+++ b/lib/cc/config/default.rb
@@ -38,7 +38,7 @@ module CC
 
       def load_defaults
         @development = false
-        @engines = [structure_engine, duplication_engine]
+        @engines = Set.new([structure_engine, duplication_engine])
         @exclude_patterns = EXCLUDE_PATTERNS
       end
 

--- a/lib/cc/config/engine.rb
+++ b/lib/cc/config/engine.rb
@@ -4,12 +4,13 @@ module CC
       DEFAULT_CHANNEL = "stable".freeze
 
       attr_reader :name, :channel, :config
+      attr_writer :enabled
 
-      def initialize(name, enabled: false, channel: DEFAULT_CHANNEL, config: {})
+      def initialize(name, enabled: false, channel: nil, config: nil)
         @name = name
         @enabled = enabled
-        @channel = channel
-        @config = config
+        @channel = channel || DEFAULT_CHANNEL
+        @config = config || {}
       end
 
       def enabled?
@@ -29,6 +30,18 @@ module CC
         else
           { "channel" => channel }
         end
+      end
+
+      # Set interface methods. Assumes we never want to store the same engine by
+      # name in the same list. This should be true except maybe if we want to
+      # work with multiple channels at once, which is unlikely.
+
+      def eql?(other)
+        other.is_a?(self.class) && name.eql?(other.name)
+      end
+
+      def hash
+        name.hash
       end
     end
   end

--- a/lib/cc/config/yaml.rb
+++ b/lib/cc/config/yaml.rb
@@ -33,7 +33,7 @@ module CC
       end
 
       def engines
-        @engines ||= default.engines.concat(plugin_engines)
+        @engines ||= default.engines | Set.new(plugin_engines)
       end
 
       def exclude_patterns
@@ -48,9 +48,9 @@ module CC
       attr_reader :path, :default, :yaml
 
       def plugin_engines
-        yaml.fetch("plugins", []).
-          map { |name, data| plugin_engine(name, data) }.
-          select(&:enabled?)
+        yaml.fetch("plugins", []).map do |name, data|
+          plugin_engine(name, data)
+        end
       end
 
       def plugin_engine(name, data)

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -36,7 +36,7 @@ module CC
     def not_found_message(ex, engine, available_channels)
       "Engine details not found" \
         " for #{engine.name}:#{engine.channel}," \
-        " available channels: #{available_channels.inspect}"
+        " available channels: #{available_channels.keys.inspect}"
     end
   end
 end

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -34,9 +34,15 @@ module CC
     attr_reader :yaml, :prefix
 
     def not_found_message(ex, engine, available_channels)
-      "Engine details not found" \
-        " for #{engine.name}:#{engine.channel}," \
-        " available channels: #{available_channels.keys.inspect}"
+      if available_channels
+        # Known engine, unknown channel
+        "Engine details not found" \
+          " for #{engine.name}:#{engine.channel}," \
+          " available channels: #{available_channels.keys.inspect}"
+      else
+        # Unknown engine
+        "Engine details not found for #{engine.name}"
+      end
     end
   end
 end

--- a/spec/cc/config/yaml_spec.rb
+++ b/spec/cc/config/yaml_spec.rb
@@ -25,7 +25,7 @@ describe CC::Config::YAML do
       EOYAML
       expect(yaml.engines.length).to eq(4)
 
-      yaml.engines.pop(2)
+      yaml.engines.replace(yaml.engines.take(2))
       expect(yaml.engines.length).to eq(2)
 
       yaml.reload
@@ -52,10 +52,10 @@ describe CC::Config::YAML do
           enabled: false
       EOYAML
 
-      expect(yaml.engines.length).to eq(4)
-      expect(yaml.engines.map(&:name)).to include("rubocop")
-      expect(yaml.engines.map(&:name)).to include("eslint")
-      expect(yaml.engines.map(&:name)).not_to include("tslint")
+      expect(yaml.engines.length).to eq(5)
+      expect(yaml.engines.map(&:name).drop(2)).to eq(
+        %w[rubocop eslint tslint],
+      )
     end
 
     it "supports a plugin:true|false shorthand" do
@@ -65,9 +65,9 @@ describe CC::Config::YAML do
         eslint: false
       EOYAML
 
-      expect(yaml.engines.length).to eq(3)
-      expect(yaml.engines.map(&:name)).to include("rubocop")
-      expect(yaml.engines.map(&:name)).not_to include("eslint")
+      _, _, rubocop, eslint = yaml.engines.to_a
+      expect(rubocop).to be_enabled
+      expect(eslint).not_to be_enabled
     end
 
     it "respects channel, and config" do

--- a/spec/cc/engine_registry_spec.rb
+++ b/spec/cc/engine_registry_spec.rb
@@ -46,7 +46,7 @@ describe CC::EngineRegistry do
       engine = double(name: "nope", channel: "beta")
       expect { registry.fetch_engine_details(engine) }.to raise_error(
         described_class::EngineDetailsNotFoundError,
-        /details not found for nope:beta, /,
+        /details not found for nope/,
       )
     end
 
@@ -61,7 +61,7 @@ describe CC::EngineRegistry do
       engine = double(name: "rubocop", channel: "nope")
       expect { registry.fetch_engine_details(engine) }.to raise_error(
         described_class::EngineDetailsNotFoundError,
-        /details not found for rubocop:nope,.*["stable","example"] /,
+        /details not found for rubocop:nope,.*\["stable", "example"\]/,
       )
     end
 


### PR DESCRIPTION
- Config#engines should be a Set

  This prevents any configuration or CLI arguments from causing the same engine
  to be run twice -- a bug that's particularly hard to avoid with our QM-related
  changes.

- Config#engines should include disabled engines

  They should be filtered only as part of running them. This allows us to
  manipulate the list for enabled-ness after the fact.

- -e,--engine should work again

  Given the above two, this was trivial to re-add.

- Handle EngineDetailsNotFoundError correctly

  Need to rescue in the loop, not outside. This means that listener.finished may
  be called with nil engine_details. No listeners in this codebase rely on it,
  but Builder will need tweaking to handle it.