### PR TITLE
Use cronopio channel by default for duplication

### DIFF
--- a/lib/cc/config/engine.rb
+++ b/lib/cc/config/engine.rb
@@ -2,6 +2,8 @@ module CC
   class Config
     class Engine
       DEFAULT_CHANNEL = "stable".freeze
+      DUPLICATION_CHANNEL = "cronopio".freeze
+      DUPLICATION = "duplication".freeze
 
       attr_reader :name, :channel, :config
       attr_writer :enabled
@@ -9,7 +11,7 @@ module CC
       def initialize(name, enabled: false, channel: nil, config: nil)
         @name = name
         @enabled = enabled
-        @channel = channel || DEFAULT_CHANNEL
+        @channel = channel || default_channel
         @config = config || {}
       end
 
@@ -36,6 +38,14 @@ module CC
       # Set interface methods. Assumes we never want to store the same engine by
       # name in the same list. This should be true except maybe if we want to
       # work with multiple channels at once, which is unlikely.
+
+      def default_channel
+        if name == DUPLICATION
+          DUPLICATION_CHANNEL
+        else
+          DEFAULT_CHANNEL
+        end
+      end
 
       def eql?(other)
         other.is_a?(self.class) && name.eql?(other.name)

--- a/lib/cc/config/engine.rb
+++ b/lib/cc/config/engine.rb
@@ -39,20 +39,22 @@ module CC
       # name in the same list. This should be true except maybe if we want to
       # work with multiple channels at once, which is unlikely.
 
-      def default_channel
-        if name == DUPLICATION
-          DUPLICATION_CHANNEL
-        else
-          DEFAULT_CHANNEL
-        end
-      end
-
       def eql?(other)
         other.is_a?(self.class) && name.eql?(other.name)
       end
 
       def hash
         name.hash
+      end
+
+      private
+
+      def default_channel
+        if name == DUPLICATION
+          DUPLICATION_CHANNEL
+        else
+          DEFAULT_CHANNEL
+        end
       end
     end
   end

--- a/spec/cc/config/merge_spec.rb
+++ b/spec/cc/config/merge_spec.rb
@@ -60,6 +60,30 @@ describe CC::Config::Merge do
           expect(engine.config).to eq(foo: "baz", meow: { "yo": "sup", "foo": "bar" })
         end
       end
+
+      it "defaults to cronopio channel for duplication" do
+        config1 = CC::Config.new(
+          engines: [
+            CC::Config::Engine.new("duplication", enabled: true, config: { languages: "java" }),
+          ].to_set,
+        )
+
+        config2 = CC::Config.new(
+          engines: [
+            CC::Config::Engine.new("duplication", enabled: true, config: { languages: "ruby" }),
+          ].to_set,
+        )
+
+        merged_config = described_class.new(config1, config2).run
+
+        expect(merged_config.engines.count).to eq(1)
+
+        merged_config.engines.to_a.first.tap do |engine|
+          expect(engine.name).to eq("duplication")
+          expect(engine.config).to eq(languages: "ruby")
+          expect(engine.channel).to eq(CC::Config::Engine::DUPLICATION_CHANNEL)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Duplication Quality Model lives on the cronopio channel instead of
master.

The default of `stable` can produce confusing results when QM users
modify the duplication engine in .codeclimate.yml.