### PR TITLE
feat(coverage): add Git tracking awareness for coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ flamegraph.svg
 /.rustfmt.toml
 /.yamllint.yaml
 tmp/
+
+docs/developer/plans

--- a/qlty-cli/tests/cmd/coverage/basic.stderr
+++ b/qlty-cli/tests/cmd/coverage/basic.stderr
@@ -26,6 +26,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: [CWD]/
+
     Auto-path fixing: Enabled
     1 unique code file path
     All code files in the coverage data were found on disk (count: 1).

--- a/qlty-cli/tests/cmd/coverage/discover_java_src_dirs.stderr
+++ b/qlty-cli/tests/cmd/coverage/discover_java_src_dirs.stderr
@@ -31,6 +31,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: [CWD]/
+
     Auto-path fixing: Enabled
     1 unique code file path
     All code files in the coverage data were found on disk (count: 1).

--- a/qlty-cli/tests/cmd/coverage/files_exist.stderr
+++ b/qlty-cli/tests/cmd/coverage/files_exist.stderr
@@ -31,6 +31,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: [CWD]/
+
     Auto-path fixing: Enabled
     WARNING: 1 code file path was excluded by configuration rules
 

--- a/qlty-cli/tests/cmd/coverage/ignore_patterns.stderr
+++ b/qlty-cli/tests/cmd/coverage/ignore_patterns.stderr
@@ -26,6 +26,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: [CWD]/
+
     Auto-path fixing: Enabled
     2 unique code file paths
     2 paths are missing on disk (100.0%)

--- a/qlty-cli/tests/cmd/coverage/json.stderr
+++ b/qlty-cli/tests/cmd/coverage/json.stderr
@@ -26,6 +26,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: [CWD]/
+
     1 unique code file path
     1 path is missing on disk (100.0%)
 

--- a/qlty-cli/tests/cmd/coverage/override_commit_time.stderr
+++ b/qlty-cli/tests/cmd/coverage/override_commit_time.stderr
@@ -27,6 +27,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: [CWD]/
+
     Auto-path fixing: Enabled
     1 unique code file path
     1 path is missing on disk (100.0%)

--- a/qlty-cli/tests/cmd/coverage/override_git_tag.stderr
+++ b/qlty-cli/tests/cmd/coverage/override_git_tag.stderr
@@ -27,6 +27,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: /Users/bhelmkamp/p/qltysh/qlty/
+
     Auto-path fixing: Enabled
     1 unique code file path
     1 path is missing on disk (100.0%)

--- a/qlty-cli/tests/cmd/coverage/overrides.stderr
+++ b/qlty-cli/tests/cmd/coverage/overrides.stderr
@@ -31,6 +31,8 @@ WARNING: --transform-add-prefix is deprecated, use --add-prefix instead
 
  COVERAGE DATA 
 
+    Git Repository: [CWD]/
+
     1 unique code file path
     1 path is missing on disk (100.0%)
 

--- a/qlty-cli/tests/cmd/coverage/publish_validate.stderr
+++ b/qlty-cli/tests/cmd/coverage/publish_validate.stderr
@@ -26,6 +26,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: [CWD]/
+
     Auto-path fixing: Enabled
     2 unique code file paths
     1 path is missing on disk (50.0%)

--- a/qlty-cli/tests/cmd/without_git/basic_coverage.stderr
+++ b/qlty-cli/tests/cmd/without_git/basic_coverage.stderr
@@ -28,6 +28,8 @@ https://qlty.sh/d/coverage
 
  COVERAGE DATA 
 
+    Git Repository: not found
+
     1 unique code file path
     1 path is missing on disk (100.0%)
 

--- a/qlty-coverage/src/git.rs
+++ b/qlty-coverage/src/git.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context as _, Result};
 use git2::Repository;
-use tracing::{error, warn};
+use std::collections::HashSet;
+use tracing::{error, info, warn};
 
 #[derive(Debug, Clone)]
 pub struct CommitMetadata {
@@ -67,4 +68,99 @@ pub fn retrieve_commit_metadata() -> Result<Option<CommitMetadata>> {
         author_email,
         commit_message,
     }))
