### PR TITLE
Fixes to validate-config

### DIFF
--- a/lib/cc/cli/validate_config.rb
+++ b/lib/cc/cli/validate_config.rb
@@ -4,94 +4,62 @@ module CC
   module CLI
     class ValidateConfig < Command
       SHORT_HELP = "Validate your .codeclimate.yml.".freeze
-
-      include CC::Analyzer
-      include CC::Yaml
-
       VALID_CONFIG_MESSAGE = "No errors or warnings found in .codeclimate.yml file.".freeze
 
       def run
         require_codeclimate_yml
-        verify_yaml
+        process_args
+
+        if any_issues?
+          display_issues
+        else
+          puts VALID_CONFIG_MESSAGE
+        end
+
+        exit 1 unless validator.valid?
       end
 
       private
 
-      def verify_yaml
-        if any_issues?
-          display_issues
-        else
-          puts colorize(VALID_CONFIG_MESSAGE, :green)
+      attr_reader :config, :registry, :validator
+
+      def process_args
+        registry_path = EngineRegistry::DEFAULT_MANIFEST_PATH
+        registry_prefix = ""
+
+        # Undocumented; we only need these from Builder so we can validate
+        # engines/channels against our own registry and prefix.
+        while (arg = @args.shift)
+          case arg
+          when "--registry" then registry_path = @args.shift
+          when "--registry-prefix" then registry_prefix = @args.shift
+          end
         end
+
+        @validator = Config::YAML::Validator.new(
+          Config::YAML::DEFAULT_PATH,
+          EngineRegistry.new(registry_path, registry_prefix),
+        )
       end
 
       def any_issues?
-        parsed_yaml.errors? || parsed_yaml.nested_warnings.any? || parsed_yaml.warnings? || invalid_engines.any?
-      end
-
-      def yaml_content
-        filesystem.read_path(CODECLIMATE_YAML).freeze
-      end
-
-      def parsed_yaml
-        @parsed_yaml ||= CC::Yaml.parse(yaml_content)
-      end
-
-      def warnings
-        @warnings ||= parsed_yaml.warnings
-      end
-
-      def nested_warnings
-        @nested_warnings ||= parsed_yaml.nested_warnings
-      end
-
-      def errors
-        @errors ||= parsed_yaml.errors
+        validator.errors.any? ||
+          validator.warnings.any? ||
+          validator.nested_warnings.any?
       end
 
       def display_issues
-        display_errors
-        display_warnings
-        display_invalid_engines
-        display_nested_warnings
-      end
-
-      def display_errors
-        errors.each do |error|
-          puts colorize("ERROR: #{error}", :red)
+        validator.errors.each do |error|
+          puts "#{colorize("ERROR", :red)}: #{error}"
         end
-      end
 
-      def display_nested_warnings
-        nested_warnings.each do |nested_warning|
-          if nested_warning[0][0]
-            puts colorize("WARNING in #{nested_warning[0][0]}: #{nested_warning[1]}", :red)
-          end
+        validator.warnings.each do |warning|
+          puts "#{colorize("WARNING", :yellow)}: #{warning}"
         end
-      end
 
-      def display_warnings
-        warnings.each do |warning|
-          puts colorize("WARNING: #{warning}", :red)
+        validator.nested_warnings.each do |warning|
+          puts "#{colorize("WARNING in #{warning.field}", :yellow)}: #{warning.message}"
         end
-      end
-
-      def display_invalid_engines
-        invalid_engines.each do |engine_name|
-          puts colorize("WARNING: unknown engine <#{engine_name}>", :red)
-        end
-      end
-
-      def invalid_engines
-        @invalid_engines ||= engine_names.reject { |engine_name| engine_registry.exists? engine_name }
-      end
-
-      def engine_names
-        @engine_names ||= engines.keys
-      end
-
-      def engines
-        @engines ||= parsed_yaml.engines || {}
       end
     end
   end

--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -1,6 +1,7 @@
 require "cc/config/default"
 require "cc/config/engine"
 require "cc/config/yaml"
+require "cc/config/yaml/validator"
 
 module CC
   module Config

