### PR TITLE
Add eslint-8 channel for eslint plugin

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -81,6 +81,7 @@ eslint:
     eslint-5: codeclimate/codeclimate-eslint:eslint-5
     eslint-6: codeclimate/codeclimate-eslint:eslint-6
     eslint-7: codeclimate/codeclimate-eslint:eslint-7
+    eslint-8: codeclimate/codeclimate-eslint:eslint-8
   description: A JavaScript/JSX linting utility.
 flog:
   channels:


### PR DESCRIPTION
This PR add `eslint-8` channel for [codeclimate-eslint](https://github.com/codeclimate/codeclimate-eslint) plugin

```yaml
plugins: 
  eslint:
    enabled: true
    channel: "eslint-8"
```

Related PR: https://github.com/codeclimate/codeclimate-eslint/pull/569