### PR TITLE
Check if CODECLIMATE_DEBUG is not blank

### DIFF
--- a/lib/cc/cli.rb
+++ b/lib/cc/cli.rb
@@ -20,7 +20,7 @@ require "cc/cli/version"
 module CC
   module CLI
     def self.debug?
-      ENV["CODECLIMATE_DEBUG"]
+      ENV["CODECLIMATE_DEBUG"].present?
     end
 
     def self.logger


### PR DESCRIPTION
This changes the CODECLIMATE_DEBUG check to check if the environment
variable has a non whitespace character in it instead of just checking
if its set or not.

Just checking if it's set or not prevents doing things like `--env "CODECLIMATE_DEBUG=${CODECLIMATE_DEBUG:-$DEBUG}"` (since this results in `CODECLIMATE_DEBUG being set to an empty string).

Context: https://gitlab.com/gitlab-org/security-products/codequality/merge_requests/22

https://github.com/codeclimate/codeclimate/pull/902 and https://github.com/codeclimate/codeclimate/pull/903 should both be merged before this.