### PR TITLE
style: Improve warning messages

### DIFF
--- a/qlty-check/src/planner.rs
+++ b/qlty-check/src/planner.rs
@@ -288,8 +288,8 @@ impl Planner {
             eprintln!(
                 "{} The `{}` field in qlty.toml is deprecated. Please use `{}` instead.",
                 style("WARNING:").bold().yellow(),
-                style("override").bold(),
-                style("triage").bold()
+                style("[[override]]").bold(),
+                style("[[triage]]").bold()
             );
 
             for issue_override in &self.config.overrides {

--- a/qlty-cli/tests/cmd/check/ignore.stderr
+++ b/qlty-cli/tests/cmd/check/ignore.stderr
@@ -1,2 +1,2 @@
-WARNING: The `ignore` field in qlty.toml is deprecated. Please use `exclude` or `exclude_patterns` instead.
+WARNING: The `[[ignore]]` field in qlty.toml is deprecated. Please use `[[exclude]]` or `exclude_patterns` instead.
 ✖ 2 issues

--- a/qlty-cli/tests/cmd/check/negated_ignore.stderr
+++ b/qlty-cli/tests/cmd/check/negated_ignore.stderr
@@ -1,2 +1,2 @@
-WARNING: The `ignore` field in qlty.toml is deprecated. Please use `exclude` or `exclude_patterns` instead.
+WARNING: The `[[ignore]]` field in qlty.toml is deprecated. Please use `[[exclude]]` or `exclude_patterns` instead.
 ✖ 4 issues

--- a/qlty-cli/tests/cmd/check/override.stderr
+++ b/qlty-cli/tests/cmd/check/override.stderr
@@ -1,2 +1,2 @@
-WARNING: The `override` field in qlty.toml is deprecated. Please use `triage` instead.
+WARNING: The `[[override]]` field in qlty.toml is deprecated. Please use `[[triage]]` instead.
 ✖ 1 issue

--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -165,8 +165,8 @@ impl Builder {
             eprintln!(
                 "{} The `{}` field in qlty.toml is deprecated. Please use `{}` or `{}` instead.",
                 style("WARNING:").bold().yellow(),
-                style("ignore").bold(),
-                style("exclude").bold(),
+                style("[[ignore]]").bold(),
+                style("[[exclude]]").bold(),
                 style("exclude_patterns").bold()
             );
 
@@ -175,7 +175,7 @@ impl Builder {
                     eprintln!(
                         "{} The use of `{}` field in qlty.toml without {} is no longer supported. Skipping ignore without file_patterns.",
                         style("WARNING:").bold().yellow(),
-                        style("ignore").bold(),
+                        style("[[ignore]]").bold(),
                         style("file_patterns").bold()
                     );
                     continue;


### PR DESCRIPTION
This pull request updates the handling of deprecated fields in `qlty.toml` configuration files to use double square bracket notation (`[[field]]`) for improved clarity and consistency. The changes affect both the codebase and test files, ensuring warnings and error messages reflect the updated syntax.


### Updates to deprecated field handling:

* **Code updates for warning messages:**
  - Updated the warning in `impl Planner` in `qlty-check/src/planner.rs` to use `[[override]]` and `[[triage]]` instead of `override` and `triage`.
  - Modified warnings in `impl Builder` in `qlty-config/src/config/builder.rs` to use `[[ignore]]` and `[[exclude]]` instead of `ignore` and `exclude`. [[1]](diffhunk://#diff-235d134f83f12c8c9d4358b9175027f7f2c0e241fca1e5825e0e34d3313f9dc2L168-R169) [[2]](diffhunk://#diff-235d134f83f12c8c9d4358b9175027f7f2c0e241fca1e5825e0e34d3313f9dc2L178-R178)

* **Test updates for deprecated fields:**
  - Adjusted test files (`qlty-cli/tests/cmd/check/ignore.stderr`, `qlty-cli/tests/cmd/check/negated_ignore.stderr`, and `qlty-cli/tests/cmd/check/override.stderr`) to reflect the new `[[field]]` syntax in warnings. [[1]](diffhunk://#diff-0bcc2083c04d9df53b740afb5f19ddfacaf814e21a20cd46f8fa5fda1df95458L1-R1) [[2]](diffhunk://#diff-7c0a1d5e51e65ec34de72c8c6b40c21720f9e80dfaa0f615e7c7d4b8603e3942L1-R1) [[3]](diffhunk://#diff-adda5eb01e9f54c9677811de6fe77d440023f9aae5f4586c9d6af63924f8e85fL1-R1)

Part of qltysh/cloud#5925