### PR TITLE
QUA-498: support arm64/v8 architecture for Mac M1 chips

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ jobs:
       CC_TEST_REPORTER_ID: e70e48da820d9d23eeb2f1fd8c25f8691be05af308dd0ffce8d1ca7e48a5f799
     machine: true
     steps:
+      - run: docker -v
+      - setup_remote_docker:
+          version: 20.10.11
+      - run: docker -v
       - checkout
       - run:
           name: Install test reporter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,11 @@ jobs:
       image: ubuntu-2004:202111-02
     steps:
       - run: docker system info
+      - run: docker buildx ls
+      - run:
+          name: Install buildx emulators
+          command: docker run -it --rm --privileged tonistiigi/binfmt --install all
+      - run: docker buildx ls
       - checkout
       - run:
           name: Install test reporter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,9 @@ jobs:
   build_test:
     environment:
       CC_TEST_REPORTER_ID: e70e48da820d9d23eeb2f1fd8c25f8691be05af308dd0ffce8d1ca7e48a5f799
-    machine: true
+    machine:
+      image: ubuntu-2004:202111-02
     steps:
-      - run: docker -v
-      - setup_remote_docker:
-          version: 20.10.11
       - run: docker -v
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,27 @@ jobs:
   build_test:
     environment:
       CC_TEST_REPORTER_ID: e70e48da820d9d23eeb2f1fd8c25f8691be05af308dd0ffce8d1ca7e48a5f799
-    machine:
-      image: ubuntu-2004:202111-02
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64/v8
+    machine: true
     steps:
       - run: docker -v
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
+
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+
+            mkdir -p ~/.docker/cli-plugins
+
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+            docker buildx install
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
       - checkout
       - run:
           name: Install test reporter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,28 +10,10 @@ jobs:
   build_test:
     environment:
       CC_TEST_REPORTER_ID: e70e48da820d9d23eeb2f1fd8c25f8691be05af308dd0ffce8d1ca7e48a5f799
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64/v8
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202111-02
     steps:
-      - run: docker -v
-      - run:
-          name: Install buildx
-          command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
-
-            curl --output docker-buildx \
-              --silent --show-error --location --fail --retry 3 \
-              "$BUILDX_BINARY_URL"
-
-            mkdir -p ~/.docker/cli-plugins
-
-            mv docker-buildx ~/.docker/cli-plugins/
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-
-            docker buildx install
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+      - run: docker system info
       - checkout
       - run:
           name: Install test reporter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - run: docker system info
       - run: docker buildx ls
+      - run: echo hola
       - run:
           name: Install buildx emulators
           command: docker run -it --rm --privileged tonistiigi/binfmt --install all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ jobs:
       CC_TEST_REPORTER_ID: e70e48da820d9d23eeb2f1fd8c25f8691be05af308dd0ffce8d1ca7e48a5f799
       DOCKER_BUILDKIT: 1
       BUILDX_PLATFORMS: linux/amd64,linux/arm64/v8
-    machine: true
+    machine:
+      image: ubuntu-1604:202007-01
     steps:
       - run: docker -v
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - run: docker system info
       - run: docker buildx ls
-      - run: echo hola
       - run:
           name: Install buildx emulators
           command: docker run -it --rm --privileged tonistiigi/binfmt --install all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.11.6
 
+ARG TARGETARCH
+
 WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
@@ -23,8 +25,11 @@ RUN apk --no-cache upgrade && \
       apk del build-base && \
       rm -fr /usr/share/ri
 
-RUN wget -q -O /tmp/docker.tgz \
-    https://download.docker.com/linux/static/stable/x86_64/docker-17.12.1-ce.tgz && \
+RUN ARCH="$TARGETARCH"; \
+    if [ "$ARCH" = "arm64" ]; then ARCH=aarch64; \
+    elif [ "$ARCH" = "amd64" ]; then ARCH=x86_64; fi; \
+    wget -q -O /tmp/docker.tgz \
+    https://download.docker.com/linux/static/stable/$ARCH/docker-17.12.1-ce.tgz && \
     tar -C /tmp -xzvf /tmp/docker.tgz && \
     mv /tmp/docker/docker /bin/docker && \
     chmod +x /bin/docker && \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PREFIX ?= /usr/local
 SKIP_ENGINES ?= 0
-BUILDX_PLATFORMS ?= linux/amd64,linux/arm64/v8
+BUILDX_PLATFORMS ?= linux/amd64,linux/arm64
 
 image:
 	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SKIP_ENGINES ?= 0
 
 image:
 	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
+	docker buildx create --name multi_arch_builder --use
 	docker buildx build --platform=linux/amd64,linux/arm64/v8 -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@
 
 PREFIX ?= /usr/local
 SKIP_ENGINES ?= 0
+BUILDX_PLATFORMS ?= linux/amd64,linux/arm64/v8
 
 image:
 	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
 	docker buildx create --name multi_arch_builder --use
-	docker buildx build --platform=linux/amd64,linux/arm64/v8 -t codeclimate/codeclimate .
+	docker buildx build --platform=$(BUILDX_PLATFORMS) -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow
 test: image

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SKIP_ENGINES ?= 0
 
 image:
 	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
-	docker build -t codeclimate/codeclimate .
+	docker buildx build --platform=linux/amd64,linux/arm64/v8 -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow
 test: image

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILDX_PLATFORMS ?= linux/amd64,linux/arm64
 image:
 	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
 	docker buildx create --name multi_arch_builder --use
-	docker buildx build --platform=$(BUILDX_PLATFORMS) -t codeclimate/codeclimate .
+	docker buildx build --platform=linux/amd64,linux/arm64 -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow
 test: image


### PR DESCRIPTION
This PR changes the flow of the CI to deploy a multi-architecture image, supporting linux/amd64 and linux/arm64/v8 architectures, to improve the performance on Macbooks with M1 chips.

Additionally, this step should be performed in Code Climate's engines to further increase speeds when running the CLI.

https://codeclimate.atlassian.net/browse/QUA-498