### PR TITLE
Use new Config & EngineRegistry for remaining engines commands

### DIFF
--- a/lib/cc/cli/command.rb
+++ b/lib/cc/cli/command.rb
@@ -73,22 +73,12 @@ module CC
         run
       end
 
-      def require_codeclimate_yml
-        unless filesystem.exist?(CODECLIMATE_YAML)
-          fatal("No '.codeclimate.yml' file found. Run 'codeclimate init' to generate a config file.")
-        end
-      end
-
       private
 
       def filesystem
         @filesystem ||= CC::Analyzer::Filesystem.new(
           CC::Analyzer::MountedPath.code.container_path,
         )
-      end
-
-      def engine_registry
-        @engine_registry ||= CC::Analyzer::EngineRegistry.new
       end
     end
   end

--- a/lib/cc/cli/engines/engine_command.rb
+++ b/lib/cc/cli/engines/engine_command.rb
@@ -4,42 +4,10 @@ module CC
   module CLI
     module Engines
       class EngineCommand < Command
-        include CC::Analyzer
-
         abstract!
 
-        private
-
-        def engine_name
-          @engine_name ||= @args.first
-        end
-
-        def parsed_yaml
-          @parsed_yaml ||= CC::Analyzer::Config.new(yaml_content)
-        end
-
-        def yaml_content
-          filesystem.read_path(CODECLIMATE_YAML).freeze
-        end
-
-        def update_yaml
-          filesystem.write_path(CODECLIMATE_YAML, parsed_yaml.to_yaml)
-        end
-
-        def engine_present_in_yaml?
-          parsed_yaml.engine_present?(engine_name)
-        end
-
-        def engine_enabled?
-          parsed_yaml.engine_enabled?(engine_name)
-        end
-
-        def engine_exists?
-          engine_registry.exists?(engine_name)
-        end
-
-        def engine_registry_list
-          engine_registry.list
+        def engine_registry
+          @engine_registry ||= EngineRegistry.new
         end
       end
     end

--- a/lib/cc/cli/engines/install.rb
+++ b/lib/cc/cli/engines/install.rb
@@ -13,10 +13,6 @@ module CC
 
         private
 
-        def engine_registry
-          @engine_registry ||= EngineRegistry.new
-        end
-
         def config
           @config ||= CC::Config.load
         end

--- a/lib/cc/cli/engines/list.rb
+++ b/lib/cc/cli/engines/list.rb
@@ -6,9 +6,11 @@ module CC
 
         def run
           say "Available engines:"
-          engine_registry_list.sort_by { |name, _| name }.each do |name, attributes|
-            say "- #{name}: #{attributes["description"]}"
-          end
+          engine_registry.
+            sort_by { |engine, _| engine.name }.
+            each do |engine, metadata|
+              say "- #{engine.name}: #{metadata.description}"
+            end
         end
       end
     end

--- a/spec/cc/cli/command_spec.rb
+++ b/spec/cc/cli/command_spec.rb
@@ -65,18 +65,6 @@ module CC::CLI
       end
     end
 
-    describe "#require_codeclimate_yml" do
-      it "exits if the file doesn't exist" do
-        Dir.chdir(Dir.mktmpdir) do
-          _, stderr = capture_io do
-            expect { Command.new.require_codeclimate_yml }.to raise_error SystemExit
-          end
-
-          expect(stderr).to match("No '.codeclimate.yml' file found. Run 'codeclimate init' to generate a config file.")
-        end
-      end
-    end
-
     describe ".synopsys" do
       it "returns just a command name when no argumes are defined" do
         class Test9 < Command; end


### PR DESCRIPTION
Trying to move away from the legacy `Analyzer::Config` and
`Analyzer::EngineRegistry` to get more things using the newer
equivalents.

This happens to improve some behavior of `engines:install` as well: previously
it would install every available channel for an enabled
engine, which is pretty excessive. This now only installs the image for
whatever channel the user has enabled.