### PR TITLE
When auto-enabling, don't write `config: FILENAME`

### DIFF
--- a/lib/cc/analyzer/plugins.rb
+++ b/lib/cc/analyzer/plugins.rb
@@ -12,7 +12,6 @@ module CC
           engine_details.auto_enable_paths.each do |path|
             if File.exist?(path)
               engine.enabled = true
-              engine.config["config"] = path
               config.engines << engine
               break
             end

--- a/spec/cc/analyzer/plugins_spec.rb
+++ b/spec/cc/analyzer/plugins_spec.rb
@@ -23,7 +23,6 @@ describe CC::Analyzer::Plugins do
       expect(config.engines.length).to eq(1)
       expect(config.engines.first).to be_enabled
       expect(config.engines.first.name).to eq("rubocop")
-      expect(config.engines.first.config["config"]).to eq(".rubocop.yml")
     end
 
     it "does not auto-enable over an already-configured engine" do
@@ -52,7 +51,6 @@ describe CC::Analyzer::Plugins do
       expect(config.engines.length).to eq(1)
       expect(config.engines.first).to be_enabled
       expect(config.engines.first.name).to eq("eslint")
-      expect(config.engines.first.config["config"]).to eq(".eslintrc.json")
     end
   end
 end


### PR DESCRIPTION
This is an older style of config that engines should not rely on
anymore: though some still handle it, others will crash.

When auto-enabling an engine based on the config file existing, the
explicit config should not be needed anyway: since it's the auto-enable
path, it should be one of the paths the engine will look for by default
anyway.