### PR TITLE
Enable java duplication analysis by default for QM

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -52,10 +52,11 @@ duplication:
     beta: codeclimate/codeclimate-duplication:beta
     cronopio: codeclimate/codeclimate-duplication:cronopio
     stable: codeclimate/codeclimate-duplication
-  description: Structural duplication detection for Ruby, Python, JavaScript, and PHP.
+  description: Structural duplication detection for Ruby, Python, Java, JavaScript, and PHP.
   default_config:
     languages:
       - ruby
+      - java
       - javascript
       - python
       - php

--- a/lib/cc/config/default.rb
+++ b/lib/cc/config/default.rb
@@ -2,6 +2,7 @@ module CC
   class Config
     class Default < Config
       DUPLICATION_LANGUAGES = %w[
+        java
         javascript
         php
         python

--- a/spec/cc/cli/engines/enable_spec.rb
+++ b/spec/cc/cli/engines/enable_spec.rb
@@ -67,7 +67,7 @@ module CC::CLI::Engines
 
             expect(stdout).to match("Engine added")
             config = CC::Analyzer::Config.new(content_after).engine_config("duplication")
-            expect(config["config"]).to eq("languages" => %w[ruby javascript python php])
+            expect(config["config"]).to eq("languages" => %w[ruby java javascript python php])
           end
         end
       end

--- a/spec/cc/config_spec.rb
+++ b/spec/cc/config_spec.rb
@@ -47,7 +47,7 @@ describe CC::Config do
       end
 
       config.engines.find { |e| e.name == "duplication" }.tap do |engine|
-        expect(engine.config["config"]["languages"].length).to eq(4)
+        expect(engine.config["config"]["languages"].length).to eq(5)
         expect(engine.config["config"]["checks"]).to eq(
           "cyclomatic-complexity" => {
             "enabled" => true,


### PR DESCRIPTION
We are already analyzing complexity for java by default on QM.