### PR TITLE
QUA-832: Do not use Ruby 3.1 hash syntax

### DIFF
--- a/lib/cc/analyzer/statsd_container_listener.rb
+++ b/lib/cc/analyzer/statsd_container_listener.rb
@@ -33,12 +33,16 @@ module CC
 
       def increment(engine, metric_name)
         tags = engine_tags(engine)
-        metrics(engine, metric_name).each { |metric| statsd.increment(metric, tags:) }
+        # rubocop:disable Style/HashSyntax
+        metrics(engine, metric_name).each { |metric| statsd.increment(metric, tags: tags) }
+        # rubocop:enable Style/HashSyntax
       end
 
       def timing(engine, metric_name, millis)
         tags = engine_tags(engine)
-        metrics(engine, metric_name).each { |metric| statsd.timing(metric, millis, tags:) }
+        # rubocop:disable Style/HashSyntax
+        metrics(engine, metric_name).each { |metric| statsd.timing(metric, millis, tags: tags) }
+        # rubocop:enable Style/HashSyntax
       end
 
       def metrics(engine, metric_name)


### PR DESCRIPTION
There are some clients of this gem, that don't use ruby 3.1 version, therefore they fail to interpret the hash syntax.