### PR TITLE
Prefer YAML.safe_load to SafeYaml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       pry (~> 0.10.1)
       rainbow (~> 2.0, >= 2.0.0)
       redcarpet (~> 3.2)
-      safe_yaml (~> 1.0)
       tty-spinner (~> 0.1.0)
       uuid (~> 2.3)
 
@@ -59,7 +58,6 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    safe_yaml (1.0.4)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)

--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |s|
   s.add_dependency "rainbow", "~> 2.0", ">= 2.0.0"
   s.add_dependency "redcarpet", "~> 3.2"
   s.add_dependency "uuid", "~> 2.3"
-  s.add_dependency "safe_yaml", "~> 1.0"
 end

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -1,5 +1,3 @@
-require "safe_yaml/load"
-
 module CC
   class EngineRegistry
     DEFAULT_COMMAND = nil
@@ -9,7 +7,7 @@ module CC
     EngineDetailsNotFoundError = Class.new(StandardError)
 
     def initialize(path = DEFAULT_MANIFEST_PATH, prefix = "")
-      @yaml = SafeYAML.load_file(path)
+      @yaml = YAML.safe_load(File.read(path))
       @prefix = prefix
     end
 


### PR DESCRIPTION
We've been mixing-and-matching these two approaches for a while. This
removes the final usage of `SafeYaml` and removes the gem.

`SafeYaml` is a 3rd party gem unassociated with the core Ruby team, and
it hasn't been touched in years. `YAML.safe_load` is a core part of
`Psych` distributed with Ruby, so it's naturally going to get more
modern updates & attention that `SafeYaml` will not. I ran many of
`SafeYaml`'s own examples through `YAML.safe_load` and `YAML`'s behavior
is equally correct.