+}
+
+#[derive(Debug, Clone)]
+pub struct GitTrackingInfo {
+    pub repo_root: String,
+    pub tracked_files: HashSet<String>,
+}
+
+impl GitTrackingInfo {
+    pub fn is_tracked(&self, relative_path: &str) -> bool {
+        let normalized = relative_path.replace('\\', "/");
+        self.tracked_files.contains(&normalized)
+    }
+}
+
+pub fn get_git_tracking_info() -> Option<GitTrackingInfo> {
+    if std::env::var("QLTY_COVERAGE_TESTING_WITHOUT_GIT").is_ok() {
+        return None;
+    }
+
+    let repo = match Repository::discover(".") {
+        Ok(repo) => repo,
+        Err(_) => {
+            info!("No Git repository found");
+            return None;
+        }
+    };
+
+    let repo_root = match repo.workdir() {
+        Some(path) => match path.to_str() {
+            Some(s) => s.to_string(),
+            None => {
+                warn!("Git repository path is not valid UTF-8");
+                return None;
+            }
+        },
+        None => {
+            warn!("Git repository has no working directory (bare repository)");
+            return None;
+        }
+    };
+
+    let index = match repo.index() {
+        Ok(index) => index,
+        Err(err) => {
+            warn!("Failed to read Git index: {:?}", err);
+            return None;
+        }
+    };
+
+    let mut tracked_files = HashSet::new();
+    for entry in index.iter() {
+        if let Ok(path) = std::str::from_utf8(&entry.path) {
+            tracked_files.insert(path.to_string());
+        }
+    }
+
+    info!("Git repository found at: {}", repo_root);
+
+    Some(GitTrackingInfo {
+        repo_root,
+        tracked_files,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_tracked_returns_false_for_untracked() {
+        let info = GitTrackingInfo {
+            repo_root: "/tmp/test".to_string(),
+            tracked_files: HashSet::from(["src/main.rs".to_string()]),
+        };
+        assert!(!info.is_tracked("src/untracked.rs"));
+    }
+
+    #[test]
+    fn test_is_tracked_returns_true_for_tracked() {
+        let info = GitTrackingInfo {
+            repo_root: "/tmp/test".to_string(),
+            tracked_files: HashSet::from(["src/main.rs".to_string()]),
+        };
+        assert!(info.is_tracked("src/main.rs"));
+    }
+
+    #[test]
+    fn test_is_tracked_normalizes_windows_paths() {
+        let info = GitTrackingInfo {
+            repo_root: "/tmp/test".to_string(),
+            tracked_files: HashSet::from(["src/main.rs".to_string()]),
+        };
+        assert!(info.is_tracked("src\\main.rs"));
+    }
 }

--- a/qlty-coverage/src/publish/report.rs
+++ b/qlty-coverage/src/publish/report.rs
@@ -18,6 +18,12 @@ pub struct Report {
     #[serde(skip_serializing)]
     pub missing_files: HashSet<String>,
 
+    #[serde(skip_serializing)]
+    pub untracked_files: HashSet<String>,
+
+    #[serde(skip_serializing)]
+    pub git_repo_path: Option<String>,
+
     pub totals: CoverageMetrics,
     pub excluded_files_count: usize,
 

--- a/qlty-coverage/src/validate.rs
+++ b/qlty-coverage/src/validate.rs
@@ -94,15 +94,15 @@ mod tests {
     use std::fs::{self, File};
     use tempfile::tempdir;
 
-    // Helper function to create a test Report instance
     fn create_test_report(file_coverages: Vec<FileCoverage>) -> Report {
-        // Create a minimal valid Report
         Report {
             metadata: CoverageMetadata::default(),
             report_files: vec![ReportFile::default()],
             file_coverages,
             found_files: HashSet::new(),
             missing_files: HashSet::new(),
+            untracked_files: HashSet::new(),
+            git_repo_path: None,
             totals: Default::default(),
             excluded_files_count: 0,
             auto_path_fixing_enabled: false,


### PR DESCRIPTION
## Summary

- Add informational display showing Git repository path and untracked files in coverage reports
- Implement `GitTrackingInfo` struct and `get_git_tracking_info()` function to check if files are tracked in Git
- Add `untracked_files` and `git_repo_path` fields to the Report struct
- Display Git repository line in COVERAGE DATA section and untracked files section (with red asterisks)
- Update display limits from 20/10 to 50/50 for missing/untracked files

This is purely informational and does NOT affect validation (which remains disk-based only).

## Test plan

- [x] All existing unit tests pass (232 tests in qlty-coverage)
- [x] All integration tests pass (including coverage and without_git tests)
- [x] Test fixtures updated to reflect new Git Repository line in output
- [ ] Manual testing: verify Git repository path displays correctly
- [ ] Manual testing: verify untracked files are displayed with red asterisks
- [ ] Manual testing: verify "not found" displays when not in a Git repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)