### PR TITLE
chore: Add back install test for windows

### DIFF
--- a/.github/workflows/installer_live_test.yml
+++ b/.github/workflows/installer_live_test.yml
@@ -22,6 +22,9 @@ jobs:
 
           - runner: macos-15
             command: curl https://qlty.sh | sh
+
+          - runner: windows-latest
+            command: powershell -c "curl.exe https://qlty.sh/install.ps1 | iex"
     steps:
       - name: Install qlty and validate
         run: ${{ matrix.command }} && ~/.qlty/bin/qlty version --no-upgrade-check

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -26,6 +26,8 @@ jobs:
             command: curl https://qlty.sh | sh
           - runner: macos-15
             command: curl https://qlty.sh | sh
+          - runner: windows-latest
+            command: powershell -c "curl.exe https://qlty.sh/install.ps1 | iex"
     steps:
       - name: Install qlty and validate
         env:


### PR DESCRIPTION
Add back the windows install test during release that was removed in https://github.com/qltysh/qlty/pull/2604