### PR TITLE
fix: Prioritize explicitly stated version during merge

### DIFF
--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -862,7 +862,7 @@ mod test {
             },
             EnabledPlugin {
                 name: "plugin1".to_string(),
-                prefix: Some("".to_string()),
+                prefix: None,
                 version: "known_good".to_string(),
                 drivers: vec!["driver2".to_string()],
                 ..Default::default()


### PR DESCRIPTION
Right now if the version is not stated in the last EnabledPlugin block for a given plugin it will default to "known_good" instead of something explicitly stated in a previous source.


So for example if a shared source had
```
[[plugin]]
name = "b"
version = "2.0.0"
mode = "block"
```
And you add the following to your qlty.toml
```
[[plugin]]
name = "b"
mode = "comment"
```
The version for plugin b will default to known good version instead of "2.0.0" which does not seem desirable.

This PR prioritizes explicitly stated version "2.0.0" in this example over "known_good" which gets set by default when no version is provided.