### PR TITLE
fix(ci): use env vars for shell variable interpolation in workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -141,7 +141,7 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |-
           tags=($(jq -cr '[.tags[] | "-t \(.)"] | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON"))
-          images=($(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *))
+          images=($(printf '${{ env.REGISTRY }}/${IMAGE_NAME}@sha256:%s ' *))
           echo tags: "${tags[@]}"
           echo images: "${images[@]}" 
           docker buildx imagetools create "${tags[@]}" "${images[@]}"
@@ -152,6 +152,8 @@ jobs:
 
           echo "Image digest: $DIGEST"
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
 
       # confirm merged image manifests
       - name: Inspect Image Manifests

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -46,5 +46,7 @@ jobs:
           aws-region: ${{ vars.QLTY_RELEASE_AWS_REGION }}
       - name: Upload to S3
         run: |
-          VERSION="${{ inputs.version }}"
+          VERSION="${INPUTS_VERSION}"
           aws s3 cp --recursive ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}/v${VERSION#v}/ ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}/latest/
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Summary
- Pass GitHub Actions context variables through `env:` instead of direct `${{ }}` interpolation in bash scripts
- Fixes `docker.yml` to use `${IMAGE_NAME}` env var in shell commands
- Fixes `release_promote.yml` to use `${INPUTS_VERSION}` env var in shell commands

## Test plan
- [ ] Verify Docker workflow builds and pushes images correctly
- [ ] Verify release promote workflow copies files to S3 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)