### PR TITLE
Run codeclimate-structure:latest

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -19,15 +19,6 @@ bundler-audit:
   channels:
     stable: codeclimate/codeclimate-bundler-audit
   description: Patch-level verification for Bundler.
-checks:
-  channels:
-    beta: codeclimate/codeclimate-checks:beta
-  description: Maintainability and reliability checks for PHP, Python, JS, and more.
-  default_config:
-    languages:
-      - javascript
-      - python
-      - php
 checkstyle:
   channels:
     beta: codeclimate/codeclimate-checkstyle:beta

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -196,8 +196,8 @@ shellcheck:
   description: A static analysis tool for shell scripts.
 structure:
   channels:
-    stable: codeclimate/codeclimate-structure:b242
-    beta: codeclimate/codeclimate-structure:b240
+    beta: codeclimate/codeclimate-structure:beta
+    stable: codeclimate/codeclimate-structure
   description: Performs structural checks on code.
   default_config:
     languages:


### PR DESCRIPTION
Like any other engine, the CLI just runs :latest. I'm not sure why this
would've been pinned to a build.