### PR TITLE
Rm EngineRegistry#each_engine

### DIFF
--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -13,19 +13,6 @@ module CC
       @prefix = prefix
     end
 
-    def each_engine
-      yaml.each do |name, _metadata|
-        begin
-          engine = Config::Engine.new(name)
-          engine_details = fetch_engine_details(engine)
-
-          yield(engine, engine_details)
-        rescue EngineDetailsNotFoundError
-          # Ignore, means no stable key
-        end
-      end
-    end
-
     def fetch_engine_details(engine, development: false)
       if development
         EngineDetails.new("codeclimate/codeclimate-#{engine.name}", nil, [])


### PR DESCRIPTION
This method is unused (here as well as `Builder`).