### PR TITLE
add rubocop-0-76-airbnb channel

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -218,6 +218,7 @@ rubocop:
     rubocop-0-74: codeclimate/codeclimate-rubocop:rubocop-0-74
     rubocop-0-75: codeclimate/codeclimate-rubocop:rubocop-0-75
     rubocop-0-76: codeclimate/codeclimate-rubocop:rubocop-0-76
+    rubocop-0-76-airbnb: codeclimate/codeclimate-rubocop:rubocop-0-76-airbnb
     rubocop-0-77: codeclimate/codeclimate-rubocop:rubocop-0-77
     rubocop-0-78: codeclimate/codeclimate-rubocop:rubocop-0-78
     rubocop-0-79: codeclimate/codeclimate-rubocop:rubocop-0-79


### PR DESCRIPTION
Created a new RuboCop channel to support the rubocop-airbnb plugin.  Because the plugin has strict dependencies that don't align with any existing channels I made an independent channel based on the latest version of rubocop-airbnb (3.0.2).

Branch: https://github.com/codeclimate/codeclimate-rubocop/tree/channel/rubocop-0-76-airbnb
Original request issue:https://github.com/codeclimate/codeclimate-rubocop/issues/131