### PR TITLE
Always pull base image before building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PREFIX ?= /usr/local
 SKIP_ENGINES ?= 0
 
 image:
+	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
 	docker build -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow


### PR DESCRIPTION
This is to ensure images will be built against an updated alpine that's
addressed the security issue discussed at
https://justi.cz/security/2018/09/13/alpine-apk-rce.html.