--- a/lib/cc/config/yaml/validator.rb
+++ b/lib/cc/config/yaml/validator.rb
@@ -1,0 +1,71 @@
+# Validations currently present in CC::Yaml are complex, so we defer to it for
+# now to avoid regressions while moving to Quality model. In the future we
+# should strangle our use of the gem down to only that, then port it, then
+# finally remove it entirely.
+require "cc/yaml"
+
+module CC
+  module Config
+    class YAML
+      class Validator
+        NestedWarning = Struct.new(:field, :message)
+
+        def initialize(path, registry)
+          @path = path
+          @registry = registry
+          @cc_yaml = CC::Yaml.parse(File.read(path))
+        end
+
+        def valid?
+          errors.none?
+        end
+
+        def errors
+          cc_yaml.errors.reject do |msg|
+            msg =~ /^No languages or engines key found/
+          end
+        end
+
+        def warnings
+          cc_yaml.warnings.concat(invalid_engine_warnings)
+        end
+
+        def nested_warnings
+          cc_yaml.nested_warnings.
+            map { |x| NestedWarning.new(x[0][0], x[1]) }.
+            reject { |x| x.field == "ratings" }
+        end
+
+        private
+
+        attr_reader :path, :registry, :cc_yaml
+
+        def invalid_engine_warnings
+          invalid_engines.map do |engine|
+            "unknown engine or channel <#{engine.name}:#{engine.channel}>"
+          end
+        end
+
+        def invalid_engines
+          return [] unless cc_yaml_processable?
+          config = CC::Config::YAML.new(path)
+          config.engines.reject do |engine|
+            engine_exists?(engine)
+          end
+        end
+
+        def engine_exists?(engine)
+          !!registry.fetch_engine_details(engine)
+        rescue CC::EngineRegistry::EngineDetailsNotFoundError
+          false
+        end
+
+        def cc_yaml_processable?
+          cc_yaml.errors.none? &&
+            cc_yaml.warnings.none? &&
+            cc_yaml.nested_warnings.none?
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/cli/validate_config_spec.rb
+++ b/spec/cc/cli/validate_config_spec.rb
@@ -2,145 +2,115 @@ require "spec_helper"
 
 module CC::CLI
   describe ValidateConfig do
+    around do |spec|
+      Dir.chdir(Dir.mktmpdir) { spec.run }
+    end
+
     describe "#run" do
-      describe "when a .codeclimate.yml file is present in working directory" do
-        it "analyzes the .codeclimate.yml file without altering it" do
-          within_temp_dir do
-            expect(filesystem.exist?(".codeclimate.yml")).to eq(false)
+      it "reports errors and exits nonzero" do
+        write_cc_yaml(<<-EOYAML)
+        engkxhfgkxfhg: sdoufhsfogh: -
+        0-
+        fgkjfhgkdjfg;h:;
+          sligj:
+        oi i ;
+        EOYAML
 
-            yaml_content_before = "This is a test yaml!"
-            File.write(".codeclimate.yml", yaml_content_before)
-
-            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
-
-            capture_io do
-              validate_config = ValidateConfig.new
-              validate_config.run
-            end
-
-            expect(filesystem.exist?(".codeclimate.yml")).to eq(true)
-
-            content_after = File.read(".codeclimate.yml")
-
-            expect(content_after).to eq(yaml_content_before)
-          end
+        stdout, _stderr, code = capture_io_and_exit_code do
+          ValidateConfig.new.run
         end
 
-        describe "when there are errors present" do
-          it "reports that an error was found" do
-            within_temp_dir do
-              yaml_content = Factory.create_yaml_with_errors
-              File.write(".codeclimate.yml", yaml_content)
+        expect(stdout).to match("ERROR")
+        expect(code).to be_nonzero
+      end
 
-              stdout, stderr = capture_io do
-                ValidateConfig.new.run
-              end
+      it "reports warnings but does not exit nonzero" do
+        write_cc_yaml(<<-EOYAML)
+        unknown_key:
+        - hey
+        - there
+        EOYAML
 
-              expect(stdout).to match("ERROR")
-            end
-          end
+        stdout, _stderr, code = capture_io_and_exit_code do
+          ValidateConfig.new.run
         end
 
-        describe "when there are warnings present" do
-          it "reports that a warning was found" do
-            within_temp_dir do
-              yaml_content = Factory.create_yaml_with_warning
-              File.open(".codeclimate.yml", "w") do |f|
-                f.write(yaml_content)
-              end
+        expect(stdout).to match("WARNING")
+        expect(code).to be_zero
+      end
 
-              stdout, stderr = capture_io do
-                ValidateConfig.new.run
-              end
+      it "reports warnings in nested keys" do
+        write_cc_yaml(<<-EOYAML)
+        engines:
+          rubocop:
+        EOYAML
 
-              expect(stdout).to match("WARNING:")
-            end
-          end
+        stdout, _stderr, code = capture_io_and_exit_code do
+          ValidateConfig.new.run
         end
 
-        describe "when there are nested warnings present" do
-          it "reports that a warning was found in the parent item" do
-            within_temp_dir do
-              yaml_content = Factory.create_yaml_with_nested_warning
-              File.write(".codeclimate.yml", yaml_content)
+        expect(stdout).to match("invalid \"engines\" section: invalid \"rubocop\" section: missing key \"enabled\"")
+        expect(code).to be_nonzero
+      end
 
-              stdout, stderr = capture_io do
-                ValidateConfig.new.run
-              end
+      it "reports errors and nested warnings together" do
+        write_cc_yaml(<<-EOYAML)
+        engines:
+          rubocop:
+            enabled: true
+          jshint:
+            not_enabled
+        strange_key:
+        EOYAML
 
