### PR TITLE
Either YAML or JSON, never both

### DIFF
--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -19,8 +19,11 @@ module CC
 
     def self.load
       config = Default.new
-      config = config.merge(YAML.new) if File.exist?(YAML::DEFAULT_PATH)
-      config = config.merge(JSON.new) if File.exist?(JSON::DEFAULT_PATH)
+      if File.exist?(JSON::DEFAULT_PATH)
+        config = config.merge(JSON.new)
+      elsif File.exist?(YAML::DEFAULT_PATH)
+        config = config.merge(YAML.new)
+      end
       config
     end
 


### PR DESCRIPTION
With plugins, we now support all core config fields in the new schema
(excpect prepare, which I'll address soon). To simplify the
understanding of the system, we're moving towards only loading one of
these files: right now, the newer-schema JSON is the pre-eminent one, so
we won't load YAML if the JSON exists.