### PR TITLE
ci: Add --ignore-scripts flag to npm install commands

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -101,5 +101,5 @@ jobs:
       - name: Run plugins tests
         working-directory: plugins
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm test

--- a/.github/workflows/update_linter_versions.yml
+++ b/.github/workflows/update_linter_versions.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Dependencies
         working-directory: qlty-plugins/plugins
-        run: npm install
+        run: npm install --ignore-scripts
 
       - name: 📦 Install qlty CLI
         run: "curl https://qlty.sh/install.sh | bash"


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` flag to npm ci/install commands in CI workflows

## Rationale
This prevents npm from executing any lifecycle scripts (including postinstall) during dependency installation, reducing the attack surface from malicious packages.

## Test plan
- [ ] CI workflows still pass
- [ ] Dependencies are installed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)