### PR TITLE
Rewrite `Net::HTTP` calls to support `http_proxy`

### DIFF
--- a/lib/cc/cli/prepare.rb
+++ b/lib/cc/cli/prepare.rb
@@ -58,7 +58,9 @@ module CC
         ensure_external!(url) unless allow_internal_ips?
 
         uri = URI.parse(url)
-        resp = Net::HTTP.get_response(uri)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        resp = http.get(uri)
         if resp.code == "200"
           write_file(target_path, resp.body)
           say("Wrote #{url} to #{target_path}")

--- a/lib/cc/cli/version_checker.rb
+++ b/lib/cc/cli/version_checker.rb
@@ -66,11 +66,13 @@ module CC
             uri = URI.parse(ENV.fetch("CODECLIMATE_VERSIONS_URL", DEFAULT_VERSIONS_URL))
             uri.query = { version: version, uid: global_config.uuid }.to_query
 
-            request = Net::HTTP::Get.new(uri, "User-Agent" => user_agent)
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.open_timeout = 5
+            http.read_timeout = 5
+            http.ssl_timeout = 5
+            http.use_ssl = uri.scheme == "https"
 
-            Net::HTTP.start(uri.host, uri.port, open_timeout: 5, read_timeout: 5, ssl_timeout: 5, use_ssl: uri.scheme == "https") do |http|
-              http.request(request)
-            end
+            http.get(uri, "User-Agent" => user_agent)
           end
       end
 

--- a/spec/cc/cli/prepare_spec.rb
+++ b/spec/cc/cli/prepare_spec.rb
@@ -21,7 +21,7 @@ YAML
         File.write(Command::CODECLIMATE_YAML, FIXTURE_CONFIG)
         resp = double(code: "200", body: "content")
 
-        stub_resp("example.com", "255.255.255.255", resp)
+        stub_resp("http://example.com/foo.json", "255.255.255.255", resp)
         stdout, stderr = capture_io do
           Prepare.new.run
         end
@@ -35,7 +35,7 @@ YAML
         File.write(Command::CODECLIMATE_YAML, FIXTURE_CONFIG)
         resp = double(code: "200", body: "content")
 
-        stub_resp("example.com", "127.0.0.1", resp)
+        stub_resp("http://example.com/foo.json", "127.0.0.1", resp)
         stdout, stderr, _ = capture_io_and_exit_code do
           Prepare.new.run
         end
@@ -48,7 +48,7 @@ YAML
         File.write(Command::CODECLIMATE_YAML, FIXTURE_CONFIG)
         resp = double(code: "200", body: "content")
 
-        stub_resp("example.com", "127.0.0.1", resp)
+        stub_resp("http://example.com/foo.json", "127.0.0.1", resp)
         stdout, stderr = capture_io do
           Prepare.new(["--allow-internal-ips"]).run
         end
@@ -62,7 +62,7 @@ YAML
         File.write(Command::CODECLIMATE_YAML, FIXTURE_CONFIG)
         resp = double(code: "404", body: "Not Found")
 
-        stub_resp("example.com", "255.255.255.255", resp)
+        stub_resp("http://example.com/foo.json", "255.255.255.255", resp)
         stdout, stderr, _ = capture_io_and_exit_code do
           Prepare.new.run
         end
@@ -70,6 +70,17 @@ YAML
 
         expect(File.exist?("bar.json")).to eq(false)
       end
+    end
+
+    def stub_resp(url, addr, resp)
+      uri = URI(url)
+
+      stub_resolv(uri.host, addr)
+
+      http = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:new).with(uri.host, uri.port).and_return(http)
+      allow(http).to receive(:get).with(uri).and_return(resp)
+      allow(http).to receive(:use_ssl=).with(false)
     end
   end
 end

--- a/spec/cc/cli/runner_spec.rb
+++ b/spec/cc/cli/runner_spec.rb
@@ -5,7 +5,7 @@ module CC::CLI
     before do
       versions_resp = { version: "0.4.1" }
       resp = double(code: "200", body: versions_resp.to_json)
-      stub_resp("versions.codeclimate.com", "255.255.255.255", resp)
+      stub_resp("https://versions.codeclimate.com", "255.255.255.255", resp)
     end
 
     describe ".run" do
@@ -92,6 +92,21 @@ module CC::CLI
           end
         end
       end
+    end
+
+    def stub_resp(url, addr, resp)
+      uri = URI(url)
+
+      stub_resolv(uri.host, addr)
+
+      http = instance_double(Net::HTTP)
+      allow(http).to receive(:open_timeout=)
+      allow(http).to receive(:read_timeout=)
+      allow(http).to receive(:ssl_timeout=)
+      allow(http).to receive(:use_ssl=)
+      allow(http).to receive(:get).and_return(resp)
+
+      allow(Net::HTTP).to receive(:new).and_return(http)
     end
   end
 end

--- a/spec/support/resolv_helpers.rb
+++ b/spec/support/resolv_helpers.rb
@@ -5,11 +5,6 @@ module ResolvHelpers
     allow(dns).to receive(:each_address).
       with(name).and_yield(Resolv::IPv4.create(address))
   end
-
-  def stub_resp(host, addr, resp)
-    stub_resolv(host, addr)
-    allow(Net::HTTP).to receive(:get_response).and_return(resp)
-  end
 end
 
 RSpec.configure do |conf|


### PR DESCRIPTION
This is one piece of support for HTTP proxies with the `fetch` directive in `.codeclimate.yml`.

`Net::HTTP` supports an `http_proxy` environment variable. It's convenient in some respects, but requires that `Net::HTTP` be directly instantiated with `#new`, as opposed to one of the alternate constructors like `.start` or `.get_response`.

For more, please see: https://www.jethrocarr.com/2014/08/14/ruby-nethttp-proxies/