### PR TITLE
Add an option to analyze a file from STDIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ The following is a brief explanation of each available command.
   `exclude_paths`. When you do provide an explicit path to analyze, your
   configured `exclude_paths` are ignored, and normally excluded files will be
   analyzed.
+
+  You can also pipe in source in combination with a path to analyze code that is
+  not yet written to disk. This is useful when you want to check if your source
+  code style matches the project's. This is also a good way to implement
+  integration with an editor to check style on the fly.
 * `console`
   start an interactive session providing access to the classes
   within the CLI. Useful for engine developers and maintainers.

--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -28,29 +28,79 @@ invalid_docker_host() {
   invalid_setup "invalid DOCKER_HOST=$host, must be unset or unix:///var/run/docker.sock"
 }
 
-if [ -n "$DOCKER_MACHINE_NAME" ] && command -v docker-machine > /dev/null 2>&1; then
-  docker-machine ssh $DOCKER_MACHINE_NAME -- \
-    test -S /var/run/docker.sock > /dev/null 2>&1 || socket_missing
+analysis_file() {
+  local file_name="";
+  local help_mode=0;
+  local analyze_mode=0;
+  local skip=0;
+  for arg; do
+    echo "! $arg" >&2
+    if [ $skip -gt 0 ]; then
+      skip=$(( $skip - 1 ))
+    else
+      case "$arg" in
+        help)
+          help_mode=1
+          ;;
+        analyze)
+          if [ "$help_mode" -eq 0 ]; then
+            analyze_mode=1;
+          fi
+          ;;
+        -*)
+          if [ $analyze_mode -ne 0 ]; then
+            case $arg in
+              -e | -f | --format)
+                skip=1
+                ;;
+            esac
+          fi
+          ;; # We don't care about flags
+        *)
+          if [ $analyze_mode -ne 0 ]; then
+            if [ -n "$file_name" ]; then
+              printf "Please supply only one file for analysis\n" >&2
+              exit 1
+            else
+              file_name="$arg"
+            fi
+          fi
+          ;;
+      esac
+    fi
+  done
+  if [ -n "$file_name" ]; then
+    printf "%s" "$file_name"
+  else
+    printf "Please supply a file name for analysis\n" >&2
+    exit 1
+  fi
+}
 
-  docker-machine ssh $DOCKER_MACHINE_NAME -- \
-    'test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock"' > /dev/null 2>&1 \
-    && invalid_docker_host $(docker-machine ssh $DOCKER_MACHINE_NAME -- 'echo "$DOCKER_HOST"')
-else
-  test -S /var/run/docker.sock || socket_missing
-  test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock" \
-    && invalid_docker_host "$DOCKER_HOST"
-fi
+ln_dir() {
+  local path="$1"
+  if [ -z "$path" ] || [ "$path" = "." ] ; then
+    return
+  fi
 
-: ${XDG_CONFIG_HOME:=$HOME/.config/}
-CC_CONFIG="${CODECLIMATE_CONFIG:-$XDG_CONFIG_HOME/codeclimate/config.yml}"
+  local source_base="$2"
+  local dest_base="$3"
 
-: ${XDG_CACHE_HOME:=$HOME/.cache/}
-CC_CACHE="${CODECLIMATE_CACHE:-$XDG_CACHE_HOME/codeclimate/cache.yml}"
+  local path_dir=$(dirname "$path")
+  mkdir -p "$dest_base"/"$path_dir"
 
-for f in "$CC_CONFIG" "$CC_CACHE"; do
-  mkdir -p "$(dirname "$f")"
-  touch "$f"
-done
+  if [ "$path_dir" = "." ]; then
+    path_dir=""
+  else
+    path_dir="/$path_dir"
+  fi
+
+  find "$source_base$path_dir" -depth 1 -type f -iname "*" | while read f; do
+    ln "$f" "$dest_base$path_dir/$(basename "$f")"
+  done
+
+  ln_dir "$(dirname "$path_dir")" "$source_base" "$dest_base"
+}
 
 docker_run() {
   exec docker run \
@@ -70,12 +120,56 @@ docker_run() {
     "$@"
 }
 
+: ${XDG_CONFIG_HOME:=$HOME/.config}
+CC_CONFIG="${CODECLIMATE_CONFIG:-$XDG_CONFIG_HOME/codeclimate/config.yml}"
+
+: ${XDG_CACHE_HOME:=$HOME/.cache}
+CC_CACHE="${CODECLIMATE_CACHE:-$XDG_CACHE_HOME/codeclimate/cache.yml}"
+
+for f in "$CC_CONFIG" "$CC_CACHE"; do
+  mkdir -p "$(dirname "$f")"
+  touch "$f"
+done
+
 if [ -z "$CODECLIMATE_CODE" ]; then
   export CODECLIMATE_CODE=$PWD
 fi
 
 if [ -z "$CODECLIMATE_TMP" ]; then
   export CODECLIMATE_TMP=/tmp/cc
+fi
+
+if [ ! -t 0 ]; then
+  tmp_source_dir=$(mktemp -d "$(dirname $CC_CACHE)/cc-code.XXXXXX")
+  trap "rm -rf '$tmp_source_dir'" EXIT
+
+  chmod a+rx "$tmp_source_dir"
+
+  focus_path=$(analysis_file "$@") || exit 1
+  source_file="$tmp_source_dir/$focus_path"
+
+  mkdir -p "$(dirname "$source_file")"
+  cat <&0 >"$source_file"
+
+  if [ -n "$(cat "$source_file")" ]; then
+    echo ln_dir "$focus_path" "$CODECLIMATE_CODE" "$tmp_source_dir"
+    ln_dir "$focus_path" "$CODECLIMATE_CODE" "$tmp_source_dir"
+  fi
+
+  export CODECLIMATE_CODE="$tmp_source_dir"
+fi
+
+if [ -n "$DOCKER_MACHINE_NAME" ] && command -v docker-machine > /dev/null 2>&1; then
+  docker-machine ssh $DOCKER_MACHINE_NAME -- \
+    test -S /var/run/docker.sock > /dev/null 2>&1 || socket_missing
+
+  docker-machine ssh $DOCKER_MACHINE_NAME -- \
+    'test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock"' > /dev/null 2>&1 \
+    && invalid_docker_host $(docker-machine ssh $DOCKER_MACHINE_NAME -- 'echo "$DOCKER_HOST"')
+else
+  test -S /var/run/docker.sock || socket_missing
+  test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock" \
+    && invalid_docker_host "$DOCKER_HOST"
 fi
 
 if [ -t 0 ] && [ -t 1 ]; then


### PR DESCRIPTION
The invocation is simple:
```shell
echo "randome code" | codeclimate analyze lib/useful.rb
```
Key parts:
* This works only with `analyze` subcommand
* A filename must be specified. This is to properly chose engines, apply inclusion/exclusion rules, and let engines pick up the right configs. Only one filename must be specified.
* Pipe source to the commands STDIN.