### PR TITLE
Switch upstream Docker image to ruby:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codeclimate/alpine-ruby:b36
+FROM ruby:2.2.10-alpine
 
 WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/
@@ -10,8 +10,12 @@ RUN apk --update add git openssh-client wget build-base && \
     bundle install -j 4 && \
     apk del build-base && rm -fr /usr/share/ri
 
-RUN wget -O /bin/docker https://get.docker.com/builds/Linux/x86_64/docker-1.6.0
-RUN chmod +x /bin/docker
+RUN wget -q -O /tmp/docker.tgz \
+    https://download.docker.com/linux/static/stable/x86_64/docker-17.12.1-ce.tgz && \
+    tar -C /tmp -xzvf /tmp/docker.tgz && \
+    mv /tmp/docker/docker /bin/docker && \
+    chmod +x /bin/docker && \
+    rm -rf /tmp/docker*
 
 COPY . /usr/src/app
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ test_all: image
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  --workdir /usr/src/app \
 	  codeclimate/codeclimate exec rake spec:all spec:benchmark
+
+citest: DOCKER_API_VERSION=$(strip $(shell docker version -f '{{ .Server.ApiVersion }}'))
 citest:
 	docker run \
 	  --entrypoint sh \
@@ -29,6 +31,7 @@ citest:
 	  --env CIRCLE_BRANCH \
 	  --env CIRCLE_SHA1 \
 	  --env CC_TEST_REPORTER_ID \
+	  --env DOCKER_API_VERSION="$(DOCKER_API_VERSION)" \
 	  --volume $(PWD)/.git:/usr/src/app/.git:ro \
 	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  --volume $(CIRCLE_TEST_REPORTS):/usr/src/app/spec/reports \

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "simplecov"
+require "tempfile"
 SimpleCov.start do
   add_filter "/spec/"
 end


### PR DESCRIPTION
We are currently on a 2015 release of Docker, and a relatively-old Ruby 2.2.x, based on [this Dockerfile][1]. 
This change switches to the official/library Ruby image, pinned to the latest/final release of 2.2, 2.2.10.

Something in that change no longer auto-loads the `tempfile` library, so I also added it explicitly to the spec_helper.

The `DOCKER_API_VERSION` environment variable is used to match the spec suite's requests against the CI server's version of the Docker daemon.

[1]: https://github.com/codeclimate/docker-alpine-ruby/blob/master/Dockerfile