### PR TITLE
Minor QM fixes

### DIFF
--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -7,12 +7,11 @@ require "cc/config/yaml/validator"
 module CC
   module Config
     def self.load
-      @config ||=
-        if File.exist?(YAML::DEFAULT_PATH)
-          YAML.new
-        else
-          Default.new
-        end
+      if File.exist?(YAML::DEFAULT_PATH)
+        YAML.new
+      else
+        Default.new
+      end
     end
   end
 end

--- a/lib/cc/config/default.rb
+++ b/lib/cc/config/default.rb
@@ -18,12 +18,9 @@ module CC
       attr_writer :development
 
       def initialize
-        load_defaults
-      end
-
-      def reload
-        load_defaults
-        self
+        @development = false
+        @engines = Set.new([structure_engine, duplication_engine])
+        @exclude_patterns = EXCLUDE_PATTERNS
       end
 
       def prepare
@@ -39,12 +36,6 @@ module CC
       end
 
       private
-
-      def load_defaults
-        @development = false
-        @engines = Set.new([structure_engine, duplication_engine])
-        @exclude_patterns = EXCLUDE_PATTERNS
-      end
 
       def structure_engine
         Engine.new(

--- a/lib/cc/config/yaml.rb
+++ b/lib/cc/config/yaml.rb
@@ -21,17 +21,6 @@ module CC
         upconvert_legacy_yaml!
       end
 
-      def reload
-        # We don't expect or support the YAML itself to have changed on disk,
-        # otherwise users who are calling reload would have to also re-validate
-        # to avoid problems using the result. This just resets the state
-        # determined from the YAML.
-        default.reload
-        @engines = nil
-        @exclude_patterns = nil
-        self
-      end
-
       def engines
         @engines ||= default.engines | Set.new(plugin_engines)
       end

--- a/spec/cc/config/yaml_spec.rb
+++ b/spec/cc/config/yaml_spec.rb
@@ -16,23 +16,6 @@ describe CC::Config::YAML do
     end
   end
 
-  describe "#reload" do
-    it "re-reads and resets" do
-      yaml = load_cc_yaml(<<-EOYAML)
-      plugins:
-        rubocop: true
-        eslint: true
-      EOYAML
-      expect(yaml.engines.length).to eq(4)
-
-      yaml.engines.replace(yaml.engines.take(2))
-      expect(yaml.engines.length).to eq(2)
-
-      yaml.reload
-      expect(yaml.engines.length).to eq(4)
-    end
-  end
-
   describe "#engines" do
     it "includes default engines" do
       yaml = load_cc_yaml("")


### PR DESCRIPTION
- Remove #reload methods on Config objects

  Thought this would be needed, it was not. Classic YAGNI.

- Don't memoize in CC::Config#load

  This isn't useful and can sometimes leak state across tests.