### PR TITLE
Revert "Include engine channels in metrics"

### DIFF
--- a/lib/cc/analyzer/statsd_container_listener.rb
+++ b/lib/cc/analyzer/statsd_container_listener.rb
@@ -6,24 +6,24 @@ module CC
       end
 
       def started(engine, _details)
-        increment(engine.name, engine.channel, "started")
+        increment(engine.name, "started")
       end
 
       def finished(engine, _details, result)
-        timing(engine.name, engine.channel, "time", result.duration)
-        increment(engine.name, engine.channel, "finished")
+        timing(engine.name, "time", result.duration)
+        increment(engine.name, "finished")
 
         if result.timed_out?
-          timing(engine.name, engine.channel, "time", result.duration)
-          increment(engine.name, engine.channel, "result.error")
-          increment(engine.name, engine.channel, "result.error.timeout")
+          timing(engine.name, "time", result.duration)
+          increment(engine.name, "result.error")
+          increment(engine.name, "result.error.timeout")
         elsif result.maximum_output_exceeded?
-          increment(engine.name, engine.channel, "result.error")
-          increment(engine.name, engine.channel, "result.error.output_exceeded")
+          increment(engine.name, "result.error")
+          increment(engine.name, "result.error.output_exceeded")
         elsif result.exit_status.nonzero?
-          increment(engine.name, engine.channel, "result.error")
+          increment(engine.name, "result.error")
         else
-          increment(engine.name, engine.channel, "result.success")
+          increment(engine.name, "result.success")
         end
       end
 
@@ -31,14 +31,14 @@ module CC
 
       attr_reader :statsd
 
-      def increment(name, channel, metric)
+      def increment(name, metric)
         statsd.increment("engines.#{metric}")
-        statsd.increment("engines.names.#{name}.#{channel}.#{metric}")
+        statsd.increment("engines.names.#{name}.#{metric}")
       end
 
-      def timing(name, channel, metric, ms)
+      def timing(name, metric, ms)
         statsd.timing("engines.#{metric}", ms)
-        statsd.timing("engines.names.#{name}.#{channel}.#{metric}", ms)
+        statsd.timing("engines.names.#{name}.#{metric}", ms)
       end
     end
   end

--- a/spec/cc/analyzer/statsd_container_listener_spec.rb
+++ b/spec/cc/analyzer/statsd_container_listener_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 module CC::Analyzer
   describe StatsdContainerListener do
-    let(:engine) { double(name: "engine", channel: "stable") }
+    let(:engine) { double(name: "engine") }
 
     describe "#started" do
       it "increments a metric in statsd" do


### PR DESCRIPTION
This reverts commit 68a912004984f678cc10666b3fb8504d22a7cab4.

Upstream in builder we fake other container steps as "engines" for
metrics tracking: I don't want to have to redo that many graphs & alerts
for changed metric names, and also don't think this is an appropriate
long term way to model the code. Reverting for now.