### PR TITLE
fix: move write permissions from workflow to job level (zizmor excessive-permissions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,13 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  attestations: write
-  id-token: write
 jobs:
   compile:
     if: github.event.commits && github.event.commits[0] && github.event.commits[0].author.name == 'qlty-releases[bot]' && startsWith(github.event.commits[0].message, 'Release ')
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -48,7 +48,9 @@ jobs:
           toolchain: stable
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@16edcff251c6bb06f6878981359f84b77b28e7e2
+        uses: taiki-e/install-action@b4b80945859e8ef89a9732a0f46499a443b196fe # v2
+        with:
+          tool: cargo-llvm-cov
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0

--- a/.github/workflows/cli_integration.yml
+++ b/.github/workflows/cli_integration.yml
@@ -15,9 +15,7 @@ on:
       - .github/workflows/cli_integration.yml
 
 permissions:
-  actions: write
   contents: read
-  id-token: write
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,12 +20,14 @@ env:
 
 permissions:
   contents: read
-  packages: write
-  attestations: write
-  id-token: write
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +109,10 @@ jobs:
           retention-days: 1
 
   merge:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' }}
     needs:

--- a/.github/workflows/release_installer.yml
+++ b/.github/workflows/release_installer.yml
@@ -7,15 +7,16 @@ on:
     paths:
       - installer/install.*
 permissions:
-  actions: write
-  attestations: write
   contents: read
-  id-token: write
 jobs:
   test:
     uses: ./.github/workflows/installer_test.yml
   release:
     needs: test
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -13,7 +13,6 @@ on:
         type: string
 permissions:
   contents: read
-  "id-token": "write"
 jobs:
   test:
     name: ${{ matrix.runner }}
@@ -36,6 +35,9 @@ jobs:
         shell: sh
   promote:
     needs: test
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Setup AWS CLI


### PR DESCRIPTION
## Summary

- Fixes 11 zizmor `excessive-permissions` errors by moving write permissions from workflow level to job level in GitHub Actions workflows
- Updates `cli.yml` install-action hash and adds explicit tool parameter

### Files changed:
- `.github/workflows/build.yml` - Moved `attestations: write`, `id-token: write` to `compile` job
- `.github/workflows/cli.yml` - Updated install-action hash, added explicit `tool` parameter
- `.github/workflows/cli_integration.yml` - Removed unused `actions: write`, `id-token: write`
- `.github/workflows/docker.yml` - Added permissions to `build` job and `merge` job
- `.github/workflows/release_installer.yml` - Moved `attestations: write`, `id-token: write` to `release` job, removed `actions: write`
- `.github/workflows/release_promote.yml` - Moved `id-token: write` to `promote` job, fixed inconsistent quoting

## Test plan

- [ ] Verify zizmor check passes with fewer errors
- [ ] Ensure CI workflows still function correctly after permission changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)