### PR TITLE
Convert old file config to newer config style

### DIFF
--- a/lib/cc/config/yaml.rb
+++ b/lib/cc/config/yaml.rb
@@ -33,7 +33,7 @@ module CC
           Engine.new(name, enabled: data)
         else
           if data.key?("config")
-            data["config"] = convert_to_legacy_file_config(data["config"])
+            data["config"] = upconvert_legacy_file_config(data["config"])
           end
 
           Engine.new(
@@ -45,18 +45,18 @@ module CC
         end
       end
 
-      # Many of our plugins still expect:
+      # We used to support
       #
       #   { config: PATH }
       #
-      # But we document, and hope to eventually move to:
+      # But we document, and have moved to:
       #
       #   { config: { file: PATH } }
       #
-      # We need to munge from the latter to the former when/if we encounter it
-      def convert_to_legacy_file_config(config)
-        if config.keys.size == 1 && config.key?("file")
-          config["file"]
+      # We need to munge from the former to the latter when we encounter it
+      def upconvert_legacy_file_config(config)
+        if config.is_a?(String)
+          { "file" => config }
         else
           config
         end

--- a/spec/cc/config/yaml_spec.rb
+++ b/spec/cc/config/yaml_spec.rb
@@ -63,18 +63,17 @@ describe CC::Config::YAML do
       expect(rubocop.config["config"]).to eq("yo" => "sup")
     end
 
-    it "re-writes as legacy file config values" do
+    it "re-writes legacy file config values as new format" do
       yaml = load_cc_yaml(<<-EOYAML)
       plugins:
         rubocop:
           enabled: true
-          config:
-            file: "foo.rb"
+          config: "foo.rb"
       EOYAML
 
       rubocop = yaml.engines.detect { |e| e.name == "rubocop" }
       expect(rubocop).to be_present
-      expect(rubocop.config["config"]).to eq("foo.rb")
+      expect(rubocop.config["config"]).to eq("file" => "foo.rb")
     end
   end
 


### PR DESCRIPTION
The [cc-yaml][] config has been doing the conversion in this direction
for a long time, so I believe pretty much all engines support the newer
config format now. We primarily keep the conversion to support legacy
customer configs, not legacy engines, AFAIK. If there are any lingering
engines, we should fix those instead of re-writing to an older config
style, since the old-style config is *not supported* and will crash on
some engines.

[cc-yaml]: https://github.com/codeclimate/codeclimate-yaml/blob/master/spec/cc/yaml/nodes/engine_config_spec.rb#L58-L70