### PR TITLE
Update EXCLUDE_PATTERNS to include **/*_test.go

### DIFF
--- a/lib/cc/config/default_adapter.rb
+++ b/lib/cc/config/default_adapter.rb
@@ -18,6 +18,7 @@ module CC
         **/test/
         **/tests/
         **/vendor/
+        **/*_test.go
         **/*.d.ts
       ].freeze
 


### PR DESCRIPTION
Adding the common Go test pattern to our list of default exclude patterns.