### PR TITLE
Extract and change merging logic when calculating total coverage

### DIFF
--- a/qlty-coverage/src/lib.rs
+++ b/qlty-coverage/src/lib.rs
@@ -3,6 +3,7 @@ mod env;
 pub mod export;
 pub mod formats;
 pub mod git;
+mod merging;
 pub mod parser;
 pub mod print;
 pub mod publish;

--- a/qlty-coverage/src/merging.rs
+++ b/qlty-coverage/src/merging.rs
@@ -1,0 +1,327 @@
+use qlty_types::tests::v1::FileCoverage;
+
+/// Merges file coverages with duplicate paths in-place.
+///
+/// When multiple FileCoverage entries share the same path, they are merged into a single entry
+/// following these rules:
+/// - All hits arrays are first truncated to the length of the shortest array
+/// - If both hits[i] are non-negative (>= 0), sum them
+/// - If any hits[i] is negative, result is -1
+pub fn merge_file_coverages(file_coverages: &mut Vec<FileCoverage>) {
+    if file_coverages.len() <= 1 {
+        return;
+    }
+
+    // Step 1: Sort by path to group duplicates together
+    file_coverages.sort_by(|a, b| a.path.cmp(&b.path));
+
+    // Step 2: Merge consecutive entries with same path
+    let mut write_idx = 0;
+    let mut read_idx = 0;
+
+    while read_idx < file_coverages.len() {
+        // Find range of entries with same path
+        let start_idx = read_idx;
+        let current_path = file_coverages[start_idx].path.clone();
+
+        while read_idx < file_coverages.len() && file_coverages[read_idx].path == current_path {
+            read_idx += 1;
+        }
+        let end_idx = read_idx;
+
+        // Merge range [start_idx..end_idx) into position write_idx
+        if end_idx - start_idx == 1 {
+            // Single entry, just move it if needed
+            if write_idx != start_idx {
+                file_coverages.swap(write_idx, start_idx);
+            }
+        } else {
+            // Multiple entries need merging
+            merge_hits_at_index(file_coverages, start_idx, end_idx, write_idx);
+        }
+
+        write_idx += 1;
+    }
+
+    // Step 3: Truncate vector to remove merged entries
+    file_coverages.truncate(write_idx);
+}
+
+fn merge_hits_at_index(
+    file_coverages: &mut [FileCoverage],
+    start_idx: usize,
+    end_idx: usize,
+    target_idx: usize,
+) {
+    // Find the minimum length across all hits arrays in this range
+    let min_len = file_coverages[start_idx..end_idx]
+        .iter()
+        .map(|fc| fc.hits.len())
+        .min()
+        .unwrap_or(0);
+
+    // Merge all entries pairwise: merge first two, then merge result with third, etc.
+    // Start with the first array truncated to min_len
+    let mut merged_hits = file_coverages[start_idx].hits[..min_len].to_vec();
+
+    for fc in &file_coverages[(start_idx + 1)..end_idx] {
+        merged_hits = merge_two_hits_arrays(&merged_hits, &fc.hits[..min_len]);
+    }
+
+    // Move first entry to target position and update its hits
+    if target_idx != start_idx {
+        file_coverages.swap(target_idx, start_idx);
+    }
+    file_coverages[target_idx].hits = merged_hits;
+}
+
+/// Merges two hits arrays following these rules:
+/// - If both hits[i] are non-negative (>= 0), sum them
+/// - If either hits[i] is negative, result is -1
+/// - Arrays should already be truncated to the same length before calling this
+fn merge_two_hits_arrays(a: &[i64], b: &[i64]) -> Vec<i64> {
+    let len = a.len().min(b.len());
+    let mut result = Vec::with_capacity(len);
+
+    for i in 0..len {
+        let val_a = a[i];
+        let val_b = b[i];
+
+        let merged = if val_a >= 0 && val_b >= 0 {
+            val_a + val_b
+        } else {
+            -1
+        };
+
+        result.push(merged);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_file_coverage(path: &str, hits: Vec<i64>) -> FileCoverage {
+        FileCoverage {
+            path: path.to_string(),
+            hits,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_no_duplicates() {
+        let mut coverages = vec![
+            create_file_coverage("src/a.rs", vec![1, 2, 3]),
+            create_file_coverage("src/b.rs", vec![4, 5, 6]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 2);
+        assert_eq!(coverages[0].path, "src/a.rs");
+        assert_eq!(coverages[0].hits, vec![1, 2, 3]);
+        assert_eq!(coverages[1].path, "src/b.rs");
+        assert_eq!(coverages[1].hits, vec![4, 5, 6]);
+    }
+
+    #[test]
+    fn test_single_duplicate_both_non_negative_sum() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![1, 2, 0]),
+            create_file_coverage("src/main.rs", vec![3, 0, 4]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, vec![4, 2, 4]); // [1+3, 2+0, 0+4]
+    }
+
+    #[test]
+    fn test_either_negative_results_in_negative_one() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![1, -1, 5]),
+            create_file_coverage("src/main.rs", vec![2, 3, -1]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, vec![3, -1, -1]); // [1+2, either neg, either neg]
+    }
+
+    #[test]
+    fn test_both_negative_results_in_negative_one() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![-1, -1]),
+            create_file_coverage("src/main.rs", vec![-1, -1]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, vec![-1, -1]);
+    }
+
+    #[test]
+    fn test_different_array_sizes_use_existing_elements() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![1, 2, 3, 4]),
+            create_file_coverage("src/main.rs", vec![5, 6]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, vec![6, 8]); // Truncated to min length (2), then [1+5, 2+6]
+    }
+
+    #[test]
+    fn test_shorter_array_first() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![1, 2]),
+            create_file_coverage("src/main.rs", vec![3, 4, 5, 6]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, vec![4, 6]); // Truncated to min length (2), then [1+3, 2+4]
+    }
+
+    #[test]
+    fn test_three_way_merge() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![1, 0, 0]),
+            create_file_coverage("src/main.rs", vec![0, 2, 0]),
+            create_file_coverage("src/main.rs", vec![0, 0, 3]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, vec![1, 2, 3]); // [1+0+0, 0+2+0, 0+0+3]
+    }
+
+    #[test]
+    fn test_three_way_merge_with_negatives() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![1, 2, 3]),
+            create_file_coverage("src/main.rs", vec![4, -1, 6]),
+            create_file_coverage("src/main.rs", vec![7, 8, 9]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, vec![12, -1, 18]); // [1+4+7, 2+(-1)+8, 3+6+9]
+    }
+
+    #[test]
+    fn test_multiple_files_with_duplicates() {
+        let mut coverages = vec![
+            create_file_coverage("src/a.rs", vec![1, 2]),
+            create_file_coverage("src/b.rs", vec![3, 4]),
+            create_file_coverage("src/a.rs", vec![5, 6]),
+            create_file_coverage("src/c.rs", vec![7, 8]),
+            create_file_coverage("src/b.rs", vec![9, 10]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 3);
+
+        // Results should be sorted by path
+        assert_eq!(coverages[0].path, "src/a.rs");
+        assert_eq!(coverages[0].hits, vec![6, 8]); // [1+5, 2+6]
+
+        assert_eq!(coverages[1].path, "src/b.rs");
+        assert_eq!(coverages[1].hits, vec![12, 14]); // [3+9, 4+10]
+
+        assert_eq!(coverages[2].path, "src/c.rs");
+        assert_eq!(coverages[2].hits, vec![7, 8]);
+    }
+
+    #[test]
+    fn test_empty_vector() {
+        let mut coverages: Vec<FileCoverage> = vec![];
+        merge_file_coverages(&mut coverages);
+        assert_eq!(coverages.len(), 0);
+    }
+
+    #[test]
+    fn test_single_entry() {
+        let mut coverages = vec![create_file_coverage("src/main.rs", vec![1, 2, 3])];
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_empty_hits_arrays() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![]),
+            create_file_coverage("src/main.rs", vec![]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, Vec::<i64>::new());
+    }
+
+    #[test]
+    fn test_one_empty_one_with_data() {
+        let mut coverages = vec![
+            create_file_coverage("src/main.rs", vec![]),
+            create_file_coverage("src/main.rs", vec![1, 2, 3]),
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].path, "src/main.rs");
+        assert_eq!(coverages[0].hits, Vec::<i64>::new()); // Truncated to min length (0)
+    }
+
+    #[test]
+    fn test_preserves_other_fields() {
+        let mut coverages = vec![
+            FileCoverage {
+                path: "src/main.rs".to_string(),
+                hits: vec![1, 2],
+                build_id: "build-123".to_string(),
+                blob_oid: "abc123".to_string(),
+                ..Default::default()
+            },
+            FileCoverage {
+                path: "src/main.rs".to_string(),
+                hits: vec![3, 4],
+                build_id: "build-456".to_string(),
+                blob_oid: "def456".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        merge_file_coverages(&mut coverages);
+
+        assert_eq!(coverages.len(), 1);
+        assert_eq!(coverages[0].hits, vec![4, 6]);
+        // Should preserve fields from the first entry
+        assert_eq!(coverages[0].build_id, "build-123");
+        assert_eq!(coverages[0].blob_oid, "abc123");
+    }
+}

--- a/qlty-coverage/src/publish/metrics.rs
+++ b/qlty-coverage/src/publish/metrics.rs
@@ -1,6 +1,6 @@
+use crate::merging::merge_file_coverages;
 use qlty_types::tests::v1::FileCoverage;
 use serde::Serialize;
-use std::collections::HashMap;
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct CoverageMetrics {
@@ -13,48 +13,15 @@ pub struct CoverageMetrics {
 
 impl CoverageMetrics {
     pub fn calculate(file_coverages: &[FileCoverage]) -> Self {
-        // Group file coverages by path
-        let mut path_hits_map: HashMap<String, Vec<Vec<i64>>> = HashMap::new();
-
-        // First collect all the file coverages by path
-        for file_coverage in file_coverages {
-            path_hits_map
-                .entry(file_coverage.path.clone())
-                .or_default()
-                .push(file_coverage.hits.clone());
-        }
-
-        // Then combine the hits arrays for each path by summing at each index
-        let mut combined_hits: HashMap<String, Vec<i64>> = HashMap::new();
-
-        for (path, hits_arrays) in path_hits_map {
-            // Skip if there are no hits arrays
-            if hits_arrays.is_empty() {
-                continue;
-            }
-
-            // Find the maximum length to handle arrays of different lengths
-            let max_len = hits_arrays.iter().map(|arr| arr.len()).max().unwrap_or(0);
-
-            // Create a combined array initialized with zeros
-            let mut combined = vec![0; max_len];
-
-            // Sum the hits at each index
-            for hits_array in hits_arrays {
-                for (i, &hit) in hits_array.iter().enumerate() {
-                    combined[i] += hit;
-                }
-            }
-
-            combined_hits.insert(path, combined);
-        }
-
         let mut covered_lines = 0;
         let mut uncovered_lines = 0;
         let mut omitted_lines = 0;
 
-        for hits in combined_hits.values() {
-            for &hit in hits {
+        let mut merged_file_coverages = file_coverages.to_vec();
+        merge_file_coverages(&mut merged_file_coverages);
+
+        for file_coverage in &merged_file_coverages {
+            for &hit in &file_coverage.hits {
                 if hit > 0 {
                     covered_lines += 1;
                 } else if hit == 0 {
@@ -137,52 +104,6 @@ mod tests {
         assert_eq!(metrics.omitted_lines, 1);
         assert_eq!(metrics.total_lines, 7);
         assert_eq!(metrics.coverage_percentage, 3.0 / 6.0 * 100.0);
-    }
-
-    #[test]
-    fn test_combining_coverages_same_file() {
-        let file_coverage1 = FileCoverage {
-            path: "src/main.rs".to_string(),
-            hits: vec![1, 0, 0],
-            ..Default::default()
-        };
-
-        let file_coverage2 = FileCoverage {
-            path: "src/main.rs".to_string(),
-            hits: vec![0, 1, 2],
-            ..Default::default()
-        };
-
-        let metrics = CoverageMetrics::calculate(&[file_coverage1, file_coverage2]);
-
-        assert_eq!(metrics.covered_lines, 3);
-        assert_eq!(metrics.uncovered_lines, 0);
-        assert_eq!(metrics.omitted_lines, 0);
-        assert_eq!(metrics.total_lines, 3);
-        assert_eq!(metrics.coverage_percentage, 100.0);
-    }
-
-    #[test]
-    fn test_combining_coverages_different_lengths() {
-        let file_coverage1 = FileCoverage {
-            path: "src/main.rs".to_string(),
-            hits: vec![1, 0, 0],
-            ..Default::default()
-        };
-
-        let file_coverage2 = FileCoverage {
-            path: "src/main.rs".to_string(),
-            hits: vec![0, 1, 2, 3, 0],
-            ..Default::default()
-        };
-
-        let metrics = CoverageMetrics::calculate(&[file_coverage1, file_coverage2]);
-
-        assert_eq!(metrics.covered_lines, 4);
-        assert_eq!(metrics.uncovered_lines, 1);
-        assert_eq!(metrics.omitted_lines, 0);
-        assert_eq!(metrics.total_lines, 5);
-        assert_eq!(metrics.coverage_percentage, 4.0 / 5.0 * 100.0);
     }
 
     #[test]


### PR DESCRIPTION
Originally I tried to create a behavior-neutral PR which introduced an new opt-in behavior: merging coverage reports for the same file on the client. However, I discovered that there was some pre-existing coverage merging behavior that I wasn't aware of before raising the question of how and/or if to do this in a behavior neutral way.

I've opened this PR to change the pre-existing logic for merging coverage reports which is used solely for calculating total coverage numbers and is not behavior neutral. However, I believe this change will cause the total coverage numbers calculated on the server to match those reported in the client in more cases.

The specific decisions regarding merging that are tricky is when you have incompatible hits arrays -- differing lengths for example, or when one hits array reports coverable and another reports uncovered/covered. That's specifically what's in question here and this PR matches the decisions we make when performing server side merging.

- Should client side merging logic match what we perform on the server?
- Should the merging logic used to calculate total coverage numbers match the client side (not yet performed) merging logic which will return file coverages unique by path?