### PR TITLE
Use the stable branch of duplication by default again

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -43,7 +43,6 @@ credo:
 duplication:
   channels:
     beta: codeclimate/codeclimate-duplication:beta
-    cronopio: codeclimate/codeclimate-duplication:cronopio
     stable: codeclimate/codeclimate-duplication
   description: Structural duplication detection for Ruby, Python, Java, JavaScript, and PHP.
 eslint:

--- a/lib/cc/config/default_adapter.rb
+++ b/lib/cc/config/default_adapter.rb
@@ -4,7 +4,7 @@ module CC
       # intentionally not sorted: we want them in a particular order
       ENGINES = {
         "structure".freeze => "stable".freeze,
-        "duplication".freeze => "cronopio".freeze,
+        "duplication".freeze => "stable".freeze,
       }.freeze
 
       EXCLUDE_PATTERNS = %w[

--- a/spec/cc/analyzer/bridge_spec.rb
+++ b/spec/cc/analyzer/bridge_spec.rb
@@ -31,10 +31,10 @@ describe CC::Analyzer::Bridge do
       )
       expect_engine_run(
         "duplication",
-        { "image" => "duplication:cronopio", "command" => nil },
+        { "image" => "duplication-stable", "command" => nil },
         {
           "enabled" => true,
-          "channel" => "cronopio",
+          "channel" => "stable",
           "include_paths" => match_array(["foo/", ".codeclimate.yml", "engines.yml"]),
         },
       )
@@ -82,10 +82,10 @@ describe CC::Analyzer::Bridge do
       )
       expect_engine_run(
         "duplication",
-        { "image" => "duplication:cronopio", "command" => nil },
+        { "image" => "duplication-stable", "command" => nil },
         {
           "enabled" => true,
-          "channel" => "cronopio",
+          "channel" => "stable",
           "include_paths" => match_array(["foo/", ".codeclimate.yml", "engines.yml"]),
         },
       )
@@ -202,7 +202,6 @@ describe CC::Analyzer::Bridge do
     duplication:
       channels:
         stable: duplication-stable
-        cronopio: "duplication:cronopio"
     foo:
       channels:
         stable: foo-stable

