### PR TITLE
Use buildx to build for both amd64 and arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SKIP_ENGINES ?= 0
 
 image:
 	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
-	docker build -t codeclimate/codeclimate .
+	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow
 test: image

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SKIP_ENGINES ?= 0
 
 image:
 	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
-	docker buildx inspect default || docker buildx create --use
+	docker buildx create --use
 	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SKIP_ENGINES ?= 0
 
 image:
 	docker pull "$(shell grep FROM Dockerfile | sed 's/FROM //')"
+	docker buildx inspect default || docker buildx create --use
 	docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t codeclimate/codeclimate .
 
 test: RSPEC_ARGS ?= --tag ~slow


### PR DESCRIPTION
This PR add cross build for arm64 and armV7.

This change should me applied to underlaying analyzer in order to work.

BR,
Nicolas