### PR TITLE
Allow engines to tell a minimum required memory to run

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -185,7 +185,7 @@ sonar-java:
     stable: codeclimate/codeclimate-sonar-java
     beta: codeclimate/codeclimate-sonar-java:beta
   description: SonarLint for Java.
-  required_memory: 2_048_000_000
+  minimum_memory_limit: 2_048_000_000
 structure:
   channels:
     beta: codeclimate/codeclimate-structure:beta

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -185,6 +185,7 @@ sonar-java:
     stable: codeclimate/codeclimate-sonar-java
     beta: codeclimate/codeclimate-sonar-java:beta
   description: SonarLint for Java.
+  memory: 2_048_000_000
 structure:
   channels:
     beta: codeclimate/codeclimate-structure:beta

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -185,7 +185,7 @@ sonar-java:
     stable: codeclimate/codeclimate-sonar-java
     beta: codeclimate/codeclimate-sonar-java:beta
   description: SonarLint for Java.
-  memory: 2_048_000_000
+  required_memory: 2_048_000_000
 structure:
   channels:
     beta: codeclimate/codeclimate-structure:beta

--- a/lib/cc/analyzer/bridge.rb
+++ b/lib/cc/analyzer/bridge.rb
@@ -70,6 +70,7 @@ module CC
           {
             "image" => engine_details.image,
             "command" => engine_details.command,
+            "memory" => engine_details.memory,
           },
           engine.config.merge(
             "channel" => engine.channel,

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -20,8 +20,6 @@ module CC
     class Engine
       Error = Class.new(StandardError)
 
-      DEFAULT_MEMORY_LIMIT = 1_024_000_000
-
       def initialize(name, metadata, config, label)
         @name = name
         @metadata = metadata
@@ -34,8 +32,8 @@ module CC
         write_config_file
 
         container = Container.new(
-          image: @metadata.fetch("image"),
-          command: @metadata["command"],
+          image: metadata.fetch("image"),
+          command: metadata["command"],
           name: container_name,
         )
 
@@ -52,7 +50,7 @@ module CC
 
       private
 
-      attr_reader :name
+      attr_reader :name, :metadata
       attr_accessor :error
 
       def handle_output(container, io, raw_output)
@@ -80,7 +78,7 @@ module CC
           "--cap-drop", "all",
           "--label", "com.codeclimate.label=#{@label}",
           "--log-driver", "none",
-          "--memory", memory_limit,
+          "--memory", metadata["memory"].to_s,
           "--memory-swap", "-1",
           "--net", "none",
           "--rm",
@@ -118,15 +116,6 @@ module CC
 
       def output_overrider
         @output_overrider ||= EngineOutputOverrider.new(@config)
-      end
-
-      # Memory limit for a running engine in bytes
-      def memory_limit
-        [@metadata["memory"].to_i, default_memory_limit.to_i].max.to_s
-      end
-
-      def default_memory_limit
-        ENV["ENGINE_MEMORY_LIMIT_BYTES"] || DEFAULT_MEMORY_LIMIT
       end
     end
   end

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -122,7 +122,7 @@ module CC
 
       # Memory limit for a running engine in bytes
       def memory_limit
-        (ENV["ENGINE_MEMORY_LIMIT_BYTES"] || DEFAULT_MEMORY_LIMIT).to_s
+        [@metadata["memory"].to_i, (ENV["ENGINE_MEMORY_LIMIT_BYTES"] || DEFAULT_MEMORY_LIMIT).to_i].max.to_s
       end
     end
   end

--- a/lib/cc/analyzer/engine.rb
+++ b/lib/cc/analyzer/engine.rb
@@ -122,7 +122,11 @@ module CC
 
       # Memory limit for a running engine in bytes
       def memory_limit
-        [@metadata["memory"].to_i, (ENV["ENGINE_MEMORY_LIMIT_BYTES"] || DEFAULT_MEMORY_LIMIT).to_i].max.to_s
+        [@metadata["memory"].to_i, default_memory_limit.to_i].max.to_s
+      end
+
+      def default_memory_limit
+        ENV["ENGINE_MEMORY_LIMIT_BYTES"] || DEFAULT_MEMORY_LIMIT
       end
     end
   end

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -27,7 +27,7 @@ module CC
 
     def fetch_engine_details(engine, development: false)
       if development
-        EngineDetails.new("codeclimate/codeclimate-#{engine.name}", nil, "", nil)
+        EngineDetails.new("codeclimate/codeclimate-#{engine.name}", nil, "")
       else
         metadata = yaml.fetch(engine.name)
         channels = metadata.fetch("channels")

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -2,6 +2,7 @@ module CC
   class EngineRegistry
     include Enumerable
 
+    DEFAULT_MEMORY_LIMIT = 1_024_000_000
     DEFAULT_COMMAND = nil
     DEFAULT_MANIFEST_PATH = File.expand_path("../../../config/engines.yml", __FILE__)
 
@@ -36,7 +37,7 @@ module CC
           [prefix, channels.fetch(engine.channel)].join,
           metadata.fetch("command", DEFAULT_COMMAND),
           metadata.fetch("description", "(No description available)"),
-          metadata.fetch("memory", nil),
+          memory_limit(metadata["memory"])
         )
       end
     rescue KeyError => ex
