### PR TITLE
ci: support linux/arm64 platform in docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,11 +46,9 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@v4
 
       - name: Log into registry ${{ env.REGISTRY }}
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -67,7 +65,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push by digest
-        if: github.event_name != 'pull_request'
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -79,7 +76,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate Artifact Attestation
-        if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -87,14 +83,12 @@ jobs:
           push-to-registry: true
 
       - name: Export digest
-        if: ${{ github.event_name != 'pull_request' }}
         run: |
           mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
@@ -115,7 +109,6 @@ jobs:
           merge-multiple: true
 
       - name: Log into registry ${{ env.REGISTRY }}
-        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
Currently, Docker images are built only for the `linux/amd64` platform.

This can be confirmed from the job logs:  
https://github.com/qltysh/qlty/actions/runs/14731801479/job/41347654076

<img width="780" alt="image" src="https://github.com/user-attachments/assets/1263b111-1eda-44ad-bc42-dec0f75f2384" />

To avoid relying on emulation on the host side (when running containers from this image), it's preferable to build native images for other platforms as well.

This PR adds support for the `linux/arm64` platform.