### PR TITLE
Bump rubocop ruby target

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: base_rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Lint/Debugger:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ Lint/Debugger:
 
 Style/SpecialGlobalVars:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -84,7 +84,7 @@ module CC
         Result.new(
           container_name: @name,
           duration: duration,
-          exit_status: @status && @status.exitstatus,
+          exit_status: @status&.exitstatus,
           maximum_output_exceeded: @maximum_output_exceeded,
           output_byte_count: output_byte_count,
           stderr: @stderr_io.string,
@@ -93,7 +93,7 @@ module CC
         )
       ensure
         kill_reader_threads
-        t_timeout.kill if t_timeout
+        t_timeout&.kill
       end
 
       def stop(message = nil)
@@ -174,12 +174,12 @@ module CC
       end
 
       def kill_reader_threads
-        @t_out.kill if @t_out
-        @t_err.kill if @t_err
+        @t_out&.kill
+        @t_err&.kill
       end
 
       def kill_wait_thread
-        @t_wait.kill if @t_wait
+        @t_wait&.kill
       end
 
       def reap_running_container(message)

--- a/lib/cc/analyzer/formatters/plain_text_formatter.rb
+++ b/lib/cc/analyzer/formatters/plain_text_formatter.rb
@@ -30,7 +30,7 @@ module CC
           end
 
           print(colorize("Analysis complete! Found #{pluralize(issues.size, "issue")}", :green))
-          if warnings.size > 0
+          unless warnings.empty?
             print(colorize(" and #{pluralize(warnings.size, "warning")}", :green))
           end
           puts(colorize(".", :green))

--- a/lib/cc/analyzer/issue_validations/type_validation.rb
+++ b/lib/cc/analyzer/issue_validations/type_validation.rb
@@ -3,7 +3,7 @@ module CC
     module IssueValidations
       class TypeValidation < Validation
         def valid?
-          type && type.casecmp("issue").zero?
+          type&.casecmp("issue")&.zero?
         end
 
         def message

--- a/lib/cc/analyzer/measurement_validations/name_validation.rb
+++ b/lib/cc/analyzer/measurement_validations/name_validation.rb
@@ -5,7 +5,7 @@ module CC
         REGEX = /^[A-Za-z0-9_\.\-]+$/
 
         def valid?
-          name && name.is_a?(String) && REGEX.match?(name)
+          name&.is_a?(String) && REGEX.match?(name)
         end
 
         def message

--- a/lib/cc/analyzer/measurement_validations/type_validation.rb
+++ b/lib/cc/analyzer/measurement_validations/type_validation.rb
@@ -3,7 +3,7 @@ module CC
     module MeasurementValidations
       class TypeValidation < Validation
         def valid?
-          type && type.casecmp("measurement").zero?
+          type&.casecmp("measurement")&.zero?
         end
 
         def message

--- a/lib/cc/analyzer/measurement_validations/value_validation.rb
+++ b/lib/cc/analyzer/measurement_validations/value_validation.rb
@@ -3,7 +3,7 @@ module CC
     module MeasurementValidations
       class ValueValidation < Validation
         def valid?
-          value && value.is_a?(Numeric)
+          value&.is_a?(Numeric)
         end
 
         def message

--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -204,7 +204,7 @@ module CC::Analyzer
             container
           end
         ensure
-          thread.join if thread
+          thread&.join
         end
 
         def assert_container_stopped


### PR DESCRIPTION
I changed the rubocop target ruby version and made some changes to make `rubocop` happy.

I also disabled the `Style/FrozenStringLiteralComment` cop since there's ~300 offenses and adding the comment to the files isn't as straightforward since it either results in runtime errors or incorrect behavior (like fingerprint mismatches).

This should be merged together with https://github.com/codeclimate/codeclimate/pull/903