### PR TITLE
Exclude slow tests by default in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SKIP_ENGINES ?= 0
 image:
 	docker build -t codeclimate/codeclimate .
 
+test: RSPEC_ARGS ?= --tag ~slow
 test: image
 	docker run --rm -it \
 	  --entrypoint bundle \


### PR DESCRIPTION
This dramatically increases test suite speed locally: we have one very
slow test that's valuable but fine to only run on CI or when you're
directly interested in it.