### PR TITLE
Add issue overrides

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     codeclimate (0.64.0)
       activesupport (>= 4.2.1, < 5.1)
-      codeclimate-yaml (~> 0.12.0)
+      codeclimate-yaml (~> 0.13.0)
       highline (~> 1.7, >= 1.7.2)
       posix-spawn (~> 0.3, >= 0.3.11)
       pry (~> 0.10.1)
@@ -24,7 +24,7 @@ GEM
     builder (3.2.3)
     codeclimate-test-reporter (1.0.6)
       simplecov
-    codeclimate-yaml (0.12.0)
+    codeclimate-yaml (0.13.0)
       activesupport
       secure_string
     coderay (1.1.1)
@@ -89,3 +89,6 @@ DEPENDENCIES
   rspec
   rspec_junit_formatter
   simplecov
+
+BUNDLED WITH
+   1.14.3

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", ">= 4.2.1", "< 5.1"
   s.add_dependency "tty-spinner", "~> 0.1.0"
-  s.add_dependency "codeclimate-yaml", "~> 0.12.0"
+  s.add_dependency "codeclimate-yaml", "~> 0.13.0"
   s.add_dependency "highline", "~> 1.7", ">= 1.7.2"
   s.add_dependency "posix-spawn", "~> 0.3", ">= 0.3.11"
   s.add_dependency "pry", "~> 0.10.1"

--- a/lib/cc/analyzer.rb
+++ b/lib/cc/analyzer.rb
@@ -9,6 +9,7 @@ module CC
     autoload :Engine, "cc/analyzer/engine"
     autoload :EngineOutput, "cc/analyzer/engine_output"
     autoload :EngineOutputFilter, "cc/analyzer/engine_output_filter"
+    autoload :EngineOutputOverrider, "cc/analyzer/engine_output_overrider"
     autoload :EngineRegistry, "cc/analyzer/engine_registry"
     autoload :EnginesConfigBuilder, "cc/analyzer/engines_config_builder"
     autoload :EnginesRunner, "cc/analyzer/engines_runner"

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -43,7 +43,7 @@ module CC
           end
 
           unless output_filter.filter?(output)
-            stdout_io.write(output.to_json) || container.stop
+            stdout_io.write(output_overrider.apply(output).to_json) || container.stop
           end
         end
 
@@ -99,6 +99,10 @@ module CC
 
       def output_filter
         @output_filter ||= EngineOutputFilter.new(@config)
+      end
+
+      def output_overrider
+        @output_overrider ||= EngineOutputOverrider.new(@config)
       end
 
       # Memory limit for a running engine in bytes

--- a/lib/cc/analyzer/engine_output_overrider.rb
+++ b/lib/cc/analyzer/engine_output_overrider.rb
@@ -1,0 +1,31 @@
+module CC
+  module Analyzer
+    class EngineOutputOverrider
+      def initialize(config = {})
+        @config = config
+      end
+
+      def apply(output)
+        if output.issue?
+          override_severity(output.as_issue.as_json)
+        else
+          output
+        end
+      end
+
+      private
+
+      attr_reader :config
+
+      def override_severity(issue)
+        issue.merge(override("severity"))
+      end
+
+      def override(name)
+        config.
+          fetch("issue_override", {}).
+          slice(name)
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engine_output_overrider_spec.rb
+++ b/spec/cc/analyzer/engine_output_overrider_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+module CC
+  module Analyzer
+    describe EngineOutputOverrider do
+      it "does not modify arbitrary json" do
+        output = EngineOutput.new(%({"arbitrary":"json"}))
+        expect(subject.apply(output)).to eq output
+      end
+
+      it "overrides issue severity" do
+        issue = build_issue("severity" => "major")
+
+        overrider = described_class.new(
+          engine_config(
+            "issue_override" => {
+              "severity" => "info",
+            },
+          ),
+        )
+
+        expect(overrider.apply(issue)["severity"]).to eq "info"
+      end
+
+      def build_issue(attributes)
+        EngineOutput.new({
+          "type" => EngineOutputFilter::ISSUE_TYPE,
+          "check_name" => "rubocop",
+          "location" => {
+            "path" => "spec/fixtures/source.rb",
+            "lines" => { "begin" => 13, "end" => 14 },
+          },
+        }.merge(attributes).to_json)
+      end
+
+      def engine_config(hash)
+        codeclimate_yaml = {
+          "engines" => {
+            "rubocop" => hash.merge("enabled" => true),
+          },
+        }.to_yaml
+
+        CC::Yaml.parse(codeclimate_yaml).engines["rubocop"]
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -105,6 +105,25 @@ module CC::Analyzer
           expect(stdout.string).not_to include %{"check":"bar"}
         end
       end
+
+      it "applies overrides" do
+        within_temp_dir do
+          make_file("foo.rb")
+
+          container = TestContainer.new([
+            %{{"type":"issue","check_name":"foo","location":{"path":"foo.rb","lines":{"begin":1,"end":1}},"description":"foo","categories":["Style"],"severity":"minor"}},
+          ])
+          expect(Container).to receive(:new).and_return(container)
+
+          stdout = StringIO.new
+          config = { "issue_override" => { "severity" => "info" } }
+          engine = Engine.new("", {}, "", config, "")
+          engine.run(stdout, ContainerListener.new)
+
+          expect(stdout.string).not_to include %{"severity":"minor"}
+          expect(stdout.string).to include %{"severity":"info"}
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Issue override is a way to modify engine output. At the moment there's only one override: severity. It can be any of the values specified in [the spec](https://github.com/codeclimate/spec/blob/master/SPEC.md#issues).

Depends on codeclimate/codeclimate-yaml#41