### PR TITLE
fix: Use single quotes to prevent $ escape in windows command

### DIFF
--- a/.github/workflows/installer_live_test.yml
+++ b/.github/workflows/installer_live_test.yml
@@ -24,7 +24,7 @@ jobs:
             command: curl https://qlty.sh | sh
 
           - runner: windows-latest
-            command: powershell -c "$ProgressPreference = 'SilentlyContinue'; iwr https://qlty.sh | iex"
+            command: powershell -c '$ProgressPreference = "SilentlyContinue"; iwr https://qlty.sh | iex'
     steps:
       - name: Install qlty and validate
         run: ${{ matrix.command }} && ~/.qlty/bin/qlty version --no-upgrade-check

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -27,7 +27,7 @@ jobs:
           - runner: macos-15
             command: curl https://qlty.sh | sh
           - runner: windows-latest
-            command: powershell -c "$ProgressPreference = 'SilentlyContinue'; iwr https://qlty.sh | iex"
+            command: powershell -c '$ProgressPreference = "SilentlyContinue"; iwr https://qlty.sh | iex'
     steps:
       - name: Install qlty and validate
         env:


### PR DESCRIPTION
https://github.com/qltysh/qlty/actions/runs/20342268234/job/58446611866

> = : The term '=' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the 
spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:2
> +  = 'SilentlyContinue'; iwr https://qlty.sh/ | iex
> +  ~

Suggests that `$` character is being interpreted by the shell (sh) before reaching PowerShell. 
Switching to using single quotes to prevent that.