### PR TITLE
fix: switch to curl for windows download

### DIFF
--- a/.github/workflows/installer_live_test.yml
+++ b/.github/workflows/installer_live_test.yml
@@ -24,7 +24,7 @@ jobs:
             command: curl https://qlty.sh | sh
 
           - runner: windows-latest
-            command: powershell -c "curl -fsSL https://qlty.sh | iex"
+            command: powershell -c "curl.exe -fsSL https://qlty.sh | iex"
     steps:
       - name: Install qlty and validate
         run: ${{ matrix.command }} && ~/.qlty/bin/qlty version --no-upgrade-check

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -27,7 +27,7 @@ jobs:
           - runner: macos-15
             command: curl https://qlty.sh | sh
           - runner: windows-latest
-            command: powershell -c "curl -fsSL https://qlty.sh | iex"
+            command: powershell -c "curl.exe -fsSL https://qlty.sh | iex"
     steps:
       - name: Install qlty and validate
         env:


### PR DESCRIPTION
Use curl instead of iwr which has been having [issues](https://github.com/qltysh/qlty/actions/runs/20441726588/job/58737185407) in CI.

> cURL is included by default in all modern versions of Windows (Windows 10 version 1803 and later, and Windows 11).