### PR TITLE
Config::Engine#config is the entire config

### DIFF
--- a/lib/cc/analyzer/bridge.rb
+++ b/lib/cc/analyzer/bridge.rb
@@ -62,14 +62,17 @@ module CC
       attr_reader :config, :formatter, :listener, :registry
 
       def run_engine(engine, engine_details)
+        # Analyzer::Engine doesn't have the best interface, but we're limiting
+        # our refactors for now.
         Engine.new(
           engine.name,
           {
             "image" => engine_details.image,
             "command" => engine_details.command,
           },
-          engine.to_config_json.merge(
-            include_paths: workspace.paths,
+          engine.config.merge(
+            "channel" => engine.channel,
+            "include_paths" => workspace.paths,
           ),
           engine.container_label,
         ).run(formatter)

--- a/lib/cc/config/default.rb
+++ b/lib/cc/config/default.rb
@@ -60,7 +60,9 @@ module CC
           enabled: true,
           channel: "cronopio",
           config: {
-            languages: %w[ruby],
+            config: {
+              languages: %w[ruby],
+            }
           },
         )
       end

--- a/lib/cc/config/engine.rb
+++ b/lib/cc/config/engine.rb
@@ -21,17 +21,6 @@ module CC
         @container_label ||= SecureRandom.uuid
       end
 
-      def to_config_json
-        if config.present?
-          {
-            "channel" => channel,
-            "config" => config,
-          }
-        else
-          { "channel" => channel }
-        end
-      end
-
       # Set interface methods. Assumes we never want to store the same engine by
       # name in the same list. This should be true except maybe if we want to
       # work with multiple channels at once, which is unlikely.

--- a/lib/cc/config/yaml.rb
+++ b/lib/cc/config/yaml.rb
@@ -61,13 +61,15 @@ module CC
         if [true, false].include?(data)
           Engine.new(name, enabled: data)
         else
-          config = convert_to_legacy_file_config(data.fetch("config", {}))
+          if data.key?("config")
+            data["config"] = convert_to_legacy_file_config(data["config"])
+          end
 
           Engine.new(
             name,
             enabled: data.fetch("enabled", true),
-            channel: data.fetch("channel", Engine::DEFAULT_CHANNEL),
-            config: config,
+            channel: data["channel"],
+            config: data
           )
         end
       end

--- a/spec/cc/config/engine_spec.rb
+++ b/spec/cc/config/engine_spec.rb
@@ -15,24 +15,16 @@ describe CC::Config::Engine do
       "duplication",
       enabled: true,
       channel: "beta",
-      config: { languages: %w[ruby] },
+      config: {
+        "config" => {
+          "languages" => %w[ruby]
+        },
+        "exclude_paths" => [""],
+      },
     )
 
     expect(engine).to be_enabled
     expect(engine.channel).to eq("beta")
-    expect(engine.config).to eq(languages: %w[ruby])
-  end
-
-  describe "#to_config_json" do
-    it "returns channel and configuration" do
-      engine = described_class.new(
-        "duplication",
-        channel: "beta",
-        config: { languages: %w[ruby] },
-      )
-
-      expect(engine.to_config_json.fetch("channel")).to eq("beta")
-      expect(engine.to_config_json.fetch("config")).to eq(languages: %w[ruby])
-    end
+    expect(engine.config["config"]["languages"]).to eq(%w[ruby])
   end
 end

--- a/spec/cc/config/yaml_spec.rb
+++ b/spec/cc/config/yaml_spec.rb
@@ -84,7 +84,7 @@ describe CC::Config::YAML do
       expect(rubocop).to be_present
       expect(rubocop).to be_enabled
       expect(rubocop.channel).to eq("beta")
-      expect(rubocop.config).to eq("yo" => "sup")
+      expect(rubocop.config["config"]).to eq("yo" => "sup")
     end
 
     it "re-writes as legacy file config values" do
@@ -98,7 +98,7 @@ describe CC::Config::YAML do
 
       rubocop = yaml.engines.detect { |e| e.name == "rubocop" }
       expect(rubocop).to be_present
-      expect(rubocop.config).to eq("foo.rb")
+      expect(rubocop.config["config"]).to eq("foo.rb")
     end
   end
 


### PR DESCRIPTION
Working with config.config was confusing, but there is good reason: we always
want to read and store config.checks, config.exclude_fingerprints, etc. Putting
the whole Hash as-is into the Config::Engine object is overall simpler.

Note: this is safe because of our existing assumption that this code works on
pre-validated configuration.