### PR TITLE
feat(plugins): add mdformat markdown formatter

### DIFF
--- a/qlty-plugins/plugins/linters/mdformat/README.md
+++ b/qlty-plugins/plugins/linters/mdformat/README.md
@@ -1,0 +1,41 @@
+# Mdformat
+
+[Mdformat](https://github.com/hukkin/mdformat) is an opinionated CommonMark compliant Markdown formatter.
+
+## Enabling Mdformat
+
+Enabling with the `qlty` CLI:
+
+```bash
+qlty plugins enable mdformat
+```
+
+Or by editing `qlty.toml`:
+
+```toml
+# Always use the latest version
+[plugins.enabled]
+mdformat = "latest"
+
+# OR enable a specific version
+[plugins.enabled]
+mdformat = "X.Y.Z"
+```
+
+## Configuration files
+
+- [`.mdformat.toml`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html)
+
+To keep your project tidy, you can move configuration files into `.qlty/configs` and Qlty will find and use them when running Mdformat.
+
+## Links
+
+- [Mdformat on GitHub](https://github.com/hukkin/mdformat)
+- [Mdformat documentation](https://mdformat.readthedocs.io/)
+- [Mdformat plugin definition](https://github.com/qltysh/qlty/tree/main/plugins/linters/mdformat)
+- [Mdformat on PyPI](https://pypi.org/project/mdformat/)
+- [Qlty's open source plugin definitions](https://github.com/qltysh/qlty/tree/main/plugins/linters)
+
+## License
+
+Mdformat is licensed under the [MIT License](https://github.com/hukkin/mdformat/blob/master/LICENSE).

--- a/qlty-plugins/plugins/linters/mdformat/fixtures/__snapshots__/basic_v1.0.0.shot
+++ b/qlty-plugins/plugins/linters/mdformat/fixtures/__snapshots__/basic_v1.0.0.shot
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`linter=mdformat fixture=basic version=1.0.0 1`] = `
+{
+  "issues": [
+    {
+      "category": "CATEGORY_STYLE",
+      "level": "LEVEL_FMT",
+      "location": {
+        "path": "basic.in.md",
+      },
+      "message": "Incorrect formatting, autoformat by running \`qlty fmt\`.",
+      "mode": "MODE_BLOCK",
+      "onAddedLine": true,
+      "ruleKey": "fmt",
+      "tool": "mdformat",
+    },
+  ],
+}
+`;

--- a/qlty-plugins/plugins/linters/mdformat/fixtures/basic.in.md
+++ b/qlty-plugins/plugins/linters/mdformat/fixtures/basic.in.md
@@ -1,0 +1,14 @@
+#   Header with extra spaces
+
+Some text with    multiple   spaces.
+
+*  inconsistent list
+*   formatting
+*here
+
+> a blockquote
+>with no space
+
+```python
+def foo():pass
+```

--- a/qlty-plugins/plugins/linters/mdformat/mdformat.test.ts
+++ b/qlty-plugins/plugins/linters/mdformat/mdformat.test.ts
@@ -1,0 +1,3 @@
+import { linterCheckTest } from "tests";
+
+linterCheckTest("mdformat", __dirname);

--- a/qlty-plugins/plugins/linters/mdformat/plugin.toml
+++ b/qlty-plugins/plugins/linters/mdformat/plugin.toml
@@ -1,0 +1,19 @@
+config_version = "0"
+
+[plugins.definitions.mdformat]
+runtime = "python"
+package = "mdformat"
+file_types = ["markdown"]
+config_files = [".mdformat.toml"]
+latest_version = "1.0.0"
+known_good_version = "1.0.0"
+version_command = "mdformat --version"
+description = "CommonMark compliant Markdown formatter"
+
+[plugins.definitions.mdformat.drivers.format]
+script = "mdformat ${target}"
+success_codes = [0]
+output = "rewrite"
+cache_results = true
+batch = true
+driver_type = "formatter"


### PR DESCRIPTION
## Summary

- Add mdformat plugin for formatting Markdown files
- Mdformat is a CommonMark compliant Markdown formatter written in Python
- Uses Python runtime with `mdformat` package (version 1.0.0)
- Supports `.mdformat.toml` configuration file

## Test plan

- [x] Plugin tests pass (`npm test -- --testNamePattern="mdformat"`)
- [x] `qlty fmt` runs without errors
- [x] `qlty check --level=low` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)