--- a/spec/cc/cli/analyze_spec.rb
+++ b/spec/cc/cli/analyze_spec.rb
@@ -17,7 +17,7 @@ module CC::CLI
         expect_bridge(
           config: match_engines([
             CC::Config::Engine.new("structure", enabled: true, config: { "enabled" => true, "channel" => "stable" }),
-            CC::Config::Engine.new("duplication", enabled: true, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("duplication", enabled: true, channel: "stable", config: { "enabled" => true, "channel" => "stable" }),
           ])
         )
 
@@ -35,7 +35,7 @@ module CC::CLI
         expect_bridge(
           config: match_engines([
             CC::Config::Engine.new("structure", enabled: false, config: { "enabled" => true, "channel" => "stable" }),
-            CC::Config::Engine.new("duplication", enabled: false, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("duplication", enabled: false, channel: "stable", config: { "enabled" => true, "channel" => "stable" }),
             CC::Config::Engine.new("rubocop", enabled: false, channel: "stable", config: { "enabled" => true }),
             CC::Config::Engine.new("eslint", enabled: true, channel: "stable"),
           ])
@@ -57,7 +57,7 @@ module CC::CLI
         expect_bridge(
           config: match_engines([
             CC::Config::Engine.new("structure", enabled: false, config: { "enabled" => true, "channel" => "stable" }),
-            CC::Config::Engine.new("duplication", enabled: false, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("duplication", enabled: false, channel: "stable", config: { "enabled" => true, "channel" => "stable" }),
             CC::Config::Engine.new("rubocop", enabled: true, channel: "stable", config: { "enabled" => true, "config" => "myconfig.yml" }),
           ])
         )
@@ -78,7 +78,7 @@ module CC::CLI
         expect_bridge(
           config: match_engines([
             CC::Config::Engine.new("structure", enabled: false, config: { "enabled" => true, "channel" => "stable" }),
-            CC::Config::Engine.new("duplication", enabled: false, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("duplication", enabled: false, channel: "stable", config: { "enabled" => true, "channel" => "stable" }),
             CC::Config::Engine.new("rubocop", enabled: true, channel: "stable", exclude_patterns: ["foo"], config: { "enabled" => true, "exclude_patterns" => ["foo"] }),
             CC::Config::Engine.new("eslint", enabled: true, channel: "stable"),
           ])
@@ -100,7 +100,7 @@ module CC::CLI
         expect_bridge(
           config: match_engines([
             CC::Config::Engine.new("structure", enabled: false, config: { "enabled" => true, "channel" => "stable" }),
-            CC::Config::Engine.new("duplication", enabled: true, channel: "cronopio", config: { "enabled" => true, "channel" => "cronopio" }),
+            CC::Config::Engine.new("duplication", enabled: true, channel: "stable", config: { "enabled" => true, "channel" => "stable" }),
             CC::Config::Engine.new("rubocop", enabled: true, channel: "foo", exclude_patterns: ["foo"], config: { "enabled" => true, "exclude_patterns" => ["foo"] }),
             CC::Config::Engine.new("eslint", enabled: true, channel: "bar"),
           ])

--- a/spec/cc/cli/engines/install_spec.rb
+++ b/spec/cc/cli/engines/install_spec.rb
@@ -13,7 +13,7 @@ module CC::CLI::Engines
         write_cc_yaml(YAML.dump("plugins" => { "madeup" => true}))
         stub_engine_registry(YAML.dump(
           "structure" => { "channels" => { "stable" => "structure" } },
-          "duplication" => { "channels" => { "cronopio" => "duplication" } },
+          "duplication" => { "channels" => { "stable" => "duplication" } },
           "madeup" => { "channels" => { "stable" => "madeup", "beta" => "madeup:beta" } },
         ))
 
@@ -47,7 +47,7 @@ module CC::CLI::Engines
         write_cc_yaml(YAML.dump("plugins" => { "madeup" => true}))
         stub_engine_registry(YAML.dump(
           "structure" => { "channels" => { "stable" => "structure" } },
-          "duplication" => { "channels" => { "cronopio" => "duplication" } },
+          "duplication" => { "channels" => { "stable" => "duplication" } },
           "madeup" => { "channels" => { "stable" => "madeup" } },
         ))
 

--- a/spec/cc/config/default_adapter_spec.rb
+++ b/spec/cc/config/default_adapter_spec.rb
@@ -7,7 +7,7 @@ describe CC::Config::DefaultAdapter do
     expect(config).to eq(
       "plugins" => {
         "structure" => { "enabled" => true, "channel" => "stable" },
-        "duplication" => { "enabled" => true, "channel" => "cronopio" },
+        "duplication" => { "enabled" => true, "channel" => "stable" },
       },
       "exclude_patterns" => described_class::EXCLUDE_PATTERNS,
     )
@@ -25,7 +25,7 @@ describe CC::Config::DefaultAdapter do
     expect(config).to eq(
       "plugins" => {
         "structure" => { "enabled" => true, "channel" => "beta" },
-        "duplication" => { "enabled" => false, "channel" => "cronopio" },
+        "duplication" => { "enabled" => false, "channel" => "stable" },
         "rubocop" => { "enabled" => true },
       },
       "exclude_patterns" => described_class::EXCLUDE_PATTERNS,
@@ -43,7 +43,7 @@ describe CC::Config::DefaultAdapter do
     expect(config).to eq(
       "plugins" => {
         "structure" => { "enabled" => true, "channel" => "stable" },
-        "duplication" => { "enabled" => true, "channel" => "cronopio" },
+        "duplication" => { "enabled" => true, "channel" => "stable" },
         "rubocop" => { "enabled" => true },
       },
       "exclude_patterns" => ["foo/", "bar/"],


### PR DESCRIPTION
Now that QM fully rolled out, we no longer need the distinction between
QM duplication & non-QM duplication.