### PR TITLE
!feat(rootless): add podman for rootless

### DIFF
--- a/.circleci/shared.bash
+++ b/.circleci/shared.bash
@@ -12,7 +12,7 @@ function install_hub() {
 
 function login_to_dockerhub() {
   set +x
-  docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
+  podman login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
   set -x
 }
 
@@ -30,10 +30,10 @@ function tag_version() {
 }
 
 function upload_docker_images() {
-  docker build --rm --tag codeclimate/codeclimate .
-  docker push codeclimate/codeclimate:latest
-  docker tag codeclimate/codeclimate "codeclimate/codeclimate:$VERSION"
-  docker push "codeclimate/codeclimate:$VERSION"
+  podman build --rm --tag codeclimate/codeclimate .
+  podman push codeclimate/codeclimate:latest
+  podman tag codeclimate/codeclimate "codeclimate/codeclimate:$VERSION"
+  podman push "codeclimate/codeclimate:$VERSION"
 }
 
 function trigger_hombrew_release() {
@@ -55,7 +55,7 @@ function publish_new_version() {
   # Trigger hombrew release
   trigger_hombrew_release
 
-  # Push docker images
+  # Push podman images
   upload_docker_images
 
   set -x

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 coverage
 spec/reports
 base_rubocop.yml
+.idea
+.vscode

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -15,7 +15,7 @@ this image:
 codeclimate version
 ```
 
-Otherwise, invoke the `docker run` command found in the README.
+Otherwise, invoke the `podman run` command found in the README.
 
 ## Releasing a new version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,17 +18,13 @@ RUN apk --no-cache upgrade && \
       ruby-bigdecimal \
       ruby-bundler \
       ruby-dev \
-      wget && \
+      wget  \
+      podman  \
+      slirp4netns  \
+      fuse-overlayfs && \
       bundle install -j 4 && \
       apk del build-base && \
       rm -fr /usr/share/ri
-
-RUN wget -q -O /tmp/docker.tgz \
-    https://download.docker.com/linux/static/stable/x86_64/docker-20.10.17.tgz && \
-    tar -C /tmp -xzvf /tmp/docker.tgz && \
-    mv /tmp/docker/docker /bin/docker && \
-    chmod +x /bin/docker && \
-    rm -rf /tmp/docker*
 
 COPY . /usr/src/app
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -19,21 +19,21 @@ following:
   the engine's repository (or Issues aren't enabled there), please do report
   your issue here.
 
-- Is this an issue with your Docker installation in general?
+- Is this an issue with your podman installation in general?
 
   While we try hard to smooth over some of this, there will always be
   system-specific issues and edge-cases that we can't work around. If you're
-  unable to use Docker at all (i.e. commands like `docker version`, `docker ps`,
-  or `docker run hello-world` fail), please try other channels (Stack Overflow,
+  unable to use podman at all (i.e. commands like `podman version`, `podman ps`,
+  or `podman run hello-world` fail), please try other channels (Stack Overflow,
   IRC, etc) before reporting the issue here.
 
-- Are you invoking `docker run codeclimate/codeclimate` without other options?
+- Are you invoking `podman run codeclimate/codeclimate` without other options?
 
-  Invoking the CLI directly via `docker run` requires additional options to work
+  Invoking the CLI directly via `podman run` requires additional options to work
   correctly. That's why we ship the `codeclimate` wrapper script. Please take a
-  look at the README for a working `docker run` example.
+  look at the README for a working `podman run` example.
 
-- Are you having trouble using this project as a gem or not via Docker?
+- Are you having trouble using this project as a gem or not via Podman?
 
   While this project is currently available as a gem, that is not a supported
   use-case. It is more an accident of history due to the way our own
@@ -52,7 +52,7 @@ If you'd still like to report this issue, please follow these guidelines:
   you're using, the following commands will update everything:
 
   ```
-  docker pull codeclimate/codeclimate
+  podman pull codeclimate/codeclimate
   codeclimate engines:install
   ```
 
@@ -67,14 +67,14 @@ If you'd still like to report this issue, please follow these guidelines:
   If this output is large, consider using a service like gist.github.com.
 
 - Indicate what you expected to happen and what happened instead
-- Include your operating system, how you run Docker (e.g. Docker Machine) and
-  the version of Docker you're using.
+- Include your operating system, how you run podman (e.g. podman Machine) and
+  the version of podman you're using.
 
   Include the output of the following commands:
 
   ```
   uname -a
-  docker version
+  podman version
   env | grep "^DOCKER_"
   ```
 

--- a/Makefile
+++ b/Makefile
@@ -4,57 +4,53 @@ PREFIX ?= /usr/local
 SKIP_ENGINES ?= 0
 
 image:
-	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
-	docker build -t codeclimate/codeclimate .
+	podman pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
+	podman build -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow
 test: image
-	docker run --rm -it \
+	podman run --rm -it \
 	  --entrypoint bundle \
-	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  --workdir /usr/src/app \
 	  codeclimate/codeclimate exec rspec $(RSPEC_ARGS)
 
 test_all: image
-	docker run --rm -it \
+	podman run --rm -it \
 	  --entrypoint bundle \
-	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  --workdir /usr/src/app \
 	  codeclimate/codeclimate exec rake spec:all spec:benchmark
 
 citest:
-	docker rm codeclimate-cli-test || true
-	docker run \
+	podman rm codeclimate-cli-test || true
+	podman run \
 	  --name codeclimate-cli-test \
 	  --entrypoint sh \
-	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  --workdir /usr/src/app \
 	  codeclimate/codeclimate -c "bundle exec rake spec:all"
 	mkdir -p coverage
-	docker cp codeclimate-cli-test:/usr/src/app/coverage/. ./coverage/
+	podman cp codeclimate-cli-test:/usr/src/app/coverage/. ./coverage/
 	./cc-test-reporter after-build --prefix /usr/src/app/
-	docker run \
+	podman run \
 	  --entrypoint sh \
-	  --volume /var/run/docker.sock:/var/run/docker.sock \
 	  --workdir /usr/src/app \
 	  codeclimate/codeclimate -c "bundle exec rake spec:benchmark"
 
 install:
 	bin/check
-	docker pull codeclimate/codeclimate:latest
+	podman pull codeclimate/codeclimate:latest
 	@[ $(SKIP_ENGINES) -eq 1 ] || \
-	  docker images | \
+	  podman images | \
 	  awk '/codeclimate\/codeclimate-/ { print $$1 }' | \
-	  xargs -n1 docker pull 2>/dev/null || true
+	  xargs -n1 podman pull 2>/dev/null || true
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	install -m 0755 codeclimate-wrapper $(DESTDIR)$(PREFIX)/bin/codeclimate
 
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/codeclimate
-	docker rmi codeclimate/codeclimate:latest
+	podman rmi codeclimate/codeclimate:latest
 
 bundle:
-	docker run --rm \
+	podman run --rm \
 	  --entrypoint bundle \
 	  --volume $(PWD):/usr/src/app \
 	  --workdir /usr/src/app \

--- a/README.md
+++ b/README.md
@@ -7,17 +7,14 @@
 
 `codeclimate` is a command line interface for the Code Climate analysis
 platform. It allows you to run Code Climate engines on your local machine inside
-of Docker containers.
+of podman containers.
 
 ## Prerequisites
 
 The Code Climate CLI is distributed and run as a
-[Docker](https://www.docker.com) image. The engines that perform the actual
-analyses are also Docker images. To support this, you must have Docker installed
-and running locally. We also require that the Docker daemon supports connections
-on the default Unix socket `/var/run/docker.sock`.
-
-On macOS, we recommend using [Docker for Mac](https://docs.docker.com/docker-for-mac/).
+[podman](https://podman.io/) container. The engines that perform the actual
+analyses are also podman images. To support this, you must have podman installed
+and running locally.
 
 ## Installation
 
@@ -44,25 +41,24 @@ cd codeclimate-* && sudo make install
 
 To upgrade to a newer version, just run those steps again.
 
-### Manual Docker invocation
+### Manual podman invocation
 
-The above packages pull the docker image and install a shell script wrapper.
-In some cases you may want to run the docker image directly.
+The above packages pull the podman image and install a shell script wrapper.
+In some cases you may want to run the podman image directly.
 
-To pull the docker image:
+To pull the podman image:
 
 ```console
-docker pull codeclimate/codeclimate
+podman pull codeclimate/codeclimate
 ```
 
 To invoke the CLI via Docker:
 
 ```console
-docker run \
+podman run \
   --interactive --tty --rm \
   --env CODECLIMATE_CODE="$PWD" \
   --volume "$PWD":/code \
-  --volume /var/run/docker.sock:/var/run/docker.sock \
   --volume /tmp/cc:/tmp/cc \
   codeclimate/codeclimate help
 ```
@@ -83,7 +79,7 @@ configuration][docs_advanced_config].
 
 ### Plugin installation
 
-Plugins, or "engines", are the docker images that run analysis tools. We support
+Plugins, or "engines", are the podman images that run analysis tools. We support
 many different plugins, and will only install the ones necessary to run
 analysis. As part of setting up your project, we recommend running `codeclimate
 engines:install` from within your repository before running `codeclimate
@@ -143,7 +139,7 @@ The following is a brief explanation of each available command.
   are currently installed, then installs any missing engines and checks for new images available for existing engines.
 * `engines:list`
   Lists all available engines in the
-  [Code Climate Docker Hub](https://hub.docker.com/u/codeclimate/)
+  [Code Climate podman Hub](https://hub.docker.com/u/codeclimate/)
   .
 * `help`
   Displays a list of commands that can be passed to the Code Climate CLI.
@@ -187,7 +183,7 @@ The releasing process includes;
 
 1. Push new version to rubygems.
 1. Create a new release on Github and an associated tag.
-1. Update docker images:
+1. Update podman images:
   * Push new `latest` image.
   * Push new image with latest version as tag.
 

--- a/bin/check
+++ b/bin/check
@@ -1,17 +1,17 @@
 #!/bin/sh
 
-command -v docker > /dev/null 2>&1 || {
+command -v podman > /dev/null 2>&1 || {
   echo "Unable to find \`docker' on your \$PATH, is it installed?" >&2
   exit 1
 }
 
-docker version | grep -q "Server version\|Server:" || {
-  echo "Unable to run \`docker version', the docker daemon may not be running" >&2
+podman version | grep -q "Server version\|Server:" || {
+  echo "Unable to run \`podman version', the podman daemon may not be running" >&2
 
   if [ "$(id --user)" -eq 0 ]; then
-    echo "Please ensure \`sudo docker version' succeeds and try again" >&2
+    echo "Please ensure \`sudo podman version' succeeds and try again" >&2
   else
-    echo "Please ensure \`docker version' succeeds and try again" >&2
+    echo "Please ensure \`podman version' succeeds and try again" >&2
   fi
 
   exit 1

--- a/bin/release
+++ b/bin/release
@@ -26,10 +26,10 @@ printf "########################################################################
 printf "\n\n"
 rake release
 
-docker build --rm --tag codeclimate/codeclimate .
-docker push codeclimate/codeclimate:latest
-docker tag codeclimate/codeclimate "codeclimate/codeclimate:$version"
-docker push "codeclimate/codeclimate:$version"
+podman build --rm --tag codeclimate/codeclimate .
+podman push codeclimate/codeclimate:latest
+podman tag codeclimate/codeclimate "codeclimate/codeclimate:$version"
+podman push "codeclimate/codeclimate:$version"
 
 (cd ../homebrew-formulae/ && bin/release "$version")
 

--- a/codeclimate-wrapper
+++ b/codeclimate-wrapper
@@ -3,29 +3,19 @@ invalid_setup() {
   local reason=$1
 
   cat >&2 <<EOF
-Your Docker setup does not support the codeclimate wrapper script:
+Your podman setup does not support the codeclimate wrapper script:
 
   > $reason
 
-We require a local Docker daemon that supports communication via the default
+We require a local podman daemon that supports communication via the default
 socket path.
 
-Please use \`docker run' to run the \`codeclimate/codeclimate' image directly.
+Please use \`podman run' to run the \`codeclimate/codeclimate' image directly.
 
 See https://github.com/codeclimate/codeclimate for more details.
 
 EOF
   exit 1
-}
-
-socket_missing() {
-  invalid_setup "/var/run/docker.sock must exist as a Unix domain socket"
-}
-
-invalid_docker_host() {
-  local host=$1
-
-  invalid_setup "invalid DOCKER_HOST=$host, must be unset or unix:///var/run/docker.sock"
 }
 
 analysis_file() {
@@ -103,7 +93,7 @@ ln_dir() {
 }
 
 docker_run() {
-  docker run \
+  podman run \
     --interactive --rm \
     --env CODECLIMATE_CODE \
     --env CODECLIMATE_TMP \
@@ -116,7 +106,6 @@ docker_run() {
     --volume "$CODECLIMATE_TMP":/tmp/cc \
     --volume "$CC_CONFIG":/config.yml \
     --volume "$CC_CACHE":/cache.yml \
-    --volume /var/run/docker.sock:/var/run/docker.sock \
     "$@"
 }
 
@@ -161,19 +150,6 @@ if [ ! -t 0 ]; then
 
     export CODECLIMATE_CODE="$tmp_source_dir"
   fi
-fi
-
-if [ -n "$DOCKER_MACHINE_NAME" ] && command -v docker-machine > /dev/null 2>&1; then
-  docker-machine ssh "$DOCKER_MACHINE_NAME" -- \
-    test -S /var/run/docker.sock > /dev/null 2>&1 || socket_missing
-
-  docker-machine ssh "$DOCKER_MACHINE_NAME" -- \
-    'test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock"' > /dev/null 2>&1 \
-    && invalid_docker_host "$(docker-machine ssh "$DOCKER_MACHINE_NAME" -- 'echo "$DOCKER_HOST"')"
-else
-  test -S /var/run/docker.sock || socket_missing
-  test -n "$DOCKER_HOST" -a "$DOCKER_HOST" != "unix:///var/run/docker.sock" \
-    && invalid_docker_host "$DOCKER_HOST"
 fi
 
 if [ -t 0 ] && [ -t 1 ]; then

--- a/config/engines.yml
+++ b/config/engines.yml
@@ -1,7 +1,7 @@
 # This file lists all the engines available to be run for analysis.
 #
 # Each engine must have `channels` (with a `stable` key) and `description`. The
-# values in `channels` will be passed to `docker run` and so may be any value
+# values in `channels` will be passed to `podman run` and so may be any value
 # appropriate for that (repo/name:tag, image id, etc).
 apexmetrics:
   channels:

--- a/lib/cc/analyzer/container.rb
+++ b/lib/cc/analyzer/container.rb
@@ -4,7 +4,7 @@ require "open3"
 module CC
   module Analyzer
     #
-    # Running an abstract docker container
+    # Running an abstract podman container
     #
     # Input:
     #   - image
@@ -51,7 +51,7 @@ module CC
         started = Time.now
 
         command = docker_run_command(options)
-        Analyzer.logger.debug("docker run: #{command.inspect}")
+        Analyzer.logger.debug("podman run: #{command.inspect}")
         _, out, err, @t_wait = Open3.popen3(*command)
 
         @t_out = read_stdout(out)
@@ -104,7 +104,7 @@ module CC
 
       def docker_run_command(options)
         [
-          "docker", "run",
+          "podman", "run",
           "--name", @name,
           options,
           @image,

--- a/lib/cc/cli/engines/install.rb
+++ b/lib/cc/cli/engines/install.rb
@@ -7,7 +7,7 @@ module CC
         ImagePullFailure = Class.new(StandardError)
 
         def run
-          say "Pulling docker images."
+          say "Pulling podman images."
           pull_docker_images
         end
 
@@ -23,7 +23,7 @@ module CC
 
         def pull_engine(engine)
           metadata = engine_registry.fetch_engine_details(engine)
-          unless system("docker pull #{metadata.image}")
+          unless system("podman pull #{metadata.image}")
             raise ImagePullFailure, "unable to pull image #{metadata.image}"
           end
         rescue EngineRegistry::EngineDetailsNotFoundError

--- a/spec/cc/analyzer/container_spec.rb
+++ b/spec/cc/analyzer/container_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 module CC::Analyzer
   describe Container do
     describe "#run" do
-      it "spawns docker run with the image, name, and options given" do
+      it "spawns podman run with the image, name, and options given" do
         container = Container.new(image: "codeclimate/foo", name: "name")
 
-        expect_spawn(%w[ docker run --name name -i -t codeclimate/foo ])
+        expect_spawn(%w[ podman run --name name -i -t codeclimate/foo ])
 
         container.run(%w[ -i -t ])
       end
@@ -14,7 +14,7 @@ module CC::Analyzer
       it "spawns the command if present" do
         container = Container.new(image: "codeclimate/foo", command: "bar", name: "name")
 
-        expect_spawn(%w[ docker run --name name codeclimate/foo bar ])
+        expect_spawn(%w[ podman run --name name codeclimate/foo bar ])
 
         container.run
       end
@@ -22,7 +22,7 @@ module CC::Analyzer
       it "spawns an array command if given" do
         container = Container.new(image: "codeclimate/foo", command: %w[ bar baz ], name: "name")
 
-        expect_spawn(%w[ docker run --name name codeclimate/foo bar baz ])
+        expect_spawn(%w[ podman run --name name codeclimate/foo bar baz ])
 
         container.run
       end
@@ -34,7 +34,7 @@ module CC::Analyzer
           name: "name",
         )
 
-        expect_spawn(%w[ docker run --name name codeclimate/foo bar baz\ bat ])
+        expect_spawn(%w[ podman run --name name codeclimate/foo bar baz\ bat ])
 
         container.run
       end
@@ -69,8 +69,8 @@ module CC::Analyzer
       describe "stopping containers", slow: true do
         before do
           @name = "codeclimate-container-test"
-          system("docker kill #{@name} &>/dev/null")
-          system("docker rm #{@name} &>/dev/null")
+          system("podman kill #{@name} &>/dev/null")
+          system("podman rm #{@name} &>/dev/null")
         end
 
         it "can be stopped" do
@@ -189,8 +189,8 @@ module CC::Analyzer
               run_container(container)
             ensure
               # Cleanup manually
-              system("docker stop #{name} >/dev/null")
-              system("docker rm #{name} >/dev/null")
+              system("podman stop #{name} >/dev/null")
+              system("podman rm #{name} >/dev/null")
             end
           end
         end
@@ -208,7 +208,7 @@ module CC::Analyzer
         end
 
         def assert_container_stopped
-          expect(`docker ps --quiet --filter name=#{@name}`.strip).to eq ""
+          expect(`podman ps --quiet --filter name=#{@name}`.strip).to eq ""
         end
       end
     end

--- a/spec/cc/cli/engines/install_spec.rb
+++ b/spec/cc/cli/engines/install_spec.rb
@@ -19,9 +19,9 @@ module CC::CLI::Engines
 
         install = Install.new
 
-        expect_system(install, "docker pull structure")
-        expect_system(install, "docker pull duplication")
-        expect_system(install, "docker pull madeup")
+        expect_system(install, "podman pull structure")
+        expect_system(install, "podman pull duplication")
+        expect_system(install, "podman pull madeup")
 
         capture_io { install.run }
       end
@@ -53,9 +53,9 @@ module CC::CLI::Engines
 
         install = Install.new
 
-        expect_system(install, "docker pull structure")
-        expect_system(install, "docker pull duplication")
-        expect_system(install, "docker pull madeup", false)
+        expect_system(install, "podman pull structure")
+        expect_system(install, "podman pull duplication")
+        expect_system(install, "podman pull madeup", false)
 
         capture_io do
           expect { install.run }.to raise_error(Install::ImagePullFailure)


### PR DESCRIPTION
# Description
I wanna try to change the codeclimate image to use the podman rootless version. If we could avoid using the docker daemon, we could run the codeclimate image without root privileges.

## Ref
* https://gitlab.com/gitlab-org/gitlab-foss/-/issues/37980
* https://gitlab.com/gitlab-org/gitlab/-/issues/9784
* https://developers.redhat.com/blog/2019/02/21/podman-and-buildah-for-docker-users
