### PR TITLE
Support "plugins" in JSON config

### DIFF
--- a/lib/cc/config/json.rb
+++ b/lib/cc/config/json.rb
@@ -20,7 +20,7 @@ module CC
         :json
 
       def structure_engine
-        base_engine = Engine.new(
+        Engine.new(
           "structure",
           enabled: true,
           channel: channel_overrides.fetch("structure", "stable"),
@@ -33,7 +33,7 @@ module CC
       end
 
       def duplication_engine
-        base_engine = Engine.new(
+        Engine.new(
           "duplication",
           enabled: true,
           channel: channel_overrides.fetch("duplication", "cronopio"),

--- a/lib/cc/config/json.rb
+++ b/lib/cc/config/json.rb
@@ -20,49 +20,47 @@ module CC
         :json
 
       def structure_engine
+        base_engine = Engine.new(
+          "structure",
+          enabled: true,
+          config: {
+            "config" => {
+              "checks" => json.fetch("checks", {}),
+            },
+          },
+        )
         override = all_configured_engines.detect { |engine| engine.name == "structure" }
 
         if override
-          set_engine_checks(override, json.fetch("checks", {}))
-          override
+          base_engine.merge(override)
         else
-          Engine.new(
-            "structure",
-            enabled: true,
-            config: {
-              "config" => {
-                "checks" => json.fetch("checks", {}),
-              },
-            },
-          )
+          base_engine
         end
       end
 
       def duplication_engine
+        base_engine = Engine.new(
+          "duplication",
+          enabled: true,
+          channel: "cronopio",
+          config: {
+            "config" => {
+              "languages" => %w[javascript ruby],
+              "checks" => json.fetch("checks", {}),
+            },
+          },
+        )
         override = all_configured_engines.detect { |engine| engine.name == "duplication" }
 
         if override
-          set_engine_checks(override, json.fetch("checks", {}))
-          override
+          base_engine.merge(override)
         else
-          Engine.new(
-            "duplication",
-            enabled: true,
-            channel: "cronopio",
-            config: {
-              "config" => {
-                "languages" => %w[javascript ruby],
-                "checks" => json.fetch("checks", {}),
-              },
-            },
-          )
+          base_engine
         end
       end
 
       def plugin_engines
-        all_configured_engines.reject do |engine|
-          %w[structure duplication].include?(engine.name)
-        end
+        all_configured_engines.select(&:plugin?)
       end
 
       def all_configured_engines
@@ -78,11 +76,6 @@ module CC
           channel: data["channel"],
           config: data
         )
-      end
-
-      def set_engine_checks(engine, checks)
-        engine.config["config"] ||= {}
-        engine.config["config"]["checks"] ||= checks
       end
     end
   end

--- a/lib/cc/config/json.rb
+++ b/lib/cc/config/json.rb
@@ -23,26 +23,20 @@ module CC
         base_engine = Engine.new(
           "structure",
           enabled: true,
+          channel: channel_overrides.fetch("structure", "stable"),
           config: {
             "config" => {
               "checks" => json.fetch("checks", {}),
             },
           },
         )
-        override = all_configured_engines.detect { |engine| engine.name == "structure" }
-
-        if override
-          base_engine.merge(override)
-        else
-          base_engine
-        end
       end
 
       def duplication_engine
         base_engine = Engine.new(
           "duplication",
           enabled: true,
-          channel: "cronopio",
+          channel: channel_overrides.fetch("duplication", "cronopio"),
           config: {
             "config" => {
               "languages" => %w[javascript ruby],
@@ -50,21 +44,10 @@ module CC
             },
           },
         )
-        override = all_configured_engines.detect { |engine| engine.name == "duplication" }
-
-        if override
-          base_engine.merge(override)
-        else
-          base_engine
-        end
       end
 
       def plugin_engines
-        all_configured_engines.select(&:plugin?)
-      end
-
-      def all_configured_engines
-        @all_configured_engines ||= json.fetch("plugins", {}).map do |name, data|
+        json.fetch("plugins", {}).map do |name, data|
           plugin_engine(name, data)
         end
       end
@@ -76,6 +59,10 @@ module CC
           channel: data["channel"],
           config: data
         )
+      end
+
+      def channel_overrides
+        json.fetch("channels", {})
       end
     end
   end

--- a/lib/cc/config/json.rb
+++ b/lib/cc/config/json.rb
@@ -8,7 +8,7 @@ module CC
         @json = ::JSON.parse(File.open(path).read) || {}
 
         super(
-          engines: Set.new([duplication_engine, structure_engine]),
+          engines: Set.new([duplication_engine, structure_engine] + plugin_engines),
           exclude_patterns: json.fetch("exclude_patterns", Default::EXCLUDE_PATTERNS)
         )
       end
@@ -20,29 +20,69 @@ module CC
         :json
 
       def structure_engine
-        Engine.new(
-          "structure",
-          enabled: true,
-          config: {
-            "config" => {
-              "checks" => json.fetch("checks", {}),
+        override = all_configured_engines.detect { |engine| engine.name == "structure" }
+
+        if override
+          set_engine_checks(override, json.fetch("checks", {}))
+          override
+        else
+          Engine.new(
+            "structure",
+            enabled: true,
+            config: {
+              "config" => {
+                "checks" => json.fetch("checks", {}),
+              },
             },
-          },
-        )
+          )
+        end
       end
 
       def duplication_engine
-        Engine.new(
-          "duplication",
-          enabled: true,
-          channel: "cronopio",
-          config: {
-            "config" => {
-              "languages" => %w[javascript ruby],
-              "checks" => json.fetch("checks", {}),
+        override = all_configured_engines.detect { |engine| engine.name == "duplication" }
+
+        if override
+          set_engine_checks(override, json.fetch("checks", {}))
+          override
+        else
+          Engine.new(
+            "duplication",
+            enabled: true,
+            channel: "cronopio",
+            config: {
+              "config" => {
+                "languages" => %w[javascript ruby],
+                "checks" => json.fetch("checks", {}),
+              },
             },
-          },
+          )
+        end
+      end
+
+      def plugin_engines
+        all_configured_engines.reject do |engine|
+          %w[structure duplication].include?(engine.name)
+        end
+      end
+
+      def all_configured_engines
+        @all_configured_engines ||= json.fetch("plugins", {}).map do |name, data|
+          plugin_engine(name, data)
+        end
+      end
+
+      def plugin_engine(name, data)
+        Engine.new(
+          name,
+          enabled: data.fetch("enabled", true),
+          channel: data["channel"],
+          config: data
         )
+      end
+
+      def set_engine_checks(engine, checks)
+        engine.config["config"] ||= {}
+        engine.config["config"]["checks"] ||= checks
       end
     end
   end

--- a/spec/cc/config/json_spec.rb
+++ b/spec/cc/config/json_spec.rb
@@ -50,19 +50,15 @@ describe CC::Config::JSON do
       })
     end
 
-    it "respects overrides of core engines" do
+    it "respects overrides of core engine channels" do
       json = load_cc_json(<<-EOS)
         {
+          "channels": {
+            "structure": "beta"
+          },
           "checks": {
             "cyclomatic-complexity": {
               "enabled": true
-            }
-          },
-          "plugins": {
-            "structure": {
-              "enabled": false,
-              "channel": "beta",
-              "config": { "something": "else" }
             }
           }
         }
@@ -72,7 +68,6 @@ describe CC::Config::JSON do
 
       engine = json.engines.detect { |engine| engine.name == "structure" }
       expect(engine).not_to be_nil
-      expect(engine.enabled?).to eq(false)
       expect(engine.channel).to eq("beta")
       expect(engine.config["config"]["checks"]).to eq(
         "cyclomatic-complexity" => {


### PR DESCRIPTION
This is the new key for specifying plugin engines.

Since we'll shortly be ignoring legacy yaml entirely when JSON is
present, we also have a practical need to be able to configure
structure/duplication in this file (e.g. to set channel), so this will
respect configuration for those engines under the "plugins" key, even
though they are not semantically plugins.