### PR TITLE
fix: Attempt to fix windows release

### DIFF
--- a/.github/workflows/installer_live_test.yml
+++ b/.github/workflows/installer_live_test.yml
@@ -24,7 +24,7 @@ jobs:
             command: curl https://qlty.sh | sh
 
           - runner: windows-latest
-            command: powershell -c "iwr https://qlty.sh | iex"
+            command: powershell -c "$ProgressPreference = 'SilentlyContinue'; iwr https://qlty.sh | iex"
     steps:
       - name: Install qlty and validate
         run: ${{ matrix.command }} && ~/.qlty/bin/qlty version --no-upgrade-check

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -27,7 +27,7 @@ jobs:
           - runner: macos-15
             command: curl https://qlty.sh | sh
           - runner: windows-latest
-            command: powershell -c "iwr https://qlty.sh | iex"
+            command: powershell -c "$ProgressPreference = 'SilentlyContinue'; iwr https://qlty.sh | iex"
     steps:
       - name: Install qlty and validate
         env:


### PR DESCRIPTION
The release has been failing on promoting:

https://github.com/qltysh/qlty/actions/runs/20312323349/job/58348224088

It worked 5 days ago:
https://github.com/qltysh/qlty/actions/runs/20179922510/job/57938851932

The error itself is not particularly clear.
According to claude:

> The runner image updated from December 8 to December 16, and there's a new "Hosted Compute Agent" component. Something in this update changed how PowerShell handles non-interactive output. This actually confirms the progress bar fix is correct - the new runner image or Hosted Compute Agent likely changed how the console/progress output is handled, triggering the NullReferenceException. 


The change is fairly minimal and unobtrusive, so maybe try it.