### PR TITLE
Add ? to supported Exclusion glob symbols

### DIFF
--- a/lib/cc/workspace/exclusion.rb
+++ b/lib/cc/workspace/exclusion.rb
@@ -15,7 +15,7 @@ module CC
       end
 
       def glob?
-        pattern.include?("*")
+        !(pattern =~ /[*?]/).nil?
       end
 
       def negated?

--- a/spec/cc/workspace/exclusion_spec.rb
+++ b/spec/cc/workspace/exclusion_spec.rb
@@ -14,5 +14,21 @@ class CC::Workspace
       exclusion = Exclusion.new("!foo")
       expect(exclusion.expand).to eq(["foo"])
     end
+
+    describe "#glob?" do
+      it "is not a glob when no glob chars are present in the pattern" do
+        exclusion = Exclusion.new("foo")
+
+        expect(exclusion).to_not be_glob
+      end
+
+      %w[* ?].each do |glob_char|
+        it "is a glob when #{glob_char} is present in the pattern" do
+          exclusion = Exclusion.new("foo#{glob_char}")
+
+          expect(exclusion).to be_glob
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This gets us to `*` and `?` but still leaves out `[a-z]`, `{a,b}`, and `\` (escapes).

Maybe it'd be easier and more robust to always glob even when there are no special characters?