### PR TITLE
Update macOS recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ analyses are also Docker images. To support this, you must have Docker installed
 and running locally. We also require that the Docker daemon supports connections
 on the default Unix socket `/var/run/docker.sock`.
 
-On OS X, we recommend using [Docker Machine](https://docs.docker.com/machine/).
+On macOS, we recommend using [Docker for Mac](https://docs.docker.com/docker-for-mac/).
 
 ## Installation
 


### PR DESCRIPTION
Since Docker for Mac stabilized, we've switched over internally, and
it's worked well. Let's recommend that externally as well.