### PR TITLE
forgot to add the org to the image reference for brakeman-5-4-1

### DIFF
--- a/config/engines.yml
+++ b/config/engines.yml
@@ -21,7 +21,7 @@ brakeman:
   channels:
     stable: codeclimate/codeclimate-brakeman
     beta: codeclimate/codeclimate-brakeman:beta
-    brakeman-5-4-1: codeclimate-brakeman:brakeman-5-4-1
+    brakeman-5-4-1: codeclimate/codeclimate-brakeman:brakeman-5-4-1
   description: A static analysis tool which checks Ruby on Rails applications for security vulnerabilities.
 bundler-audit:
   channels:


### PR DESCRIPTION
When you try to use the new channel it will say it cannot find the image, forgot that we needed to add the prefix for the org in the image.