### PR TITLE
Pass DEBUG onto engines

### DIFF
--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -95,6 +95,7 @@ module CC
       end
 
       def write_config_file
+        @config["debug"] = ENV["CODECLIMATE_DEBUG"]
         Analyzer.logger.debug "/config.json content: #{@config.inspect}"
         config_file.write(@config.to_json)
       end


### PR DESCRIPTION
If an engine respects a top-level `debug` key in `/config.json`, it will
receive it's value from `CODECLIMATE_DEBUG`. The boolean-ness is the same as
how it's used in this codebase: any value is considered true, even `0` or
`"false"`.