### PR TITLE
feat: add attestations for installer scripts

### DIFF
--- a/.github/workflows/release_installer.yml
+++ b/.github/workflows/release_installer.yml
@@ -8,8 +8,9 @@ on:
       - installer/install.*
 permissions:
   actions: write
+  attestations: write
   contents: read
-  "id-token": "write"
+  id-token: write
 jobs:
   test:
     uses: ./.github/workflows/installer_test.yml
@@ -21,6 +22,12 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+      - name: Generate attestations for installer scripts
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a
+        with:
+          subject-path: |
+            installer/install.sh
+            installer/install.ps1
       - name: Setup AWS CLI
         uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838
         with:


### PR DESCRIPTION
## Summary
- Add build provenance attestations for installer scripts (`install.sh` and `install.ps1`)
- Add `attestations: write` permission to the `release_installer` workflow
- Attestations are generated after checkout and before S3 upload

## Context
Currently, only the binary archives (`.tar.xz`, `.zip`) are attested. This PR extends attestations to the installer scripts themselves, completing the chain of trust for the entire distribution pipeline.

## Benefits
- Users can verify installer authenticity with `gh attestation verify install.sh --owner qltysh`
- Protection against compromised distribution channels
- Compliance with supply chain security best practices

## Testing
- All existing tests pass
- Changes are limited to GitHub Actions workflow configuration
- Will be verified when workflow runs on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)