### PR TITLE
Support disabling plugins when analyzing

### DIFF
--- a/lib/cc/analyzer/bridge.rb
+++ b/lib/cc/analyzer/bridge.rb
@@ -29,8 +29,10 @@ module CC
       end
 
       def run
-        plugins = Plugins.new
-        plugins.auto_enable_engines(config)
+        if config.auto_enable_plugins?
+          plugins = Plugins.new
+          plugins.auto_enable_engines(config)
+        end
 
         formatter.started
 

--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -59,6 +59,8 @@ module CC
             )
           when "--dev"
             config.development = true
+          when "--no-plugins"
+            config.disable_plugins!
           else
             config.analysis_paths << arg
           end

--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -26,6 +26,7 @@ module CC
 
     def initialize(analysis_paths: [], development: false, engines: Set.new, exclude_patterns: [], prepare: Prepare.new)
       @analysis_paths = analysis_paths
+      @auto_enable_plugins = true
       @development = development
       @engines = engines
       @exclude_patterns = exclude_patterns
@@ -38,6 +39,15 @@ module CC
 
     def development?
       @development
+    end
+
+    def auto_enable_plugins?
+      @auto_enable_plugins
+    end
+
+    def disable_plugins!
+      @auto_enable_plugins = false
+      @engines.delete_if(&:plugin?)
     end
   end
 end

--- a/lib/cc/config/default.rb
+++ b/lib/cc/config/default.rb
@@ -1,6 +1,7 @@
 module CC
   class Config
     class Default < Config
+      ENGINE_NAMES = %w[duplication structure]
       EXCLUDE_PATTERNS = %w[
         config/
         db/

--- a/lib/cc/config/engine.rb
+++ b/lib/cc/config/engine.rb
@@ -17,6 +17,10 @@ module CC
         @enabled
       end
 
+      def plugin?
+        !Default::ENGINE_NAMES.include?(name)
+      end
+
       def container_label
         @container_label ||= SecureRandom.uuid
       end

--- a/spec/cc/config/engine_spec.rb
+++ b/spec/cc/config/engine_spec.rb
@@ -34,4 +34,17 @@ describe CC::Config::Engine do
       expect { engine1.merge(described_class.new("bar")) }.to raise_error(ArgumentError, /Engine names must match to merge/)
     end
   end
+
+  describe "#plugin?" do
+    it "returns true for plugin engines" do
+      expect(described_class.new("eslint")).to be_plugin
+      expect(described_class.new("rubocop")).to be_plugin
+      expect(described_class.new("whatever")).to be_plugin
+    end
+
+    it "returns false for our engines" do
+      expect(described_class.new("duplication")).not_to be_plugin
+      expect(described_class.new("structure")).not_to be_plugin
+    end
+  end
 end

--- a/spec/cc/config_spec.rb
+++ b/spec/cc/config_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe CC::Config do
-  describe "load" do
+  describe ".load" do
     it "loads default then yaml configurations" do
       yaml = write_cc_yaml(<<-EOYAML)
       prepare:

--- a/spec/cc/config_spec.rb
+++ b/spec/cc/config_spec.rb
@@ -90,4 +90,29 @@ describe CC::Config do
       end
     end
   end
+
+  describe "#disable_plugins!" do
+    it "deletes plugins from #engines" do
+      config = CC::Config.new(engines: Set.new(
+        [
+          double(name: "1", plugin?: false),
+          double(name: "2", plugin?: true),
+          double(name: "3", plugin?: false),
+        ]
+      ))
+
+      config.disable_plugins!
+
+      expect(config.engines.count).to eq(2)
+      expect(config.engines.map(&:name)).to eq(%w[1 3])
+    end
+
+    it "sets auto_enable_plugins? to false" do
+      config = CC::Config.new
+      expect(config).to be_auto_enable_plugins
+
+      config.disable_plugins!
+      expect(config).not_to be_auto_enable_plugins
+    end
+  end
 end


### PR DESCRIPTION
To backfill repositories with historical analysis, we need to run builds on
commits many years old. Such commits might have code and configuration that
expects the then-latest version of engine tooling (e.g. rubocop). This causes
the builds to fail.

Our own engines should be stable to this (or we will make it so), but we can't
in any way ensure recent plugins would run on older codebases. Therefore, we'll
not run any plugins in such builds.

This will knowingly create builds that are missing any issues or analysis data
provided by plugins. Because of this, they can't be used to render results on
site or as merge-base analyses in comparisons. We're comfortable with this
limitation.