### PR TITLE
fix: handle empty stdin in pre-push hook gracefully

### DIFF
--- a/qlty-cli/src/commands/check.rs
+++ b/qlty-cli/src/commands/check.rs
@@ -26,6 +26,17 @@ static LOOKING_GLASS: Emoji<'_, '_> = Emoji("🔍  ", "");
 static THINKING: Emoji<'_, '_> = Emoji("🤔  ", "");
 static FORMATTING: Emoji<'_, '_> = Emoji("📝  ", "");
 
+/// Represents stdin input for Git hook upstream computation.
+///
+/// This is separate from `--trigger=pre-push` which can be used manually without stdin.
+/// `--upstream-from-pre-push` specifically means "read upstream from Git hook stdin".
+enum GitHookStdin {
+    /// Not reading upstream from Git hook stdin
+    None,
+    /// Git hook stdin content (already validated as non-empty)
+    Content(String),
+}
+
 #[derive(Args, Clone, Debug)]
 pub struct Check {
     /// Check all files, not just changed
@@ -137,7 +148,19 @@ impl Check {
         let workspace = Workspace::require_initialized()?;
         workspace.fetch_sources()?;
 
-        let settings = self.build_settings(&workspace)?;
+        let git_hook_stdin = if self.upstream_from_pre_push {
+            match Self::read_pre_push_stdin()? {
+                Some(content) => GitHookStdin::Content(content),
+                None => {
+                    info!("No commits to push, skipping checks");
+                    return CommandSuccess::ok();
+                }
+            }
+        } else {
+            GitHookStdin::None
+        };
+
+        let settings = self.build_settings(&workspace, git_hook_stdin)?;
 
         let mut counter = 0;
         let mut dirty = true;
@@ -283,7 +306,11 @@ impl Check {
         Ok(())
     }
 
-    fn build_settings(&self, workspace: &Workspace) -> Result<Settings> {
+    fn build_settings(
+        &self,
+        workspace: &Workspace,
+        git_hook_stdin: GitHookStdin,
+    ) -> Result<Settings> {
         let mut settings = Settings::default();
         settings.root = Workspace::assert_within_git_directory()?;
         settings.verbose = self.verbose as usize;
@@ -296,7 +323,7 @@ impl Check {
         settings.progress = !self.no_progress;
         settings.formatters = !self.no_formatters;
         settings.filters = CheckFilter::from_optional_list(self.filter.clone());
-        settings.upstream = self.compute_upstream(workspace)?;
+        settings.upstream = self.compute_upstream(workspace, git_hook_stdin)?;
         settings.level = self.level;
         settings.fail_level = if self.no_fail {
             None
@@ -323,48 +350,56 @@ impl Check {
         Ok(settings)
     }
 
-    fn compute_upstream(&self, workspace: &Workspace) -> Result<Option<String>> {
-        if self.upstream_from_pre_push {
-            let mut buffer = String::new();
-            io::stdin().read_to_string(&mut buffer)?;
+    fn compute_upstream(
+        &self,
+        workspace: &Workspace,
+        git_hook_stdin: GitHookStdin,
+    ) -> Result<Option<String>> {
+        match git_hook_stdin {
+            GitHookStdin::None => Ok(self.upstream.clone()),
+            GitHookStdin::Content(buffer) => {
+                // https://git-scm.com/docs/githooks#_pre_push
+                //
+                // <local-ref> SP <local-object-name> SP <remote-ref> SP <remote-object-name> LF
+                let parts: Vec<&str> = buffer.split_whitespace().collect();
+                let remote_commit_id = parts.get(3).unwrap_or(&"");
 
-            if buffer.trim().is_empty() {
-                info!("No commits to push, checking uncommitted changes");
-                return Ok(None);
-            }
+                if remote_commit_id.is_empty() {
+                    bail!("Missing remote commit ID from Git pre-push input")
+                }
 
-            // https://git-scm.com/docs/githooks#_pre_push
-            //
-            // <local-ref> SP <local-object-name> SP <remote-ref> SP <remote-object-name> LF
-            let parts: Vec<&str> = buffer.split_whitespace().collect();
-            let remote_commit_id = parts.get(3).unwrap_or(&"");
-
-            if remote_commit_id.is_empty() {
-                bail!("Missing remote commit ID from Git pre-push input")
-            }
-
-            // When pushing a new branch, the remote object name is 40 zeros.
-            // In this case, revert to the upstream branch.
-            if remote_commit_id.chars().all(|c| c == '0') {
-                Ok(self.upstream.clone())
-            } else {
-                // Check if the remote commit ID exists in the repository
-                let remote_commit_present_locally =
-                    workspace.repo()?.revparse_single(remote_commit_id).is_ok();
-
-                // If the remote commit ID is not present locally, revert to the upstream branch.
-                if remote_commit_present_locally {
-                    Ok(Some(remote_commit_id.to_string()))
-                } else {
-                    warn!(
-                        "Remote commit ID {} is not present locally, reverting to upstream branch",
-                        remote_commit_id
-                    );
+                // When pushing a new branch, the remote object name is 40 zeros.
+                // In this case, revert to the upstream branch.
+                if remote_commit_id.chars().all(|c| c == '0') {
                     Ok(self.upstream.clone())
+                } else {
+                    // Check if the remote commit ID exists in the repository
+                    let remote_commit_present_locally =
+                        workspace.repo()?.revparse_single(remote_commit_id).is_ok();
+
+                    // If the remote commit ID is not present locally, revert to the upstream branch.
+                    if remote_commit_present_locally {
+                        Ok(Some(remote_commit_id.to_string()))
+                    } else {
+                        warn!(
+                            "Remote commit ID {} is not present locally, reverting to upstream branch",
+                            remote_commit_id
+                        );
+                        Ok(self.upstream.clone())
+                    }
                 }
             }
+        }
+    }
+
+    fn read_pre_push_stdin() -> Result<Option<String>> {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer)?;
+
+        if buffer.trim().is_empty() {
+            Ok(None)
         } else {
-            Ok(self.upstream.clone())
+            Ok(Some(buffer))
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix pre-push hook error when there are no commits to push
- When running `git push` with no new commits, Git invokes the pre-push hook with empty stdin
- Previously this caused: `ERROR > Missing remote commit ID from Git pre-push input`
- Now we detect empty stdin and skip checks gracefully with an info log

## Test plan

- [ ] Push when up-to-date with remote → should succeed silently
- [ ] Push new commits → should run checks as normal
- [ ] Push new branch → should work as before (falls back to upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)