### PR TITLE
QUA-543: Don't include the response body when raising FetchError

### DIFF
--- a/lib/cc/cli/prepare.rb
+++ b/lib/cc/cli/prepare.rb
@@ -65,7 +65,7 @@ module CC
           write_file(target_path, resp.body)
           say("Wrote #{url} to #{target_path}")
         else
-          raise FetchError, "Failed fetching #{url}: code=#{resp.code} body=#{resp.body}"
+          raise FetchError, "Failed fetching #{url}: code=#{resp.code}"
         end
       end
 

--- a/spec/cc/cli/prepare_spec.rb
+++ b/spec/cc/cli/prepare_spec.rb
@@ -67,6 +67,7 @@ YAML
           Prepare.new.run
         end
         expect(stderr).to match("Failed fetching")
+        expect(stderr).not_to match(resp.body)
 
         expect(File.exist?("bar.json")).to eq(false)
       end


### PR DESCRIPTION
### Purpose

When fetching an inaccessible file, we're printing the full response body, which in most of the situations will contain unnecessary data.

```
codeclimate prepare
Failed fetching http://169.254.169.254/latest/meta-data/local-hostnamex: code=404 body=&lt;?xml version=&quot;1.0&quot; encoding=&quot;iso-8859-1&quot;?&gt;
&lt;!DOCTYPE html PUBLIC &quot;-//W3C//DTD XHTML 1.0 Transitional//EN&quot;
&quot;http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd&quot;&gt;
&lt;html xmlns=&quot;http://www.w3.org/1999/xhtml&quot; xml:lang=&quot;en&quot;lang=&quot;en&quot;&gt;
&lt;head&gt;
&lt;title&gt;404 - Not Found&lt;/title&gt;
&lt;/head&gt;
&lt;body&gt;
&lt;h1&gt;404 - Not Found&lt;/h1&gt;
&lt;/body&gt;
&lt;/html&gt;
```

### Related issue

https://codeclimate.atlassian.net/browse/QUA-543

### Description

- Removed the response body from the exception raised so it won't appear when executing the fetch step while the repo building process

