### PR TITLE
Use `alpine` instead of `ruby` base image; 100MB vs. 180MB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,7 @@ RUN apk --no-cache upgrade && \
       wget && \
       bundle install -j 4 && \
       apk del build-base && \
-      rm -fr /usr/share/ri && \
-      printf 'export PATH=$PATH:/usr/lib/ruby/gems/2.4.0/bin' \
-      >> /etc/profile.d/rubygems.sh && \
-      chmod +x /etc/profile.d/rubygems.sh
+      rm -fr /usr/share/ri
 
 RUN wget -q -O /tmp/docker.tgz \
     https://download.docker.com/linux/static/stable/x86_64/docker-17.12.1-ce.tgz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
-FROM ruby:2.2.10-alpine
+FROM alpine:3.6
 
 WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
 COPY VERSION /usr/src/app/
 COPY codeclimate.gemspec /usr/src/app/
+ENV CODECLIMATE_DOCKER=1 BUNDLE_SILENCE_ROOT_WARNING=1
 
-RUN apk --update add git openssh-client wget build-base && \
-    bundle install -j 4 && \
-    apk del build-base && rm -fr /usr/share/ri
+RUN apk --no-cache upgrade && \
+      apk --no-cache --update add \
+      build-base \
+      ca-certificates \
+      git \
+      openssh-client \
+      openssl \
+      ruby \
+      ruby-bigdecimal \
+      ruby-bundler \
+      ruby-dev \
+      wget && \
+      bundle install -j 4 && \
+      apk del build-base && \
+      rm -fr /usr/share/ri && \
+      printf 'export PATH=$PATH:/usr/lib/ruby/gems/2.4.0/bin' \
+      >> /etc/profile.d/rubygems.sh && \
+      chmod +x /etc/profile.d/rubygems.sh
 
 RUN wget -q -O /tmp/docker.tgz \
     https://download.docker.com/linux/static/stable/x86_64/docker-17.12.1-ce.tgz && \
@@ -21,5 +37,4 @@ COPY . /usr/src/app
 
 VOLUME /code
 WORKDIR /code
-ENV CODECLIMATE_DOCKER 1
 ENTRYPOINT ["/usr/src/app/bin/codeclimate"]


### PR DESCRIPTION
This also updates the image to Ruby v2.4.4, from v2.2.10.

```
REPOSITORY                                      TAG                 IMAGE ID            CREATED             SIZE
codeclimate/codeclimate                         alpine              e22835391cc0        5 minutes ago       108MB
codeclimate/codeclimate                         latest              670535193ffc        20 hours ago        187MB
codeclimate/codeclimate                         0.73.0              7e8f7e46e8fc        13 days ago         98.3MB
```