### PR TITLE
add new channel for brakeman 5.4.1

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -21,6 +21,7 @@ brakeman:
   channels:
     stable: codeclimate/codeclimate-brakeman
     beta: codeclimate/codeclimate-brakeman:beta
+    brakeman-5-4-1: codeclimate-brakeman:brakeman-5-4-1
   description: A static analysis tool which checks Ruby on Rails applications for security vulnerabilities.
 bundler-audit:
   channels:


### PR DESCRIPTION
@fede-moya since we are in the process of fixing the publish step to use a different flow and are doing releases manually, should I disable that in the CircleCI config just so the builds appear green?