### PR TITLE
chore: Reapply "build(deps): bump actions-rust-lang/setup-rust-toolchain from 1.14.1 to 1.15.0"

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a
+        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
         with:
           toolchain: stable
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a
+        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
         with:
           toolchain: stable
 

--- a/.github/workflows/cli_integration.yml
+++ b/.github/workflows/cli_integration.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a
+        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
         with:
           toolchain: stable
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -72,7 +72,7 @@ jobs:
         if: contains(matrix.os, 'windows')
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a
+        uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39
         with:
           toolchain: stable
 


### PR DESCRIPTION
This reverts commit aa2d416ab13d8a28068e94e3b49c68b6d2d22549.

That commit was a failed attempt to one-shot fix failing builds.