### PR TITLE
Skip engines that are missing, warn about them being skipped

### DIFF
--- a/lib/cc/analyzer/bridge.rb
+++ b/lib/cc/analyzer/bridge.rb
@@ -45,10 +45,11 @@ module CC
               listener.started(engine, engine_details)
               result = run_engine(engine, engine_details)
             rescue CC::EngineRegistry::EngineDetailsNotFoundError => ex
-              result = Container::Result.from_exception(ex)
+              result = Container::Result.skipped(ex)
             end
 
             listener.finished(engine, engine_details, result)
+            result
           end
         end
 

--- a/lib/cc/analyzer/container/result.rb
+++ b/lib/cc/analyzer/container/result.rb
@@ -16,6 +16,7 @@ module CC
           exit_status: 0,
           maximum_output_exceeded: false,
           output_byte_count: 0,
+          skipped: false,
           stderr: "",
           stdout: "",
           timed_out: false
@@ -25,15 +26,18 @@ module CC
           @exit_status = exit_status
           @maximum_output_exceeded = maximum_output_exceeded
           @output_byte_count = output_byte_count
+          @skipped = skipped
           @stderr = stderr
           @stdout = stdout
           @timed_out = timed_out
         end
 
-        # N.B. This is lossy in that we don't know duration or output_byte_count.
-        def self.from_exception(ex)
-          instance = new
-          instance.merge_from_exception(ex)
+        def self.skipped(ex)
+          new(
+            exit_status: 0,
+            skipped: true,
+            stderr: ex.message,
+          )
         end
 
         def merge_from_exception(ex)
@@ -55,6 +59,10 @@ module CC
             maximum_output_exceeded? ||
             exit_status.nil? ||
             exit_status.nonzero?
+        end
+
+        def skipped?
+          @skipped
         end
 
         private

--- a/lib/cc/analyzer/formatters/plain_text_formatter.rb
+++ b/lib/cc/analyzer/formatters/plain_text_formatter.rb
@@ -38,7 +38,10 @@ module CC
 
         def engine_running(engine, &block)
           super(engine) do
-            with_spinner("Running #{current_engine.name}: ", &block)
+            result = with_spinner("Running #{current_engine.name}: ", &block)
+            if result.skipped?
+              puts(colorize("Skipped #{current_engine.name}: #{result.stderr}", :yellow))
+            end
           end
         end
 

--- a/lib/cc/analyzer/logging_container_listener.rb
+++ b/lib/cc/analyzer/logging_container_listener.rb
@@ -9,8 +9,11 @@ module CC
         logger.info("starting engine #{engine.name}")
       end
 
-      def finished(engine, _details, _result)
+      def finished(engine, _details, result)
         logger.info("finished engine #{engine.name}")
+        if result.skipped?
+          logger.warn("skipped engine #{engine.name}: #{result.stderr}")
+        end
       end
 
       private

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -49,12 +49,12 @@ module CC
     def not_found_message(ex, engine, available_channels)
       if available_channels
         # Known engine, unknown channel
-        "Engine details not found" \
-          " for #{engine.name}:#{engine.channel}," \
+        "Channel #{engine.channel} not found" \
+          " for #{engine.name}," \
           " available channels: #{available_channels.keys.inspect}"
       else
         # Unknown engine
-        "Engine details not found for #{engine.name}"
+        "No engine named #{engine.name} found"
       end
     end
   end

--- a/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
+++ b/spec/cc/analyzer/formatters/plain_text_formatter_spec.rb
@@ -15,11 +15,23 @@ module CC::Analyzer::Formatters
 
         expect do
           capture_io do
-            write_from_engine(formatter, engine, "type" => "thing")
+            write_from_engine(formatter, engine, { "type" => "thing" }, double(:result))
           end
         end.to raise_error(
           RuntimeError, "Invalid type found: thing"
         )
+      end
+    end
+
+    describe "#engine_running" do
+      it "prints a message when an engine is skipped" do
+        engine = double(name: "cool_engine")
+
+        stdout, _ = capture_io do
+          write_from_engine(formatter, engine, sample_issue, double(:result, skipped?: true, stderr: "foo"))
+        end
+
+        expect(stdout).to include("Skipped cool_engine: foo")
       end
     end
 
@@ -28,7 +40,7 @@ module CC::Analyzer::Formatters
         engine = double(name: "cool_engine")
 
         stdout, _ = capture_io do
-          write_from_engine(formatter, engine, sample_issue)
+          write_from_engine(formatter, engine, sample_issue, double(:result, skipped?: false))
           formatter.finished
         end
 
@@ -38,9 +50,10 @@ module CC::Analyzer::Formatters
       end
     end
 
-    def write_from_engine(formatter, engine, issue)
+    def write_from_engine(formatter, engine, issue, result)
       formatter.engine_running(engine) do
         formatter.write(issue.to_json)
+        result
       end
     end
   end

--- a/spec/cc/analyzer/logging_container_listener_spec.rb
+++ b/spec/cc/analyzer/logging_container_listener_spec.rb
@@ -22,7 +22,17 @@ module CC::Analyzer
 
         expect(logger).to receive(:info).with(/finished engine engine/)
 
-        listener.finished(engine, nil, nil)
+        listener.finished(engine, nil, double(:result, skipped?: false))
+      end
+
+      it "warns about skip" do
+        logger = double
+        listener = LoggingContainerListener.new(logger)
+
+        expect(logger).to receive(:info).with(/finished engine engine/)
+        expect(logger).to receive(:warn).with(/skipped engine engine/)
+
+        listener.finished(engine, nil, double(:result, skipped?: true, stderr: "foo"))
       end
     end
   end

--- a/spec/cc/engine_registry_spec.rb
+++ b/spec/cc/engine_registry_spec.rb
@@ -46,7 +46,7 @@ describe CC::EngineRegistry do
       engine = double(name: "nope", channel: "beta")
       expect { registry.fetch_engine_details(engine) }.to raise_error(
         described_class::EngineDetailsNotFoundError,
-        /details not found for nope/,
+        /No engine named nope found/,
       )
     end
 
@@ -61,7 +61,7 @@ describe CC::EngineRegistry do
       engine = double(name: "rubocop", channel: "nope")
       expect { registry.fetch_engine_details(engine) }.to raise_error(
         described_class::EngineDetailsNotFoundError,
-        /details not found for rubocop:nope,.*\["stable", "example"\]/,
+        /Channel nope not found for rubocop,.*\["stable", "example"\]/,
       )
     end
 


### PR DESCRIPTION
In .com we "skip" invalid engines, and don't crash on them. Treating a
missing engine as an exit code `99` will make maintaining that behavior
in .com difficult due to some other details of error handling.

This seems preferable: we'll treat skipped results as exit code `0`
(since they're not "errors"), and mark them as `skipped`, similar to
other meta-states like timed out.

I've also made the CLI's handling of this state more similar to what
.com's behavior used to be, and will be again: we don't crash, we just
warn.