### PR TITLE
Update bridge spec

### DIFF
--- a/spec/cc/analyzer/bridge_spec.rb
+++ b/spec/cc/analyzer/bridge_spec.rb
@@ -163,7 +163,7 @@ describe CC::Analyzer::Bridge do
         {
           "enabled" => true,
           "channel" => "stable",
-          "include_paths" => [".codeclimate.yml", "engines.yml"]
+          "include_paths" => match_array([".codeclimate.yml", "engines.yml"])
         },
       )
 
@@ -177,7 +177,7 @@ describe CC::Analyzer::Bridge do
         {
           "enabled" => true,
           "channel" => "stable",
-          "include_paths" => [".codeclimate.yml", "engines.yml"]
+          "include_paths" => match_array([".codeclimate.yml", "engines.yml"])
         },
       )
 


### PR DESCRIPTION
Added ```match_array()``` to ```include_path``` in this spec. Previously failing due to an ordering issue in these arrays.