### PR TITLE
Remove "Quality" context from circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,7 @@ workflows:
   version: 2
   build_test:
     jobs:
-      - build_test:
-          context: Quality
+      - build_test
 
 notify:
   webhooks:


### PR DESCRIPTION
Removing `Quality` context as it doesn't seem to be actually needed here and its presence prevents PRs from forked repos to be built.