@@ -46,6 +47,17 @@ module CC
     private
 
     attr_reader :yaml, :prefix
+
+    def memory_limit(required_memory)
+      [
+        required_memory.to_i,
+        default_memory_limit.to_i,
+      ].max
+    end
+
+    def default_memory_limit
+      ENV["ENGINE_MEMORY_LIMIT_BYTES"] || DEFAULT_MEMORY_LIMIT
+    end
 
     def not_found_message(ex, engine, available_channels)
       if available_channels

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -37,7 +37,7 @@ module CC
           [prefix, channels.fetch(engine.channel)].join,
           metadata.fetch("command", DEFAULT_COMMAND),
           metadata.fetch("description", "(No description available)"),
-          memory_limit(metadata["required_memory"])
+          memory_limit(metadata["minimum_memory_limit"])
         )
       end
     rescue KeyError => ex
@@ -48,9 +48,9 @@ module CC
 
     attr_reader :yaml, :prefix
 
-    def memory_limit(required_memory)
+    def memory_limit(minimum_memory_limit)
       [
-        required_memory.to_i,
+        minimum_memory_limit.to_i,
         default_memory_limit.to_i,
       ].max
     end

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -5,7 +5,7 @@ module CC
     DEFAULT_COMMAND = nil
     DEFAULT_MANIFEST_PATH = File.expand_path("../../../config/engines.yml", __FILE__)
 
-    EngineDetails = Struct.new(:image, :command, :description)
+    EngineDetails = Struct.new(:image, :command, :description, :memory)
     EngineDetailsNotFoundError = Class.new(StandardError)
 
     def initialize(path = DEFAULT_MANIFEST_PATH, prefix = "")
@@ -27,7 +27,7 @@ module CC
 
     def fetch_engine_details(engine, development: false)
       if development
-        EngineDetails.new("codeclimate/codeclimate-#{engine.name}", nil, "")
+        EngineDetails.new("codeclimate/codeclimate-#{engine.name}", nil, "", nil)
       else
         metadata = yaml.fetch(engine.name)
         channels = metadata.fetch("channels")
@@ -36,6 +36,7 @@ module CC
           [prefix, channels.fetch(engine.channel)].join,
           metadata.fetch("command", DEFAULT_COMMAND),
           metadata.fetch("description", "(No description available)"),
+          metadata.fetch("memory", nil),
         )
       end
     rescue KeyError => ex

--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -37,7 +37,7 @@ module CC
           [prefix, channels.fetch(engine.channel)].join,
           metadata.fetch("command", DEFAULT_COMMAND),
           metadata.fetch("description", "(No description available)"),
-          memory_limit(metadata["memory"])
+          memory_limit(metadata["required_memory"])
         )
       end
     rescue KeyError => ex

