### PR TITLE
Update engines.yml

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -218,6 +218,7 @@ rubocop:
     rubocop-0-78: codeclimate/codeclimate-rubocop:rubocop-0-78
     rubocop-0-79: codeclimate/codeclimate-rubocop:rubocop-0-79
     rubocop-0-80: codeclimate/codeclimate-rubocop:rubocop-0-80
+    rubocop-0-81: codeclimate/codeclimate-rubocop:rubocop-0-81
   description: A Ruby static code analyzer, based on the community Ruby style guide.
 rubymotion:
   channels:


### PR DESCRIPTION
Including already released channel for `rubocop-0-81` (ref. https://github.com/codeclimate/codeclimate-rubocop/tree/channel/rubocop-0-81) to fix `WARNING: unknown engine <rubocop:rubocop-0-81>` message when ran `codeclimate engines:install`. This channel is