### PR TITLE
Exclude TypeScript `d.ts` files from analysis

### DIFF
--- a/lib/cc/config/default_adapter.rb
+++ b/lib/cc/config/default_adapter.rb
@@ -18,7 +18,8 @@ module CC
         **/test/
         **/tests/
         **/vendor/
-      ]
+        **/*.d.ts
+      ].freeze
 
       attr_reader :config
 


### PR DESCRIPTION
Exclude TypeScript declaration files (`d.ts`) from analysis by default.

These files are not source code: they are are artifacts of TypeScript compilation and are intended to be packaged with the resulting JavaScript to provide a TypeScript interface. For more information, please see:

  https://en.wikipedia.org/wiki/TypeScript#Declaration_files

Ticket: codeclimate/app#6343.