### PR TITLE
build: Only push merged image to registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,9 +72,8 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=${{ github.event_name != 'pull_request' }},name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Currently, the workflow creates broken container images because it pushes incomplete images to the registry by tag.

This change will only push the digests to the registry in the build jobs and only allow the merge job to push the tags.

See Docker [documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/) for reference.