### PR TITLE
fix: use explicit PowerShell installer URL for Windows

### DIFF
--- a/.github/workflows/installer_live_test.yml
+++ b/.github/workflows/installer_live_test.yml
@@ -24,7 +24,7 @@ jobs:
             command: curl https://qlty.sh | sh
 
           - runner: windows-latest
-            command: powershell -c "curl.exe -fsSL https://qlty.sh | iex"
+            command: powershell -c "curl.exe -fsSL https://qlty.sh/install.ps1 | iex"
     steps:
       - name: Install qlty and validate
         run: ${{ matrix.command }} && ~/.qlty/bin/qlty version --no-upgrade-check

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -27,7 +27,7 @@ jobs:
           - runner: macos-15
             command: curl https://qlty.sh | sh
           - runner: windows-latest
-            command: powershell -c "curl.exe -fsSL https://qlty.sh | iex"
+            command: powershell -c "curl.exe -fsSL https://qlty.sh/install.ps1 | iex"
     steps:
       - name: Install qlty and validate
         env:


### PR DESCRIPTION
## Summary
- Uses `https://qlty.sh/install.ps1` instead of `https://qlty.sh` for Windows CI installer tests
- Fixes the release promote workflow failure where PowerShell was receiving a bash script

## Root Cause
The `qlty.sh` endpoint uses User-Agent detection to decide which script to serve. When `curl.exe` is used (instead of `iwr`), it sends a generic `curl/x.x.x` User-Agent that isn't recognized as Windows, causing the bash script (`install.sh`) to be served instead of the PowerShell script (`install.ps1`).

## Test plan
- [ ] Verify Windows CI job passes in release promote workflow
- [ ] Verify installer live tests pass on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)