### PR TITLE
QUA-580: Don't analyze files fetched in the prepare step

### DIFF
--- a/lib/cc/cli/prepare.rb
+++ b/lib/cc/cli/prepare.rb
@@ -11,7 +11,6 @@ module CC
   module CLI
     class Prepare < Command
       ARGUMENT_LIST = "[--allow-internal-ips]".freeze
-      FETCHED_PATHS_FILE_PATH = "fetched_paths".freeze
       SHORT_HELP = "Run the commands in your prepare step.".freeze
       HELP = "#{SHORT_HELP}\n" \
         "\n" \
@@ -31,7 +30,6 @@ module CC
 
       def run
         ::CC::Resolv.with_fixed_dns { fetch_all }
-        write_fetched_paths_file unless fetched_paths.empty?
       rescue FetchError, InternalHostError => ex
         fatal(ex.message)
       end

--- a/lib/cc/cli/prepare.rb
+++ b/lib/cc/cli/prepare.rb
@@ -50,10 +50,6 @@ module CC
         @config ||= CC::Config.load
       end
 
-      def fetched_paths
-        @fetched_paths ||= []
-      end
-
       def fetch_all
         fetches.each do |entry|
           fetch(entry.url, entry.path)
@@ -69,7 +65,7 @@ module CC
         resp = http.get(uri)
         if resp.code == "200"
           write_file(target_path, resp.body)
-          say("Wroteee #{url} to #{target_path}")
+          say("Wrote #{url} to #{target_path}")
         else
           raise FetchError, "Failed fetching #{url}: code=#{resp.code}"
         end
@@ -77,16 +73,7 @@ module CC
 
       def write_file(target_path, content)
         FileUtils.mkdir_p(Pathname.new(target_path).parent.to_s)
-        fetched_paths << target_path
         File.write(target_path, content)
-      end
-
-      def write_fetched_paths_file
-        say("Writing fetched paths file")
-        say(FETCHED_PATHS_FILE_PATH)
-        say(fetched_paths)
-        result = File.write(FETCHED_PATHS_FILE_PATH, fetched_paths.join("\n"))
-        say(result)
       end
 
       def ensure_external!(url)

--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -41,10 +41,13 @@ module CC
     end
 
     def self.build(data)
+      prepare_data = Prepare.from_data(data["prepare"])
+      prepare_paths = prepare_data.fetch.entries.map(&:path)
+      exclude_patterns_data = data.fetch("exclude_patterns", DefaultAdapter::EXCLUDE_PATTERNS) + prepare_paths
       new(
         engines: EngineSet.new(data.fetch("plugins", {})).engines,
-        exclude_patterns: data.fetch("exclude_patterns", DefaultAdapter::EXCLUDE_PATTERNS),
-        prepare: Prepare.from_data(data["prepare"]),
+        exclude_patterns: exclude_patterns_data,
+        prepare: prepare_data,
       )
     end
 

--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -40,13 +40,12 @@ module CC
     end
 
     def self.build(data)
-      prepare_data = Prepare.from_data(data["prepare"])
-      prepare_paths = prepare_data.fetch.map(&:path)
-      exclude_patterns_data = data.fetch("exclude_patterns", DefaultAdapter::EXCLUDE_PATTERNS) + prepare_paths
+      prepare = Prepare.from_data(data["prepare"])
+      base_excluded_patterns = data.fetch("exclude_patterns", DefaultAdapter::EXCLUDE_PATTERNS)
       new(
         engines: EngineSet.new(data.fetch("plugins", {})).engines,
-        exclude_patterns: exclude_patterns_data,
-        prepare: prepare_data,
+        exclude_patterns: base_excluded_patterns + prepare.fetch.paths,
+        prepare: prepare,
       )
     end
 

--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -42,7 +42,7 @@ module CC
 
     def self.build(data)
       prepare_data = Prepare.from_data(data["prepare"])