-              expect(stdout).to match("ERROR: invalid \"engines\" section")
-            end
-          end
+        stdout, _stderr, code = capture_io_and_exit_code do
+          ValidateConfig.new.run
         end
 
-        describe "when there are both regular and nested warnings present" do
-          it "reports both kinds of warnings" do
-            within_temp_dir do
-              yaml_content = Factory.create_yaml_with_nested_and_unnested_warnings
-              File.write(".codeclimate.yml", yaml_content)
+        expect(stdout).to match("invalid \"engines\" section: invalid \"jshint\" section: unexpected scalar, missing key \"enabled\"")
+        expect(stdout).to match("unexpected key \"strange_key\", dropping")
+        expect(code).to be_nonzero
+      end
 
-              stdout, stderr = capture_io do
-                ValidateConfig.new.run
-              end
+      it "reports copy looks great for valid configs" do
+        write_cc_yaml(<<-EOYAML)
+        engines:
+          rubocop:
+            enabled: true
+        EOYAML
 
-              expect(stdout).to match("ERROR: invalid \"engines\" section")
-            end
-          end
+        stdout, _stderr, code = capture_io_and_exit_code do
+          ValidateConfig.new.run
         end
 
-        describe "when the present yaml is valid" do
-          it "reports copy looks great" do
-            within_temp_dir do
-              yaml_content = Factory.create_correct_yaml
-              File.write(".codeclimate.yml", yaml_content)
+        expect(stdout).to match(/no errors or warnings/i)
+        expect(code).to be_zero
+      end
 
-              stdout, stderr = capture_io do
-                ValidateConfig.new.run
-              end
+      it "warns of invalid engines or channels" do
+        write_cc_yaml(<<-EOYAML)
+        engines:
+          rubocop:
+            enabled: true
+          duplication:
+            enabled: true
+            channel: madeup
+          madeup:
+            enabled: true
+        EOYAML
 
-              expect(stdout).to match("No errors or warnings found in .codeclimate.yml file.")
-            end
-          end
+        stdout, _stderr, code = capture_io_and_exit_code do
+          ValidateConfig.new.run
         end
 
-        describe "when there are invalid engines" do
-          it "reports that those engines are invalid" do
-            within_temp_dir do
-              yaml_content = <<-YAML
-                engines:
-                  rubocop:
-                    enabled: true
-                  madeup:
-                    enabled: true
-                ratings:
-                  paths:
-                  - "**/*.rb"
-                  - "**/*.js"
-              YAML
-
-              File.write(".codeclimate.yml", yaml_content)
-
-              stdout, stderr = capture_io do
-                ValidateConfig.new.run
-              end
-
-              expect(stdout).to include("WARNING: unknown engine <madeup>")
-            end
-          end
-        end
+        expect(stdout).to include("unknown engine or channel <madeup:stable>")
+        expect(stdout).to include("unknown engine or channel <duplication:madeup>")
+        expect(code).to be_zero
       end
     end
 
-    def filesystem
-      @filesystem ||= CC::Analyzer::Filesystem.new(".")
-    end
-
-    def within_temp_dir(&block)
-      temp = Dir.mktmpdir
-
-      Dir.chdir(temp) do
-        yield
-      end
+    def write_cc_yaml(content)
+      File.write(".codeclimate.yml", content)
     end
   end
 end

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -33,53 +33,9 @@ module Factory
     }
   end
 
-  def create_yaml_with_errors
-    %{
-      engkxhfgkxfhg: sdoufhsfogh: -
-      0-
-      fgkjfhgkdjfg;h:;
-        sligj:
-      oi i ;
-    }
-  end
-
-  def create_yaml_with_warning
-    %{
-      engines:
-      unknown_key:
-    }
-  end
-
-  def create_yaml_with_nested_warning
-    %{
-      engines:
-        rubocop:
-    }
-  end
-
-  def create_yaml_with_nested_and_unnested_warnings
-    %{
-      engines:
-        rubocop:
-          enabled: true
-        jshint:
-          not_enabled
-      strange_key:
-    }
-  end
-
   def create_yaml_with_no_engines
     %{
       engines:
-    }
-  end
-
-  def create_classic_yaml
-    %{
-      languages:
-        Ruby: true
-      exclude_paths:
-        - excluded.rb
     }
   end
 


### PR DESCRIPTION
UX/UI:

- Exit non-zero if ERRORs are found, so this works as a fail-able Build step
- Don't color whole lines, makes them harder to read
- Don't color success messages, it was also hard to read
- Don't color WARNINGs red, I think this was a bug
- Filter validation issues that are expected in QM-land

Functionality:

- Allow injecting registry (undocumented) so we can run this "normally" via
  Builder instead of having to require and invoke classes ourselves (and fake
  our usual container logging, snapshot-events, etc, etc).

Implementation:

- Encapsulate through a class under CC::Config, so we have only a single place
  to change as we move from CC::Yaml to the new CC::Config-based logic to
  support Quality Model.