### PR TITLE
fix: allow lockfile issues for brakeman

### DIFF
--- a/qlty-config/default.toml
+++ b/qlty-config/default.toml
@@ -138,6 +138,9 @@ globs = [
 ]
 interpreters = ["jruby", "rbx", "rake", "macruby", "ruby"]
 
+[file_types.gemfile_lock]
+globs = ["**/Gemfile.lock"]
+
 [file_types.rust]
 globs = ["*.rs"]
 

--- a/qlty-plugins/plugins/linters/brakeman/fixtures/__snapshots__/basic_nested_v6.1.2.shot
+++ b/qlty-plugins/plugins/linters/brakeman/fixtures/__snapshots__/basic_nested_v6.1.2.shot
@@ -27,6 +27,46 @@ exports[`linter=brakeman fixture=basic_nested version=6.1.2 1`] = `
 end",
       "tool": "brakeman",
     },
+    {
+      "category": "CATEGORY_VULNERABILITY",
+      "documentationUrl": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "level": "LEVEL_HIGH",
+      "location": {
+        "path": "nested/Gemfile.lock",
+        "range": {
+          "endColumn": 1,
+          "endLine": 105,
+          "startColumn": 1,
+          "startLine": 105,
+        },
+      },
+      "message": "Support for Rails 5.2.8.1 ended on 2022-06-01.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "BRAKE0120",
+      "snippet": "    rails (5.2.8.1)",
+      "snippetWithContext": "      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.14.1)
+      racc (~> 1.4)
+    puma (4.3.12)
+      nio4r (~> 2.0)
+    racc (1.6.2)
+    rack (2.2.6.2)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (5.2.8.1)
+      actioncable (= 5.2.8.1)
+      actionmailer (= 5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activerecord (= 5.2.8.1)
+      activestorage (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      bundler (>= 1.3.0)",
+      "tool": "brakeman",
+    },
   ],
 }
 `;

--- a/qlty-plugins/plugins/linters/brakeman/fixtures/__snapshots__/basic_nested_v6.2.2.shot
+++ b/qlty-plugins/plugins/linters/brakeman/fixtures/__snapshots__/basic_nested_v6.2.2.shot
@@ -27,6 +27,46 @@ exports[`linter=brakeman fixture=basic_nested version=6.2.2 1`] = `
 end",
       "tool": "brakeman",
     },
+    {
+      "category": "CATEGORY_VULNERABILITY",
+      "documentationUrl": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "level": "LEVEL_HIGH",
+      "location": {
+        "path": "nested/Gemfile.lock",
+        "range": {
+          "endColumn": 1,
+          "endLine": 105,
+          "startColumn": 1,
+          "startLine": 105,
+        },
+      },
+      "message": "Support for Rails 5.2.8.1 ended on 2022-06-01.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "BRAKE0120",
+      "snippet": "    rails (5.2.8.1)",
+      "snippetWithContext": "      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.14.1)
+      racc (~> 1.4)
+    puma (4.3.12)
+      nio4r (~> 2.0)
+    racc (1.6.2)
+    rack (2.2.6.2)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (5.2.8.1)
+      actioncable (= 5.2.8.1)
+      actionmailer (= 5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activerecord (= 5.2.8.1)
+      activestorage (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      bundler (>= 1.3.0)",
+      "tool": "brakeman",
+    },
   ],
 }
 `;

--- a/qlty-plugins/plugins/linters/brakeman/fixtures/__snapshots__/basic_v6.1.2.shot
+++ b/qlty-plugins/plugins/linters/brakeman/fixtures/__snapshots__/basic_v6.1.2.shot
@@ -27,6 +27,46 @@ exports[`linter=brakeman fixture=basic version=6.1.2 1`] = `
 end",
       "tool": "brakeman",
     },
+    {
+      "category": "CATEGORY_VULNERABILITY",
+      "documentationUrl": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "level": "LEVEL_HIGH",
+      "location": {
+        "path": "Gemfile.lock",
+        "range": {
+          "endColumn": 1,
+          "endLine": 105,
+          "startColumn": 1,
+          "startLine": 105,
+        },
+      },
+      "message": "Support for Rails 5.2.8.1 ended on 2022-06-01.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "BRAKE0120",
+      "snippet": "    rails (5.2.8.1)",
+      "snippetWithContext": "      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.14.1)
+      racc (~> 1.4)
+    puma (4.3.12)
+      nio4r (~> 2.0)
+    racc (1.6.2)
+    rack (2.2.6.2)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (5.2.8.1)
+      actioncable (= 5.2.8.1)
+      actionmailer (= 5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activerecord (= 5.2.8.1)
+      activestorage (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      bundler (>= 1.3.0)",
+      "tool": "brakeman",
+    },
   ],
 }
 `;

--- a/qlty-plugins/plugins/linters/brakeman/fixtures/__snapshots__/basic_v6.2.2.shot
+++ b/qlty-plugins/plugins/linters/brakeman/fixtures/__snapshots__/basic_v6.2.2.shot
@@ -27,6 +27,46 @@ exports[`linter=brakeman fixture=basic version=6.2.2 1`] = `
 end",
       "tool": "brakeman",
     },
+    {
+      "category": "CATEGORY_VULNERABILITY",
+      "documentationUrl": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "level": "LEVEL_HIGH",
+      "location": {
+        "path": "Gemfile.lock",
+        "range": {
+          "endColumn": 1,
+          "endLine": 105,
+          "startColumn": 1,
+          "startLine": 105,
+        },
+      },
+      "message": "Support for Rails 5.2.8.1 ended on 2022-06-01.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "BRAKE0120",
+      "snippet": "    rails (5.2.8.1)",
+      "snippetWithContext": "      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.14.1)
+      racc (~> 1.4)
+    puma (4.3.12)
+      nio4r (~> 2.0)
+    racc (1.6.2)
+    rack (2.2.6.2)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (5.2.8.1)
+      actioncable (= 5.2.8.1)
+      actionmailer (= 5.2.8.1)
+      actionpack (= 5.2.8.1)
+      actionview (= 5.2.8.1)
+      activejob (= 5.2.8.1)
+      activemodel (= 5.2.8.1)
+      activerecord (= 5.2.8.1)
+      activestorage (= 5.2.8.1)
+      activesupport (= 5.2.8.1)
+      bundler (>= 1.3.0)",
+      "tool": "brakeman",
+    },
   ],
 }
 `;

--- a/qlty-plugins/plugins/linters/brakeman/plugin.toml
+++ b/qlty-plugins/plugins/linters/brakeman/plugin.toml
@@ -3,7 +3,7 @@ config_version = "0"
 [plugins.definitions.brakeman]
 runtime = "ruby"
 package = "brakeman"
-file_types = ["ruby"]
+file_types = ["ruby", "gemfile_lock"]
 latest_version = "7.1.0"
 known_good_version = "6.2.2"
 version_command = "brakeman --version"


### PR DESCRIPTION
Brakeman also raises issues about various packages pointing to `Gemfile.lock`, but since `Gemfile.lock` is not part of the `ruby` file type, it gets filtered out. Instead of adding it to the existing `ruby` type which can have affects on other plugins, I think best would be to keep it as a separate file type