### PR TITLE
chore: pin cargo-chef to 0.1.72-rust-latest for Docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest AS chef
+FROM lukemathwalker/cargo-chef:0.1.72-rust-latest AS chef
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
We have suspicion that the 0.1.73 release of cargo-chef may have introduced issues with glibc compatibility on Linux ARM64.