### PR TITLE
922: Add plugin to engine_registry.rb

### DIFF
--- a/lib/cc/engine_registry.rb
+++ b/lib/cc/engine_registry.rb
@@ -6,7 +6,7 @@ module CC
     DEFAULT_COMMAND = nil
     DEFAULT_MANIFEST_PATH = File.expand_path("../../../config/engines.yml", __FILE__)
 
-    EngineDetails = Struct.new(:image, :command, :description, :memory, :source_library, :channel_versions)
+    EngineDetails = Struct.new(:image, :command, :description, :memory, :source_library, :channel_versions, :plugin)
     EngineDetailsNotFoundError = Class.new(StandardError)
 
     def initialize(path = DEFAULT_MANIFEST_PATH, prefix = nil)
@@ -40,6 +40,7 @@ module CC
           memory_limit(metadata["minimum_memory_limit"]),
           metadata.fetch("source-library", {}),
           metadata.fetch("channel-versions", {}),
+          metadata.fetch("plugin", {}),
         )
       end
     rescue KeyError


### PR DESCRIPTION
We need to add `plugin` to engine_registry.rb file in order to continue working on [this PR](https://github.com/codeclimate/codeclimate-ee/pull/776).