### PR TITLE
Ensure Module#remove_method is defined

### DIFF
--- a/lib/cc/cli.rb
+++ b/lib/cc/cli.rb
@@ -1,4 +1,5 @@
 require "active_support"
+require "active_support/core_ext/module/remove_method"
 require "active_support/core_ext"
 require "yaml"
 require "cc/analyzer"

--- a/lib/cc/cli.rb
+++ b/lib/cc/cli.rb
@@ -1,5 +1,5 @@
 require "active_support"
-require "active_support/core_ext/module/remove_method"
+require "active_support/core_ext/module/remove_method" # Temporary, see https://github.com/codeclimate/codeclimate/pull/658
 require "active_support/core_ext"
 require "yaml"
 require "cc/analyzer"


### PR DESCRIPTION
I accidentally updated activesupport in my last CLI release:
https://github.com/codeclimate/codeclimate/pull/657

And this version has a bug. Context:
https://github.com/rails/rails/issues/28918#issuecomment-298084204

This change patches over the bug. I could also downgrade activesupport,
but I think it's likely to happen again via our `bin/prep-release`
script, so this feels more stable to me.