### PR TITLE
EngineOutput: catch invalid JSON

### DIFF
--- a/lib/cc/analyzer/engine_output.rb
+++ b/lib/cc/analyzer/engine_output.rb
@@ -20,16 +20,24 @@ module CC
       end
 
       def valid?
-        validator.valid?
+        valid_json? && validator.valid?
       end
 
       def error
-        validator.error
+        if valid_json?
+          validator.error
+        else
+          { message: "Invalid JSON: #{raw_output}" }
+        end
       end
 
       private
 
       attr_accessor :name, :raw_output
+
+      def valid_json?
+        parsed_output.present?
+      end
 
       def parsed_output
         @parsed_output ||= JSON.parse(raw_output)

--- a/spec/cc/analyzer/engine_output_spec.rb
+++ b/spec/cc/analyzer/engine_output_spec.rb
@@ -9,5 +9,38 @@ module CC::Analyzer
         expect(EngineOutput.new("", output).issue?).to eq(true)
       end
     end
+
+    describe "#valid?" do
+      it "is true for a valid issue" do
+        output = sample_issue.to_json
+        expect(EngineOutput.new("engine", output)).to be_valid
+      end
+
+      it "is false for an invalid issue" do
+        output = { type: "issue", categories: ["Foo"] }.to_json
+        expect(EngineOutput.new("engine", output)).not_to be_valid
+      end
+
+      it "is false for invalid JSON" do
+        output = "{bad"
+        expect(EngineOutput.new("engine", output)).not_to be_valid
+      end
+    end
+
+    describe "#error" do
+      it "gets IssueValidator errors for invalid issue" do
+        output = { type: "issue", categories: ["Foo"] }.to_json
+        expect(EngineOutput.new("engine", output).error[:message]).to match(
+          "Category must be at least one of"
+        )
+      end
+
+      it "is appropriate for invalid JSON" do
+        output = "{bad"
+        expect(EngineOutput.new("engine", output).error[:message]).to match(
+          "Invalid JSON"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Bad engine output should be treated as an engine error.