### PR TITLE
Demonstration of sqlfluff plugin ignoring dialect specified in a configuration file

### DIFF
--- a/qlty-plugins/plugins/linters/sqlfluff/fixtures/__snapshots__/postgres_config_v3.5.0.shot
+++ b/qlty-plugins/plugins/linters/sqlfluff/fixtures/__snapshots__/postgres_config_v3.5.0.shot
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`linter=sqlfluff fixture=postgres_config version=3.5.0 1`] = `
+{
+  "issues": [
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "test.sql",
+        "range": {
+          "endColumn": 22,
+          "endLine": 1,
+          "startColumn": 17,
+          "startLine": 1,
+        },
+      },
+      "message": "Unnecessary quoted identifier "bar".",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "RF06",
+      "snippet": "SELECT "foo" AS "bar";",
+      "snippetWithContext": "SELECT "foo" AS "bar";",
+      "suggestions": [
+        {
+          "patch": "--- original
++++ modified
+@@ -1 +1 @@
+-SELECT "foo" AS "bar";
++SELECT "foo" AS bar;
+",
+          "replacements": [
+            {
+              "data": "bar",
+              "location": {
+                "path": "test.sql",
+                "range": {
+                  "endByte": 21,
+                  "endColumn": 22,
+                  "endLine": 1,
+                  "startByte": 16,
+                  "startColumn": 17,
+                  "startLine": 1,
+                },
+              },
+            },
+          ],
+          "source": "SUGGESTION_SOURCE_TOOL",
+        },
+      ],
+      "tool": "sqlfluff",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "test.sql",
+        "range": {
+          "endColumn": 13,
+          "endLine": 1,
+          "startColumn": 8,
+          "startLine": 1,
+        },
+      },
+      "message": "Unnecessary quoted identifier "foo".",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "RF06",
+      "snippet": "SELECT "foo" AS "bar";",
+      "snippetWithContext": "SELECT "foo" AS "bar";",
+      "suggestions": [
+        {
+          "patch": "--- original
++++ modified
+@@ -1 +1 @@
+-SELECT "foo" AS "bar";
++SELECT foo AS "bar";
+",
+          "replacements": [
+            {
+              "data": "foo",
+              "location": {
+                "path": "test.sql",
+                "range": {
+                  "endByte": 12,
+                  "endColumn": 13,
+                  "endLine": 1,
+                  "startByte": 7,
+                  "startColumn": 8,
+                  "startLine": 1,
+                },
+              },
+            },
+          ],
+          "source": "SUGGESTION_SOURCE_TOOL",
+        },
+      ],
+      "tool": "sqlfluff",
+    },
+  ],
+}
+`;

--- a/qlty-plugins/plugins/linters/sqlfluff/fixtures/postgres_config.in/.sqlfluff
+++ b/qlty-plugins/plugins/linters/sqlfluff/fixtures/postgres_config.in/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+dialect = postgres

--- a/qlty-plugins/plugins/linters/sqlfluff/fixtures/postgres_config.in/test.sql
+++ b/qlty-plugins/plugins/linters/sqlfluff/fixtures/postgres_config.in/test.sql
@@ -1,0 +1,1 @@
+SELECT "foo" AS "bar";


### PR DESCRIPTION
The sqlfluff plugin script is defined as follows:

```
sqlfluff lint ${target} --format json --nofail --dialect ansi
```

When a dialect is specified as a command line option it takes precedence over the option in a configuration file. So if a repository has a configuration file defined as:

```
[sqlfluff]
dialect = postgres
```

The dialect will be `ansi`, ignoring the value in the configuration file. This PR intentionally introduces a failing test to demonstrate the behavior. The SQL in the PR is supposed to produce a lint issue (in postgres), but doesn't because the dialect is set to ansi.

The sqlfluff plugin's use of a `--dialect ansi` effectively creates a smart default; the sqlfluff linter itself does not have one. If you run sqlfluff (not the plugin), without a dialect (it can be passed as a command line argument or placed in a configuration file), sqlfluff raises an error.

A fix for this plugin issue should retain the smart default for backwards compatibility. While removing the `--dialect ansi` from the script directive will cause the linter to successfully honor the dialect in configuration files, it will raise an error for any users of the plugin who haven't specified a dialect.

One possible solution to maintain backwards compatibility would be initialize the plugin with a configuration file with a default dialect. This has its own issues -- e.g. if the customer has defined a dialect already, it should be honored. sqlfluff supports [5 different kinds of configuration files](https://docs.sqlfluff.com/en/stable/configuration/setting_configuration.html#configuration-files) -- we could conditionally add the lowest precedent configuration file if it doesn't exist. In those cases it would be overridden by higher precedent configuration files, or not set if it already exists. This is pretty complex though.