### PR TITLE
Exclude flow-typed directory by default

### DIFF
--- a/lib/cc/config/default_adapter.rb
+++ b/lib/cc/config/default_adapter.rb
@@ -12,6 +12,7 @@ module CC
         db/
         dist/
         features/
+        flow-typed/
         **/node_modules/
         script/
         **/spec/


### PR DESCRIPTION
See [Library Definitions](https://flow.org/en/docs/libdefs/) on flow.org and [flow-typed’s install command](https://github.com/flow-typed/flow-typed/wiki/CLI-Commands-and-Flags#install).