### PR TITLE
fix: Fix broken URLs

### DIFF
--- a/qlty-config/src/config/builder.rs
+++ b/qlty-config/src/config/builder.rs
@@ -19,7 +19,7 @@ const QLTY_TOML_PARSE_ERROR: &str = r#"There was an error reading your qlty.toml
 
 Please make sure you are using the latest version of the CLI with `qlty upgrade`.
 
-For more information, please visit: https://qlty.io/docs/troubleshooting/qlty-toml-parse-error"#;
+For more information, please visit: https://docs.qlty.sh/qlty-toml"#;
 
 pub struct Builder;
 

--- a/qlty-config/src/sources/source.rs
+++ b/qlty-config/src/sources/source.rs
@@ -16,7 +16,7 @@ Please make sure you are using the latest version of the CLI with `qlty upgrade`
 
 Also, please make sure you are specifying the latest source tag in your qlty.toml file.
 
-For more information, please visit: https://qlty.io/docs/troubleshooting/source-parse-error"#;
+For more information, please visit: https://docs.qlty.sh/cli/debugging"#;
 
 /// Configure proxy options for git operations
 ///


### PR DESCRIPTION
The URL was pointing to qlty.io which doesn't exist, however even after changing that, the target pages also no longer exist, resulting in a redirect to the debugging page. This commit changes the URLs to a new place to help the end user.

---

Note that I'm not sure if these URls are the "right" place for the user to land. If you have better suggestions, please let me know.