### PR TITLE
Include engine channels in metrics

### DIFF
--- a/lib/cc/analyzer/statsd_container_listener.rb
+++ b/lib/cc/analyzer/statsd_container_listener.rb
@@ -6,24 +6,24 @@ module CC
       end
 
       def started(engine, _details)
-        increment(engine.name, "started")
+        increment(engine.name, engine.channel, "started")
       end
 
       def finished(engine, _details, result)
-        timing(engine.name, "time", result.duration)
-        increment(engine.name, "finished")
+        timing(engine.name, engine.channel, "time", result.duration)
+        increment(engine.name, engine.channel, "finished")
 
         if result.timed_out?
-          timing(engine.name, "time", result.duration)
-          increment(engine.name, "result.error")
-          increment(engine.name, "result.error.timeout")
+          timing(engine.name, engine.channel, "time", result.duration)
+          increment(engine.name, engine.channel, "result.error")
+          increment(engine.name, engine.channel, "result.error.timeout")
         elsif result.maximum_output_exceeded?
-          increment(engine.name, "result.error")
-          increment(engine.name, "result.error.output_exceeded")
+          increment(engine.name, engine.channel, "result.error")
+          increment(engine.name, engine.channel, "result.error.output_exceeded")
         elsif result.exit_status.nonzero?
-          increment(engine.name, "result.error")
+          increment(engine.name, engine.channel, "result.error")
         else
-          increment(engine.name, "result.success")
+          increment(engine.name, engine.channel, "result.success")
         end
       end
 
@@ -31,14 +31,14 @@ module CC
 
       attr_reader :statsd
 
-      def increment(name, metric)
+      def increment(name, channel, metric)
         statsd.increment("engines.#{metric}")
-        statsd.increment("engines.names.#{name}.#{metric}")
+        statsd.increment("engines.names.#{name}.#{channel}.#{metric}")
       end
 
-      def timing(name, metric, ms)
+      def timing(name, channel, metric, ms)
         statsd.timing("engines.#{metric}", ms)
-        statsd.timing("engines.names.#{name}.#{metric}", ms)
+        statsd.timing("engines.names.#{name}.#{channel}.#{metric}", ms)
       end
     end
   end

--- a/spec/cc/analyzer/statsd_container_listener_spec.rb
+++ b/spec/cc/analyzer/statsd_container_listener_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 module CC::Analyzer
   describe StatsdContainerListener do
-    let(:engine) { double(name: "engine") }
+    let(:engine) { double(name: "engine", channel: "stable") }
 
     describe "#started" do
       it "increments a metric in statsd" do


### PR DESCRIPTION
We've had this on master for a long time, and I've found the lack of it
frustrating while monitoring QM. It's good to be able to distinguish
engine metrics by channel.

Shipping this will require adjusting a few charts/alerts, I'll do that
after shipping.