### PR TITLE
perf: lower issue batch size

### DIFF
--- a/qlty-cli/src/export/analysis.rs
+++ b/qlty-cli/src/export/analysis.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use tracing::info;
 
 const INVOCATION_BATCH_SIZE: usize = 200;
-const ISSUES_BATCH_SIZE: usize = 5000;
+const ISSUES_BATCH_SIZE: usize = 2000;
 const MESSAGES_BATCH_SIZE: usize = 10000;
 const STATS_BATCH_SIZE: usize = 10000;
 


### PR DESCRIPTION
The issues insert is still showing up as using 1GB of RAM on average, which is manageable but we'd prefer to trade some extra time inserting to save RAM