--- a/spec/cc/analyzer/bridge_spec.rb
+++ b/spec/cc/analyzer/bridge_spec.rb
@@ -213,7 +213,7 @@ describe CC::Analyzer::Bridge do
     memoryhungry:
       channels:
         stable: memoryhungry-stable
-      memory: 2_048_000_000
+      required_memory: 2_048_000_000
     EOYAML
     CC::EngineRegistry.new("engines.yml")
   end

--- a/spec/cc/analyzer/bridge_spec.rb
+++ b/spec/cc/analyzer/bridge_spec.rb
@@ -213,7 +213,7 @@ describe CC::Analyzer::Bridge do
     memoryhungry:
       channels:
         stable: memoryhungry-stable
-      required_memory: 2_048_000_000
+      minimum_memory_limit: 2_048_000_000
     EOYAML
     CC::EngineRegistry.new("engines.yml")
   end

--- a/spec/cc/analyzer/bridge_spec.rb
+++ b/spec/cc/analyzer/bridge_spec.rb
@@ -147,10 +147,25 @@ describe CC::Analyzer::Bridge do
         "plugins" => {
           "structure" => false,
           "duplication" => false,
+          "bar" => true,
           "memoryhungry" => true,
         },
         "exclude_patterns" => ["bar/"]
       ))
+
+      expect_engine_run(
+        "bar",
+        {
+          "image" => "bar-stable",
+          "command" => nil,
+          "memory" => 1_024_000_000,
+        },
+        {
+          "enabled" => true,
+          "channel" => "stable",
+          "include_paths" => [".codeclimate.yml", "engines.yml"]
+        },
+      )
 
       expect_engine_run(
         "memoryhungry",
@@ -207,7 +222,7 @@ describe CC::Analyzer::Bridge do
     engine_double = double("engine_#{name}")
     expect(CC::Analyzer::Engine).to receive(:new).with(
       name,
-      { "memory" => nil }.merge(metadata),
+      { "memory" => 1024000000 }.merge(metadata),
       config,
       instance_of(String),
     ).and_return(engine_double)

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 module CC::Analyzer
   describe Engine do
+    let(:metadata) { { "image" => "codeclimate/foo", "command" => "bar", "memory" => 1024000000 } }
+
     describe "#run" do
       it "passes the correct options to Container" do
         container = double
@@ -14,7 +16,6 @@ module CC::Analyzer
           expect(args[:name]).to match(/^cc-engines-foo/)
         end.and_return(container)
 
-        metadata = { "image" => "codeclimate/foo", "command" => "bar" }
         engine = Engine.new("foo", metadata, {}, "")
         engine.run(StringIO.new)
       end
@@ -34,7 +35,7 @@ module CC::Analyzer
         )).and_return(Container::Result.new)
 
         expect(Container).to receive(:new).and_return(container)
-        engine = Engine.new("", { "image" => "" }, {}, "a-label")
+        engine = Engine.new("", metadata, {}, "a-label")
         engine.run(StringIO.new)
       end
 
@@ -63,7 +64,7 @@ module CC::Analyzer
           expect(Container).to receive(:new).and_return(container)
 
           stdout = TestFormatter.new
-          engine = Engine.new("bar", { "image" => "" }, {}, "")
+          engine = Engine.new("bar", metadata, {}, "")
           engine.run(stdout)
 
           expected = "{\"type\":\"issue\",\"check_name\":\"foo\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"engine_name\":\"bar\",\"fingerprint\":\"bdc0c2bb1201c4739118a51481a86fa1\",\"severity\":\"minor\"}{\"type\":\"issue\",\"check_name\":\"bar\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"engine_name\":\"bar\",\"fingerprint\":\"cbd5b8962eb9e2950fbb02f0ddf6c404\",\"severity\":\"minor\"}{\"type\":\"issue\",\"check_name\":\"baz\",\"location\":{\"path\":\"foo.rb\",\"lines\":{\"begin\":1,\"end\":1}},\"description\":\"foo\",\"categories\":[\"Style\"],\"engine_name\":\"bar\",\"fingerprint\":\"a08df13d51af2259c425551cb84c135f\",\"severity\":\"minor\"}"
