### PR TITLE
Bundle if necessary in bin/release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -15,6 +15,7 @@ git pull
 version=$(< VERSION)
 
 printf "RELEASE %s\n" "$version"
+bundle check || bundle install
 rake release
 
 docker build --rm -t codeclimate/codeclimate .


### PR DESCRIPTION
I recently installed ruby 2.4.1 and hadn't yet installed everything I
need to run this, and it led to a kind of awkward LoadError. This should
make it automatically bundle install when necessary.