### PR TITLE
Add required ruby version to gemspec

### DIFF
--- a/codeclimate.gemspec
+++ b/codeclimate.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.bindir = "bin"
   s.executables = []
 
+  s.required_ruby_version = "~> 2.3"
+
   s.add_dependency "activesupport", ">= 5.1.3", "< 5.2"
   s.add_dependency "tty-spinner", "~> 0.1.0"
   s.add_dependency "highline", "~> 1.7", ">= 1.7.2"


### PR DESCRIPTION
`.ruby-version.yml` uses ruby 2.3. I assume this means the whole repository uses ruby 2.3 so I added it as a requirement to the gemspec.

This should be merged together with https://github.com/codeclimate/codeclimate/pull/902