### PR TITLE
Validate issue remediation points

### DIFF
--- a/lib/cc/analyzer/issue_validations.rb
+++ b/lib/cc/analyzer/issue_validations.rb
@@ -11,6 +11,7 @@ module CC
       autoload :PathIsFileValidation, "cc/analyzer/issue_validations/path_is_file_validation"
       autoload :PathPresenceValidation, "cc/analyzer/issue_validations/path_presence_validation"
       autoload :RelativePathValidation, "cc/analyzer/issue_validations/relative_path_validation"
+      autoload :RemediationPointsValidation, "cc/analyzer/issue_validations/remediation_points_validation"
       autoload :SeverityValidation, "cc/analyzer/issue_validations/severity_validation"
       autoload :TypeValidation, "cc/analyzer/issue_validations/type_validation"
       autoload :Validation, "cc/analyzer/issue_validations/validation"

--- a/lib/cc/analyzer/issue_validations/remediation_points_validation.rb
+++ b/lib/cc/analyzer/issue_validations/remediation_points_validation.rb
@@ -1,0 +1,25 @@
+module CC
+  module Analyzer
+    module IssueValidations
+      class RemediationPointsValidation < Validation
+        def valid?
+          remediation_points.nil? || positive_integer?(remediation_points)
+        end
+
+        def message
+          "Remediation points must be a non-negative integer"
+        end
+
+        private
+
+        def remediation_points
+          @remediation_points ||= object["remediation_points"]
+        end
+
+        def positive_integer?(x)
+          x.is_a?(Integer) && x >= 0
+        end
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/issue_validations/remediation_points_validation_spec.rb
+++ b/spec/cc/analyzer/issue_validations/remediation_points_validation_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+module CC::Analyzer::IssueValidations
+  describe RemediationPointsValidation do
+    describe "#valid?" do
+      context "when points is missing" do
+        it "is valid" do
+          expect(RemediationPointsValidation.new({})).to be_valid
+        end
+      end
+
+      context "when points is 0" do
+        it "is valid" do
+          expect(RemediationPointsValidation.new("remediation_points" => 0)).to be_valid
+        end
+      end
+
+      context "when points is greater than 0" do
+        it "is valid" do
+          expect(RemediationPointsValidation.new("remediation_points" => 42)).to be_valid
+        end
+      end
+
+      context "when points is less than 0" do
+        it "is not valid" do
+          expect(RemediationPointsValidation.new("remediation_points" => -42)).not_to be_valid
+        end
+      end
+
+      context "when points is a float" do
+        it "is not valid" do
+          expect(RemediationPointsValidation.new("remediation_points" => 4.2)).not_to be_valid
+        end
+      end
+
+      context "when points is a string" do
+        it "is not valid" do
+          expect(RemediationPointsValidation.new("remediation_points" => "foo")).not_to be_valid
+        end
+      end
+    end
+
+    describe "#message" do
+      it "is a message" do
+        expect(RemediationPointsValidation.new("remediation_points" => -42).message)
+          .to match("Remediation points must be a non-negative integer")
+      end
+    end
+  end
+end

--- a/spec/cc/analyzer/issue_validations_spec.rb
+++ b/spec/cc/analyzer/issue_validations_spec.rb
@@ -15,6 +15,7 @@ module CC::Analyzer
           IssueValidations::PathIsFileValidation,
           IssueValidations::PathPresenceValidation,
           IssueValidations::RelativePathValidation,
+          IssueValidations::RemediationPointsValidation,
           IssueValidations::SeverityValidation,
           IssueValidations::TypeValidation,
         ]


### PR DESCRIPTION
We introduced a bug in duplication that incorrectly emitted negative
remediation points in some instances. We're fixing that bug, but we
should also validate issues more thoroughly to catch issues like this
earlier & prevent downstream issues.