### PR TITLE
Updated the rubocop engines to include rubocop-0-68, rubocop-0-69 and…

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -199,6 +199,9 @@ rubocop:
     rubocop-0-65: codeclimate/codeclimate-rubocop:rubocop-0-65
     rubocop-0-66: codeclimate/codeclimate-rubocop:rubocop-0-66
     rubocop-0-67: codeclimate/codeclimate-rubocop:rubocop-0-67
+    rubocop-0-68: codeclimate/codeclimate-rubocop:rubocop-0-68
+    rubocop-0-69: codeclimate/codeclimate-rubocop:rubocop-0-69
+    rubocop-0-70: codeclimate/codeclimate-rubocop:rubocop-0-70
   description: A Ruby static code analyzer, based on the community Ruby style guide.
 rubymotion:
   channels:


### PR DESCRIPTION
… rubocop-0-70

This should allow using the following in .codecliate.yml

```
version: "2"
plugins:
  rubocop:
    enabled: true
#    channel: "rubocop-0-68"
#    channel: "rubocop-0-69"
    channel: "rubocop-0-70"
```
Current unable to pull down any image after 67
$ codeclimate engines:install
Pulling docker images.
.....
WARNING: unknown engine <rubocop:rubocop-0-70>

I see rubocop-0-70 at https://hub.docker.com/r/codeclimate/codeclimate-rubocop/tags
