### PR TITLE
fix: Handle JaCoCo reports with no packages

### DIFF
--- a/qlty-coverage/src/parser/jacoco.rs
+++ b/qlty-coverage/src/parser/jacoco.rs
@@ -10,6 +10,7 @@ use tracing::debug;
 #[derive(Debug, Deserialize)]
 #[serde(rename = "report")]
 struct JacocoSource {
+    #[serde(default)]
     package: Vec<Package>,
 }
 
@@ -382,5 +383,13 @@ mod tests {
                 .join("be/apo/basic/rest/EchoService.java")
                 .to_string_lossy()
         );
+    }
+
+    #[test]
+    fn jacoco_empty_report_no_packages() {
+        let input = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd"><report name="emptyModule"><sessioninfo id="test-session" start="1764819063102" dump="1764819063595"/></report>"#;
+
+        let parsed_results = Jacoco::new().parse_text(input).unwrap();
+        assert!(parsed_results.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Add `#[serde(default)]` to the `package` field in `JacocoSource` so that JaCoCo reports without any packages parse correctly
- Add test case for empty JaCoCo reports (modules with no classes)

## Test plan
- [x] Added unit test `jacoco_empty_report_no_packages` that verifies empty reports parse without error
- [x] All existing JaCoCo tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)