### PR TITLE
Partial scan support

### DIFF
--- a/lib/cc/analyzer/engines_config_builder.rb
+++ b/lib/cc/analyzer/engines_config_builder.rb
@@ -24,16 +24,17 @@ module CC
         :container_label,
       )
 
-      def initialize(registry:, config:, container_label:, source_dir:, requested_paths:)
+      def initialize(registry:, config:, container_label:, source_dir:, requested_paths:, partial:)
         @registry = RegistryAdapter.new(registry)
         @config = config
         @container_label = container_label
-        @requested_paths = requested_paths
+        @requested_paths = Array(requested_paths)
         @source_dir = source_dir
+        @partial = partial
       end
 
       def run
-        names_and_raw_engine_configs.map do |name, raw_engine_config|
+        enabled_engine_configs.map do |name, raw_engine_config|
           label = @container_label || SecureRandom.uuid
           engine_config = engine_config(raw_engine_config)
           engine_metadata = @registry.fetch(name, raw_engine_config.channel)
@@ -55,7 +56,7 @@ module CC
       end
 
       def engine_workspace(raw_engine_config)
-        if raw_engine_config.key?("exclude_paths") && !@requested_paths.present?
+        if apply_excludes? && raw_engine_config.key?("exclude_paths")
           base_workspace.clone.tap do |workspace|
             workspace.remove(raw_engine_config["exclude_paths"])
           end
@@ -64,24 +65,25 @@ module CC
         end
       end
 
-      def names_and_raw_engine_configs
-        {}.tap do |ret|
-          (@config.engines || {}).each do |name, raw_engine_config|
-            if raw_engine_config.enabled? && @registry.key?(name)
-              ret[name] = raw_engine_config
-            end
-          end
+      def enabled_engine_configs
+        Hash(@config.engines).select do |name, raw_engine_config|
+          raw_engine_config.enabled? && @registry.key?(name)
         end
       end
 
       def base_workspace
         @base_workspace ||= Workspace.new.tap do |workspace|
           workspace.add(@requested_paths)
-          unless @requested_paths.present?
+
+          if apply_excludes?
             workspace.remove([".git"])
             workspace.remove(@config.exclude_paths)
           end
         end
+      end
+
+      def apply_excludes?
+        @partial || @requested_paths.empty?
       end
 
       # The yaml gem turns a config file string into a hash, but engines expect

--- a/lib/cc/analyzer/engines_runner.rb
+++ b/lib/cc/analyzer/engines_runner.rb
@@ -5,13 +5,14 @@ module CC
     class EnginesRunner
       NoEnabledEngines = Class.new(StandardError)
 
-      def initialize(registry, formatter, source_dir, config, requested_paths = [], container_label = nil)
+      def initialize(registry, formatter, source_dir, config, requested_paths = [], container_label = nil, partial = false)
         @registry = registry
         @formatter = formatter
         @source_dir = source_dir
         @config = config
         @requested_paths = requested_paths
         @container_label = container_label
+        @partial = partial
       end
 
       def run(container_listener = ContainerListener.new)
@@ -28,7 +29,7 @@ module CC
 
       private
 
-      attr_reader :requested_paths
+      attr_reader :partial, :requested_paths
 
       def build_engine(built_config)
         Engine.new(
@@ -47,6 +48,7 @@ module CC
           container_label: @container_label,
           source_dir: @source_dir,
           requested_paths: requested_paths,
+          partial: partial,
         ).run
       end
 

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -7,6 +7,7 @@ module CC
       SHORT_HELP = "Run analysis with the given arguments".freeze
       HELP = "#{SHORT_HELP}\n" \
         "\n" \
+        "    -p, --partial                    Perform partial analysis." \
         "    -f <format>, --format <format>   Format of output. Possible values: #{CC::Analyzer::Formatters::FORMATTERS.keys.join ", "}\n" \
         "    -e <engine[:channel]>            Engine to run. Can be specified multiple times.\n" \
         "    --dev                            Run in development mode. Engines installed locally that are not in the manifest will be run.\n" \
@@ -18,6 +19,7 @@ module CC
         super
         @engine_options = []
         @path_options = []
+        @partial = false
 
         process_args
         apply_config_options
@@ -27,7 +29,7 @@ module CC
         require_codeclimate_yml
 
         Dir.chdir(MountedPath.code.container_path) do
-          runner = EnginesRunner.new(registry, formatter, source_dir, config, path_options)
+          runner = EnginesRunner.new(registry, formatter, source_dir, config, path_options, nil, partial)
           runner.run
         end
       rescue EnginesRunner::NoEnabledEngines
@@ -37,7 +39,7 @@ module CC
       private
 
       attr_accessor :config
-      attr_reader :engine_options, :path_options
+      attr_reader :engine_options, :path_options, :partial
 
       def process_args
         while (arg = @args.shift)
@@ -48,6 +50,8 @@ module CC
             @engine_options << @args.shift
           when "--dev"
             @dev_mode = true
+          when "-p", "--partial"
+            @partial = true
           else
             @path_options << arg
           end

--- a/lib/cc/workspace.rb
+++ b/lib/cc/workspace.rb
@@ -16,9 +16,7 @@ module CC
     end
 
     def add(paths)
-      if paths.present?
-        path_tree.include_paths(paths)
-      end
+      path_tree.include_paths(Array(paths))
     end
 
     def remove(patterns)

