### PR TITLE
EngineFailure: take engine_name argument

### DIFF
--- a/lib/cc/cli/analyze.rb
+++ b/lib/cc/cli/analyze.rb
@@ -12,7 +12,7 @@ module CC
         "    --dev                            Run in development mode. Engines installed locally that are not in the manifest will be run.\n" \
         "    path                             Path to check. Can be specified multiple times.".freeze
 
-      EngineFailure = Class.new(StandardError)
+      autoload :EngineFailure, "cc/cli/analyze/engine_failure"
 
       include CC::Analyzer
 

--- a/lib/cc/cli/analyze/engine_failure.rb
+++ b/lib/cc/cli/analyze/engine_failure.rb
@@ -1,0 +1,11 @@
+module CC
+  module CLI
+    class Analyze < Command
+      class EngineFailure < StandardError
+        def initialize(message, _engine_name)
+          super(message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We pass two args to these exceptions now, but the CLI's internal
exception class wasn't updated to take one.