### PR TITLE
Add support for .codeclimate.json config

### DIFF
--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -1,3 +1,4 @@
+require "cc/config/json"
 require "cc/config/default"
 require "cc/config/engine"
 require "cc/config/prepare"

--- a/lib/cc/config/default.rb
+++ b/lib/cc/config/default.rb
@@ -42,6 +42,11 @@ module CC
           "complexity-ruby",
           enabled: true,
           channel: "beta",
+          config: {
+            "config" => {
+              "checks" => json.checks,
+            },
+          },
         )
       end
 
@@ -53,9 +58,14 @@ module CC
           config: {
             "config" => {
               "languages" => %w[ruby],
-            }
+              "checks" => json.checks,
+            },
           },
         )
+      end
+
+      def json
+        @json ||= JSON.new
       end
     end
   end

--- a/lib/cc/config/json.rb
+++ b/lib/cc/config/json.rb
@@ -1,0 +1,27 @@
+module CC
+  module Config
+    class JSON
+      DEFAULT_PATH = ".codeclimate.json".freeze
+
+      def initialize(path = DEFAULT_PATH)
+        @path = path
+      end
+
+      def checks
+        @checks ||= json.fetch("checks", {})
+      end
+
+      private
+
+      attr_reader :path
+
+      def json
+        @json ||= {}.tap do |j|
+          if File.exist?(path)
+            j.merge!(::JSON.parse(File.read(path)))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/config/default_spec.rb
+++ b/spec/cc/config/default_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe CC::Config::Default do
+  describe "#engines" do
+    it "returns hash in checks key" do
+      write_cc_json(<<-EOS)
+      {
+        "checks": {
+          "ruby-cyclomatic-complexity": {
+            "enabled": true,
+            "config": {
+              "threshold": 20
+            }
+          }
+        }
+      }
+      EOS
+
+      config = described_class.new
+
+      expect(config.engines.count).to eq(2)
+
+      expect(config.engines.any? { |engine| engine.name == "complexity-ruby" }).to eq(true)
+      expect(config.engines.any? { |engine| engine.name == "duplication" }).to eq(true)
+
+      config.engines.each do |engine|
+        expect(engine.config["config"]["checks"]).to eq(
+          "ruby-cyclomatic-complexity" => {
+            "enabled" => true,
+            "config" => {
+              "threshold" => 20,
+            },
+          },
+        )
+      end
+    end
+  end
+
+  def write_cc_json(json)
+    Tempfile.open("") do |tmp|
+      tmp.puts(json)
+      tmp.rewind
+
+      stub_const("CC::Config::JSON::DEFAULT_PATH", tmp.path)
+    end
+  end
+end

--- a/spec/cc/config/json_spec.rb
+++ b/spec/cc/config/json_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe CC::Config::JSON do
+  describe "#exclude" do
+    it "returns hash in checks key" do
+      json = load_cc_json(<<-EOS)
+      {
+        "checks": {
+          "ruby-cyclomatic-complexity": {
+            "enabled": true,
+            "config": {
+              "threshold": 20
+            }
+          }
+        }
+      }
+      EOS
+
+      expect(json.checks).to eq(
+        "ruby-cyclomatic-complexity" => {
+          "enabled" => true,
+          "config" => {
+            "threshold" => 20,
+          },
+        },
+      )
+    end
+
+    it "returns empty hash if checks key doesn't exist" do
+      json = load_cc_json(<<-EOS)
+      {
+        "foo": "bar"
+      }
+      EOS
+
+      expect(json.checks).to eq({})
+    end
+
+    it "returns empty hash if file doesn't exist" do
+      json = described_class.new("missing.json")
+      expect(json.checks).to eq({})
+    end
+  end
+
+  def load_cc_json(json)
+    Tempfile.open("") do |tmp|
+      tmp.puts(json)
+      tmp.rewind
+
+      described_class.new(tmp.path)
+    end
+  end
+end


### PR DESCRIPTION
This also passes the "checks" key from the JSON config to default
engines (complexity-ruby and duplication).