--- a/spec/cc/analyzer/engines_runner_spec.rb
+++ b/spec/cc/analyzer/engines_runner_spec.rb
@@ -29,6 +29,39 @@ module CC::Analyzer
       expect { runner.run }.to raise_error(EnginesRunner::NoEnabledEngines)
     end
 
+    describe "partial flag" do
+      let(:config) { config_with_engine("steam") }
+      let(:registry) { registry_with_engine("steam") }
+      let(:whatever) { [anything] * 6 }
+      let(:engine_config) do
+        double(
+          name: "Steam",
+          registry_entry: {},
+          code_path: "/code",
+          config: {},
+          container_label: nil
+        )
+      end
+
+      [true, false].each do |flag|
+        it "passes partial flag to engine config builder: #{flag.inspect}" do
+          allow(Engine).to receive(:new).and_return(double name: "Steam", run: nil)
+          allow(EnginesConfigBuilder).to receive(:new).and_return(double run: [engine_config])
+
+          EnginesRunner.new(registry, null_formatter, "/code", config, [], nil, flag).run
+
+          expect(EnginesConfigBuilder).to have_received(:new).with(
+            registry: anything,
+            config: anything,
+            container_label: anything,
+            source_dir: anything,
+            requested_paths: anything,
+            partial: flag,
+          )
+        end
+      end
+    end
+
     describe "when the formatter does not respond to #close" do
       let(:config) { config_with_engine("an_engine") }
       let(:formatter) do

--- a/spec/cc/cli/analyze_spec.rb
+++ b/spec/cc/cli/analyze_spec.rb
@@ -98,7 +98,75 @@ module CC::CLI
             analyze = Analyze.new(args)
             engines_runner = double(run: "peace")
 
-            expect(CC::Analyzer::EnginesRunner).to receive(:new).with(anything, anything, anything, anything, paths).and_return(engines_runner)
+            expect(CC::Analyzer::EnginesRunner).to receive(:new).with(anything, anything, anything, anything, paths, anything, anything).and_return(engines_runner)
+
+            analyze.run
+          end
+        end
+      end
+
+      describe "partial scan flag" do
+        it "is off by default" do
+          within_temp_dir do
+            create_yaml(<<-EOYAML)
+              engines:
+                rubocop:
+                  enabled: true
+                eslint:
+                  enabled: true
+            EOYAML
+
+            args = []
+
+            analyze = Analyze.new(args)
+            engines_runner = double(run: "peace")
+            other_args = [anything] * 6
+
+            expect(CC::Analyzer::EnginesRunner).to receive(:new).with(*other_args, false).and_return(engines_runner)
+
+            analyze.run
+          end
+        end
+
+        it "passes the flag provided" do
+          within_temp_dir do
+            create_yaml(<<-EOYAML)
+              engines:
+                rubocop:
+                  enabled: true
+                eslint:
+                  enabled: true
+            EOYAML
+
+            args = ["-p", "foo.rb"]
+
+            analyze = Analyze.new(args)
+            engines_runner = double(run: "peace")
+            other_args = [anything] * 6
+
+            expect(CC::Analyzer::EnginesRunner).to receive(:new).with(*other_args, true).and_return(engines_runner)
+
+            analyze.run
+          end
+        end
+
+        it "passes the flag provided (long form)" do
+          within_temp_dir do
+            create_yaml(<<-EOYAML)
+              engines:
+                rubocop:
+                  enabled: true
+                eslint:
+                  enabled: true
+            EOYAML
+
+            args = ["--partial", "foo.rb"]
+
+            analyze = Analyze.new(args)
+            engines_runner = double(run: "peace")
+            other_args = [anything] * 6
+
+            expect(CC::Analyzer::EnginesRunner).to receive(:new).with(*other_args, true).and_return(engines_runner)
 
             analyze.run
           end

--- a/spec/cc/workspace/path_tree_spec.rb
+++ b/spec/cc/workspace/path_tree_spec.rb
@@ -66,6 +66,29 @@ class CC::Workspace
       end
     end
 
+    it "excludes directory after including its children" do
+      within_temp_dir do
+        make_fixture_tree
+
+        tree = PathTree.for_path(".")
+        tree.include_paths(["code/a/bar.rb"])
+        tree.exclude_paths(["code/a/"])
+        expect(tree.all_paths.sort).to eq []
+      end
+    end
+
+    it "doesn't repopulate nodes after removal" do
+      within_temp_dir do
+        make_fixture_tree
+
+        tree = PathTree.for_path(".")
+        tree.include_paths(["code/a/bar.rb"])
+        tree.exclude_paths(["code/"])
+        tree.exclude_paths([".git/"])
+        expect(tree.all_paths.sort).to eq []
+      end
+    end
+
     it "handles including nonexistent files" do
       within_temp_dir do
         make_fixture_tree


### PR DESCRIPTION
Notable changes:

* Workspace doesn't assume we include all files by default. Now we have to explicitly do that.
* Fixed a bug when removing all files in a directory it became fully included.
* Simplified inclusion/exclusion state tracking. Main features:

  * It's about as performant as the old one
  * It may consume a bit more memory on big code bases
  * It prevents project root escape
  * It may produce a more compact resulting path set

* Added a partial scan mode

### Partial Scan mode

This is a new way to construct a workspace for analysis. It's similar to target file mode when one can specify files for analysis except it takes into account `exclude_paths`.

This is useful in particular for editor integration where one would want to get edited files automatically analyzed but not get reports for excluded files. The results of a partial scan are always a subset of a full scan.