### PR TITLE
Docker daemon must be running before brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ for the above invocation:
 
 ```console
 brew tap codeclimate/formulae
+# Make sure your docker daemon is running first
+# before executing the next command.
+# Don't have docker installed? Go here to install it:
+# https://docs.docker.com/engine/installation
 brew install codeclimate
 ```
 


### PR DESCRIPTION
Otherwise, the `make install` step will fail:

```
==> make install
Last 15 lines from /Users/kortaggio/Library/Logs/Homebrew/codeclimate/01.make:
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
Unable to run `docker version', the docker daemon may not be running
id: illegal option -- -
usage: id [user]
       id -A
       id -F [user]
       id -G [-n] [user]
       id -M
       id -P [user]
       id -g [-nr] [user]
       id -p [user]
       id -u [-nr] [user]
bin/check: line 11: [: : integer expression expected
Please ensure `docker version' succeeds and try again
make: *** [install] Error 1
```