### PR TITLE
Include RuboCop 1.30.0 and 1.31.0 in `config/engines.yml` (closes #1054)

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -256,6 +256,8 @@ rubocop:
     rubocop-1-22-2: codeclimate/codeclimate-rubocop:rubocop-1-22-2
     rubocop-1-22-3: codeclimate/codeclimate-rubocop:rubocop-1-22-3
     rubocop-1-23-0: codeclimate/codeclimate-rubocop:rubocop-1-23-0
+    rubocop-1-30-0: codeclimate/codeclimate-rubocop:rubocop-1-30-0
+    rubocop-1-31-0: codeclimate/codeclimate-rubocop:rubocop-1-31-0
   description: A Ruby static code analyzer, based on the community Ruby style guide.
 rubymotion:
   channels:


### PR DESCRIPTION
Adds channels for RuboCop 1.30.0 and 1.31.0 to the engines configuration file.