-      prepare_paths = prepare_data.fetch.entries.map(&:path)
+      prepare_paths = prepare_data.fetch.map(&:path)
       exclude_patterns_data = data.fetch("exclude_patterns", DefaultAdapter::EXCLUDE_PATTERNS) + prepare_paths
       new(
         engines: EngineSet.new(data.fetch("plugins", {})).engines,

--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -23,7 +23,8 @@ module CC
       :prepare
 
     attr_writer \
-      :development
+      :development,
+      :exclude_patterns
 
     def self.load
       config =

--- a/lib/cc/config.rb
+++ b/lib/cc/config.rb
@@ -23,8 +23,7 @@ module CC
       :prepare
 
     attr_writer \
-      :development,
-      :exclude_patterns
+      :development
 
     def self.load
       config =

--- a/lib/cc/config/prepare.rb
+++ b/lib/cc/config/prepare.rb
@@ -34,8 +34,8 @@ module CC
           entries.each(&block)
         end
 
-        def map(&block)
-          entries.map(&block)
+        def paths
+          entries.map(&:path)
         end
 
         def merge(other)

--- a/lib/cc/config/prepare.rb
+++ b/lib/cc/config/prepare.rb
@@ -34,6 +34,10 @@ module CC
           entries.each(&block)
         end
 
+        def map(&block)
+          entries.map(&block)
+        end
+
         def merge(other)
           Fetch.new(each.to_a | other.each.to_a)
         end

--- a/spec/cc/config_spec.rb
+++ b/spec/cc/config_spec.rb
@@ -104,6 +104,32 @@ describe CC::Config do
       expect(config.prepare.fetch.each.to_a).to eq([CC::Config::Prepare::Fetch::Entry.new("rubocop.yml")])
     end
 
+    it "adds files fetched in prepare step to exclude_patterns" do
+      yaml = write_cc_yaml(<<-EOYAML)
+      prepare:
+        fetch:
+        - rubocop.yml
+        - url: https://google.com/
+          path: ignore/this.json
+        - url: https://test.com/nopath.yml
+      plugins:
+        rubocop:
+          enabled: true
+      exclude_patterns:
+      - "**/*.rb"
+      - foo/
+      EOYAML
+
+      config = CC::Config.load
+
+      expect(config.exclude_patterns).to include("**/*.rb")
+      expect(config.exclude_patterns).to include("foo/")
+      expect(config.exclude_patterns).to include("rubocop.yml")
+      expect(config.exclude_patterns).to include("ignore/this.json")
+      expect(config.exclude_patterns).to include("nopath.yml")
+      expect(config.prepare.fetch.map(&:path)).to eq(["rubocop.yml", "ignore/this.json", "nopath.yml"])
+    end
+
     it "loads prepare from JSON" do
       yaml = write_cc_json(<<-EOJSON)
       {

--- a/spec/cc/config_spec.rb
+++ b/spec/cc/config_spec.rb
@@ -122,12 +122,24 @@ describe CC::Config do
 
       config = CC::Config.load
 
-      expect(config.exclude_patterns).to include("**/*.rb")
-      expect(config.exclude_patterns).to include("foo/")
-      expect(config.exclude_patterns).to include("rubocop.yml")
-      expect(config.exclude_patterns).to include("ignore/this.json")
-      expect(config.exclude_patterns).to include("nopath.yml")
-      expect(config.prepare.fetch.map(&:path)).to eq(["rubocop.yml", "ignore/this.json", "nopath.yml"])
+      expect(config.exclude_patterns).to match_array(["**/*.rb", "foo/", "rubocop.yml", "ignore/this.json", "nopath.yml"])
+      expect(config.prepare.fetch.paths).to match_array(["rubocop.yml", "ignore/this.json", "nopath.yml"])
+    end
+
+    it "doesn't add any files to exclude_patterns if no prepare step is specified" do
+      yaml = write_cc_yaml(<<-EOYAML)
+      plugins:
+        rubocop:
+          enabled: true
+      exclude_patterns:
+      - "**/*.rb"
+      - foo/
+      EOYAML
+
+      config = CC::Config.load
+
+      expect(config.exclude_patterns).to match_array(["**/*.rb", "foo/"])
+      expect(config.prepare.fetch.paths).to be_empty
     end
 
     it "loads prepare from JSON" do


### PR DESCRIPTION
This PR tells the Analyzer to ignore all files fetched in the `prepare` step of the build.

It does so by going through the prepare config in the `.codeclimate.yml` file and adding the paths to the `exclude_patterns` setting programmatically. This is done so no analysis is run on these files, and they don't appear in the `Code` tab in the user's dashboard.

Example:

In a project with this configuration:

![image](https://user-images.githubusercontent.com/65265704/171681230-f7f57e0f-fe41-49e3-856f-bb9cccc6e0eb.png)

The fetched files are saved in the codebase:

![image](https://user-images.githubusercontent.com/65265704/171681391-13ca8388-d10c-4a2a-b5fd-9f10cf17c3f6.png)

And they don't appear in the Code tab:

![image](https://user-images.githubusercontent.com/65265704/171690217-8716f7f6-cc0f-4f22-9a3b-d77985accdce.png)


https://codeclimate.atlassian.net/browse/QUA-580