### PR TITLE
Rename workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
 workflows:
   version: 2
-  build_publish:
+  build_test:
     jobs:
       - build_test
       - publish:


### PR DESCRIPTION
Open pull requests are getting hang waiting for required `build_test` workflow. The workflow has been recently renamed to `build_publish` since it includes a releasing step. We need someone with admin access over the repo to re-configure that required build in the repo settings to be `build_publish` until we get that done we can keep things moving by renaming the `build_publish` version to it's previous state. 