### PR TITLE
Git ignore `base_rubocop.yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 coverage
 spec/reports
+base_rubocop.yml


### PR DESCRIPTION
We used to check this in, now that it's being pulled via `prepare` we
should ignore it.