### PR TITLE
Re-add Pylint to the CLI and promote to stable

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -161,6 +161,11 @@ pmd:
   channels:
     stable: codeclimate/codeclimate-pmd
   description: A source code analyzer for Java.
+pylint:
+  channels:
+   beta: codeclimate/codeclimate-pylint:beta
+   stable: codeclimate/codeclimate-pylint
+  description: A linter for Python.
 radon:
   channels:
     stable: codeclimate/codeclimate-radon


### PR DESCRIPTION
We previously removed it in error. Promoting it to stable while I'm at it.