@@ -85,7 +86,7 @@ module CC::Analyzer
 
           stdout = StringIO.new
           config = { "checks" => { "bar" => { "enabled" => false } } }
-          engine = Engine.new("", { "image" => "" }, config, "")
+          engine = Engine.new("", metadata, config, "")
           engine.run(stdout)
 
           expect(stdout.string).not_to include %{"check":"bar"}
@@ -103,7 +104,7 @@ module CC::Analyzer
 
           stdout = StringIO.new
           config = { "issue_override" => { "severity" => "info" } }
-          engine = Engine.new("", { "image" => "" }, config, "")
+          engine = Engine.new("", metadata, config, "")
           engine.run(stdout)
 
           expect(stdout.string).not_to include %{"severity":"minor"}

--- a/spec/cc/analyzer/engine_spec.rb
+++ b/spec/cc/analyzer/engine_spec.rb
@@ -38,6 +38,19 @@ module CC::Analyzer
         engine.run(StringIO.new)
       end
 
+      it "runs a Container with engine memory overrides" do
+        container = double
+        allow(container).to receive(:on_output).and_yield("")
+
+        expect(container).to receive(:run).with(including(
+          "--memory", "2048000000",
+        )).and_return(Container::Result.new)
+
+        expect(Container).to receive(:new).and_return(container)
+        engine = Engine.new("", { "image" => "", "memory" => 2048000000 }, {}, "a-label")
+        engine.run(StringIO.new)
+      end
+
       it "parses stdout for null-delimited issues" do
         within_temp_dir do
           make_file("foo.rb")

--- a/spec/cc/engine_registry_spec.rb
+++ b/spec/cc/engine_registry_spec.rb
@@ -78,6 +78,32 @@ describe CC::EngineRegistry do
 
       expect(engine_details.image).to eq "codeclimate/codeclimate-madeup"
     end
+
+    describe "memory limits" do
+      let(:registry) {
+        registry_from_yaml(<<-EOYAML)
+          sonar-java:
+            channels:
+              stable: foo
+            memory: 2_048_000_000
+        EOYAML
+      }
+      let(:engine) { double(name: "sonar-java", channel: "stable") }
+
+      it "uses at least the minimum set by the engine" do
+        ENV["ENGINE_MEMORY_LIMIT_BYTES"] = "1_500_000_000"
+        engine_details = registry.fetch_engine_details(engine)
+
+        expect(engine_details.memory).to eq 2_048_000_000
+      end
+
+      it "uses ENGINE_MEMORY_LIMIT_BYTES" do
+        ENV["ENGINE_MEMORY_LIMIT_BYTES"] = "4_000_000_000"
+        engine_details = registry.fetch_engine_details(engine)
+
+        expect(engine_details.memory).to eq 4_000_000_000
+      end
+    end
   end
 
   def registry_from_yaml(yaml)

--- a/spec/cc/engine_registry_spec.rb
+++ b/spec/cc/engine_registry_spec.rb
@@ -85,7 +85,7 @@ describe CC::EngineRegistry do
           sonar-java:
             channels:
               stable: foo
-            memory: 2_048_000_000
+            required_memory: 2_048_000_000
         EOYAML
       }
       let(:engine) { double(name: "sonar-java", channel: "stable") }

--- a/spec/cc/engine_registry_spec.rb
+++ b/spec/cc/engine_registry_spec.rb
@@ -85,7 +85,7 @@ describe CC::EngineRegistry do
           sonar-java:
             channels:
               stable: foo
-            required_memory: 2_048_000_000
+            minimum_memory_limit: 2_048_000_000
         EOYAML
       }
       let(:engine) { double(name: "sonar-java", channel: "stable") }


### PR DESCRIPTION
Set SonarJava memory to 2G

Related to https://github.com/codeclimate/app/issues/6291