### PR TITLE
Config validation: warn about missing version key

### DIFF
--- a/lib/cc/config/validation/json.rb
+++ b/lib/cc/config/validation/json.rb
@@ -10,6 +10,7 @@ module CC
 
           return unless validate_hash_data
 
+          validate_version
           validate_prepare
           validate_engines("plugins")
           validate_checks
@@ -18,6 +19,12 @@ module CC
           warn_unrecognized_keys(%w[prepare plugins exclude_patterns version])
         rescue ::JSON::ParserError => ex
           errors << "Unable to parse: #{ex.message}"
+        end
+
+        def validate_version
+          unless data.key?("version")
+            warnings << %{missing 'version' key. Please add `"version": "2"`}
+          end
         end
       end
     end

--- a/lib/cc/config/validation/yaml.rb
+++ b/lib/cc/config/validation/yaml.rb
@@ -10,6 +10,7 @@ module CC
 
           return unless validate_hash_data
 
+          validate_version
           validate_prepare
 
           validate_one_of(%w[engines plugins])
@@ -27,6 +28,12 @@ module CC
           warn_unrecognized_keys(%w[prepare engines plugins ratings languages exclude_paths exclude_patterns version])
         rescue Psych::SyntaxError => ex
           errors << "Unable to parse: #{ex.message}"
+        end
+
+        def validate_version
+          if !data.key?("version") && (data.key?("plugins") || data.key?("exclude_patterns"))
+            warnings << %{missing 'version' key. Please add `version: "2"`}
+          end
         end
 
         def validate_one_of(keys)

--- a/spec/cc/cli/validate_config_spec.rb
+++ b/spec/cc/cli/validate_config_spec.rb
@@ -80,6 +80,7 @@ module CC::CLI
 
       it "reports copy looks great for valid yaml" do
         write_cc_yaml(<<-EOYAML)
+        version: "2"
         plugins:
           rubocop:
             enabled: true

--- a/spec/cc/config/validation/json_spec.rb
+++ b/spec/cc/config/validation/json_spec.rb
@@ -4,6 +4,7 @@ describe CC::Config::Validation::JSON do
   it "is valid for a complete config" do
     validator = validate_json(<<-EOJSON)
     {
+      "version": "2",
       "prepare": {
         "fetch": [
           "http://test.test/rubocop.yml",
@@ -217,6 +218,17 @@ describe CC::Config::Validation::JSON do
     expect(validator).to be_valid
     expect(validator.warnings).to include("engine rubocop: unrecognized key 'enalbed'")
     expect(validator.warnings).to include("unrecognized key 'exclude_pattttttterns'")
+  end
+
+  describe "version validation" do
+    it "warns about missing version" do
+      validator = validate_json(<<-EOJSON)
+      { "plugins": {} }
+      EOJSON
+
+      expect(validator).to be_valid
+      expect(validator.warnings).to include(%{missing 'version' key. Please add `"version": "2"`})
+    end
   end
 
   def validate_json(json, registry = nil)

--- a/spec/cc/config/validation/yaml_spec.rb
+++ b/spec/cc/config/validation/yaml_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe CC::Config::Validation::YAML do
   it "is valid for a complete config" do
     validator = validate_yaml(<<-EOYAML)
+    version: "2"
     prepare:
       fetch:
       - http://test.test/rubocop.yml
@@ -221,6 +222,26 @@ describe CC::Config::Validation::YAML do
     expect(validator).to be_valid
     expect(validator.warnings).to include("engine rubocop: unrecognized key 'enabbled'")
     expect(validator.warnings).to include("unrecognized key 'exclude_pattttttterns'")
+  end
+
+  describe "version validation" do
+    it "does not warn about version for v1 schema" do
+      validator = validate_yaml(<<-EOYAML)
+      engines: {}
+      EOYAML
+
+      expect(validator).to be_valid
+      expect(validator.warnings).not_to include(%{missing 'version' key. Please add `version: "2"`})
+    end
+
+    it "does warn about version for v2 schema" do
+      validator = validate_yaml(<<-EOYAML)
+      plugins: {}
+      EOYAML
+
+      expect(validator).to be_valid
+      expect(validator.warnings).to include(%{missing 'version' key. Please add `version: "2"`})
+    end
   end
 
   def validate_yaml(yaml, registry = nil)


### PR DESCRIPTION
This should always exist in JSON configs, but we still support v1 YAML,
so in YAML it only warns if it sees one of the v2 keys.