### PR TITLE
fix: add file path context to coverage parsing errors

### DIFF
--- a/qlty-coverage/src/parser.rs
+++ b/qlty-coverage/src/parser.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use qlty_types::tests::v1::FileCoverage;
 use std::path::Path;
 
@@ -22,8 +22,10 @@ pub use simplecov::Simplecov;
 
 pub trait Parser {
     fn parse_file(&self, path: &Path) -> Result<Vec<FileCoverage>> {
-        let text = std::fs::read_to_string(path)?;
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read coverage file: {}", path.display()))?;
         self.parse_text(&text)
+            .with_context(|| format!("Failed to parse coverage file: {}", path.display()))
     }
 
     fn parse_text(&self, text: &str) -> Result<Vec<FileCoverage>>;


### PR DESCRIPTION
## Summary

- Added file path context to coverage parsing errors using `anyhow::Context`
- Errors from `Parser::parse_file` now include which file failed to read or parse
- Makes debugging coverage issues much easier when processing multiple files

## Problem

When parsing multiple coverage files and one failed, the error message didn't indicate which file caused the problem. For example, an error like "No such file or directory" gave no indication of the problematic path.

## Solution

Wrapped the file read and parse operations with `.with_context()` to include the file path in error messages:
- "Failed to read coverage file: /path/to/file"
- "Failed to parse coverage file: /path/to/file"

## Test plan

- [x] Ran `cargo check` - passes
- [x] Ran `qlty fmt` - no formatting changes needed
- [x] Ran `qlty check --fix --level=low` - no issues
- [x] Ran `cargo test --package qlty-coverage` - all 197 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)