### PR TITLE
fix: prettier success_codes

### DIFF
--- a/qlty-plugins/plugins/linters/prettier/plugin.toml
+++ b/qlty-plugins/plugins/linters/prettier/plugin.toml
@@ -39,7 +39,7 @@ package_file_candidate_filters = ["prettier"]
 script = "prettier --config ${config_file} -w ${target}"
 runs_from = { type = "tool_directory" }
 batch_by = "config_file"
-success_codes = [0, 2]
+success_codes = [0] # https://prettier.io/docs/cli#exit-codes
 cache_results = true
 output = "rewrite"
 batch = true


### PR DESCRIPTION
2 was in the prettier driver success_codes, which it should not be https://prettier.io/docs/cli#exit-codes