### PR TITLE
Use `/bin/bash` shebangs where appropriate.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,9 +7,10 @@ prepare:
 plugins:
   rubocop:
     enabled: true
+    channel: rubocop-0-57
   fixme:
     enabled: true
-    exclude_paths:
+    exclude_patterns:
       - config/engines.yml
   markdownlint:
     enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "simplecov"
-  gem "stackprof"
   gem "rake"
   gem "rspec"
   gem "rspec_junit_formatter"
+  gem "simplecov"
+  gem "stackprof"
 end

--- a/bin/prep-release
+++ b/bin/prep-release
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Open a PR for releasing a new version of this repository.
 #

--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Release a new version of this repository.
 #

--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 invalid_setup() {
   local reason=$1
 
@@ -35,7 +35,7 @@ analysis_file() {
   local skip=0;
   for arg; do
     if [ $skip -gt 0 ]; then
-      skip=$(( $skip - 1 ))
+      skip=$(( skip - 1 ))
     else
       case "$arg" in
         help)
@@ -85,14 +85,15 @@ ln_dir() {
   local source_base="$2"
   local dest_base="$3"
 
-  local path_dir=$(dirname "$path")
+  local path_dir
+  path_dir=$(dirname "$path")
   mkdir -p "$dest_base"/"$path_dir"
 
   if [ "$path_dir" = "." ]; then
     path_dir=""
   fi
 
-  find "$source_base/$path_dir" -depth 1 -type f -iname "*" | while read f; do
+  find "$source_base/$path_dir" -depth 1 -type f -iname "*" | while read -r f; do
     if [ ! -e "$dest_base/$path_dir/$(basename "$f")" ]; then
       ln "$f" "$dest_base/$path_dir/$(basename "$f")"
     fi
@@ -119,10 +120,10 @@ docker_run() {
     "$@"
 }
 
-: ${XDG_CONFIG_HOME:=$HOME/.config}
+: "${XDG_CONFIG_HOME:=$HOME/.config}"
 CC_CONFIG="${CODECLIMATE_CONFIG:-$XDG_CONFIG_HOME/codeclimate/config.yml}"
 
-: ${XDG_CACHE_HOME:=$HOME/.cache}
+: "${XDG_CACHE_HOME:=$HOME/.cache}"
 CC_CACHE="${CODECLIMATE_CACHE:-$XDG_CACHE_HOME/codeclimate/cache.yml}"
 
 for f in "$CC_CONFIG" "$CC_CACHE"; do
@@ -139,12 +140,12 @@ if [ -z "$CODECLIMATE_TMP" ]; then
 fi
 
 if [ ! -t 0 ]; then
-  stdin_stash=$(mktemp "$(dirname "$CC_CACHE")/cc-stdin.XXXXXX")
+  stdin_stash=$(mktemp "$(dirname \"$CC_CACHE\")/cc-stdin.XXXXXX")
   cat <&0 >"$stdin_stash"
   trap "rm '$stdin_stash'" EXIT
 
   if [ -n "$(cat "$stdin_stash")" ]; then
-    tmp_source_dir=$(mktemp -d "$(dirname $CC_CACHE)/cc-code.XXXXXX")
+    tmp_source_dir=$(mktemp -d "$(dirname \"$CC_CACHE\")/cc-code.XXXXXX")
     trap "rm -rf '$tmp_source_dir'" EXIT
 
     chmod a+rx "$tmp_source_dir"
@@ -163,12 +164,12 @@ if [ ! -t 0 ]; then
 fi
 
 if [ -n "$DOCKER_MACHINE_NAME" ] && command -v docker-machine > /dev/null 2>&1; then
-  docker-machine ssh $DOCKER_MACHINE_NAME -- \
+  docker-machine ssh "$DOCKER_MACHINE_NAME" -- \
     test -S /var/run/docker.sock > /dev/null 2>&1 || socket_missing
 
-  docker-machine ssh $DOCKER_MACHINE_NAME -- \
+  docker-machine ssh "$DOCKER_MACHINE_NAME" -- \
     'test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock"' > /dev/null 2>&1 \
-    && invalid_docker_host $(docker-machine ssh $DOCKER_MACHINE_NAME -- 'echo "$DOCKER_HOST"')
+    && invalid_docker_host $(docker-machine ssh "$DOCKER_MACHINE_NAME" -- 'echo "$DOCKER_HOST"')
 else
   test -S /var/run/docker.sock || socket_missing
   test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock" \


### PR DESCRIPTION
This corrects a few issues pointed out by running the gem on itself:
- There was an invalid config line in the `.codeclimate.yml`
- The Gemfile wasn't alphabetized
- Several `bash` scripts were running under `/bin/sh`
- Some variables needed quoting in the bin wrapper script