### PR TITLE
fix(ci): add persist-credentials: false to checkout actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
@@ -137,6 +138,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Fetch local artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -153,11 +155,17 @@ jobs:
           echo "sha_x86_64_linux=$(cat target/distrib/qlty-x86_64-unknown-linux-gnu.tar.xz.sha256 | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
       - name: Create Homebrew formula
         run: |
-          sed "s/{{VERSION}}/${{ steps.data.outputs.version }}/g" installer/qlty.rb.template > qlty.rb
-          sed -i "s/{{SHA_AARCH64_MAC}}/${{ steps.data.outputs.sha_aarch64_mac }}/g" qlty.rb
-          sed -i "s/{{SHA_X86_64_MAC}}/${{ steps.data.outputs.sha_x86_64_mac }}/g" qlty.rb
-          sed -i "s/{{SHA_AARCH64_LINUX}}/${{ steps.data.outputs.sha_aarch64_linux }}/g" qlty.rb
-          sed -i "s/{{SHA_X86_64_LINUX}}/${{ steps.data.outputs.sha_x86_64_linux }}/g" qlty.rb
+          sed "s/{{VERSION}}/${STEPS_DATA_OUTPUTS_VERSION}/g" installer/qlty.rb.template > qlty.rb
+          sed -i "s/{{SHA_AARCH64_MAC}}/${STEPS_DATA_OUTPUTS_SHA_AARCH64_MAC}/g" qlty.rb
+          sed -i "s/{{SHA_X86_64_MAC}}/${STEPS_DATA_OUTPUTS_SHA_X86_64_MAC}/g" qlty.rb
+          sed -i "s/{{SHA_AARCH64_LINUX}}/${STEPS_DATA_OUTPUTS_SHA_AARCH64_LINUX}/g" qlty.rb
+          sed -i "s/{{SHA_X86_64_LINUX}}/${STEPS_DATA_OUTPUTS_SHA_X86_64_LINUX}/g" qlty.rb
+        env:
+          STEPS_DATA_OUTPUTS_VERSION: ${{ steps.data.outputs.version }}
+          STEPS_DATA_OUTPUTS_SHA_AARCH64_MAC: ${{ steps.data.outputs.sha_aarch64_mac }}
+          STEPS_DATA_OUTPUTS_SHA_X86_64_MAC: ${{ steps.data.outputs.sha_x86_64_mac }}
+          STEPS_DATA_OUTPUTS_SHA_AARCH64_LINUX: ${{ steps.data.outputs.sha_aarch64_linux }}
+          STEPS_DATA_OUTPUTS_SHA_X86_64_LINUX: ${{ steps.data.outputs.sha_x86_64_linux }}
       - name: Upload Homebrew formula
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -165,7 +173,9 @@ jobs:
           if-no-files-found: error
           path: qlty.rb
       - name: Create dist-manifest.json
-        run: echo "{\"announcement_tag\":\"v${{ steps.data.outputs.version }}\"}" > dist-manifest.json
+        run: echo "{\"announcement_tag\":\"v${STEPS_DATA_OUTPUTS_VERSION}\"}" > dist-manifest.json
+        env:
+          STEPS_DATA_OUTPUTS_VERSION: ${{ steps.data.outputs.version }}
       - name: Upload manifest
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 500
+          persist-credentials: false
 
       - name: Install Qlty CLI
         uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install Qlty CLI
         uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Checkout qlty
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39

--- a/.github/workflows/cli_integration.yml
+++ b/.github/workflows/cli_integration.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout cloud
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@2fcdc490d667999e01ddbbf0f2823181beef6b39

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Checkout repository
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: ${{ github.event_name != 'pull_request' }}
@@ -90,8 +92,10 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest="${STEPS_BUILD_OUTPUTS_DIGEST}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
+        env:
+          STEPS_BUILD_OUTPUTS_DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Upload digest
         if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           ref: ${{ github.head_ref }}
+          persist-credentials: false
       - uses: qltysh/qlty-action/fmt@a19242102d17e497f437d7466aa01b528537e899
       - name: Commit changes
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e

--- a/.github/workflows/installer_test.yml
+++ b/.github/workflows/installer_test.yml
@@ -95,6 +95,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         if: matrix.package_install

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install cargo-release
         uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,21 +24,26 @@ jobs:
 
       - name: Get GitHub App User ID
         id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: echo "user-id=$(gh api "/users/${STEPS_APP_TOKEN_OUTPUTS_APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STEPS_APP_TOKEN_OUTPUTS_APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
 
       - name: Git config
         run: |
           git config --global core.longpaths true
           git config --global core.autocrlf false
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+          git config --global user.name '${STEPS_APP_TOKEN_OUTPUTS_APP_SLUG}[bot]'
+          git config --global user.email '${STEPS_GET_USER_ID_OUTPUTS_USER_ID}+${STEPS_APP_TOKEN_OUTPUTS_APP_SLUG}[bot]@users.noreply.github.com>'
+        env:
+          STEPS_APP_TOKEN_OUTPUTS_APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          STEPS_GET_USER_ID_OUTPUTS_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
 
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install cargo-release
         uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2
@@ -76,15 +81,16 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          PRERELEASE_FLAG: "${{ false && '--prerelease' || '' }}"
-          ANNOUNCEMENT_TITLE: "Release v${{ steps.version.outputs.version }}"
-          ANNOUNCEMENT_BODY: "Automated release created by GitHub Actions."
-          RELEASE_COMMIT: "${{ github.sha }}"
+          PRERELEASE_FLAG: ${{ false && '--prerelease' || '' }}
+          ANNOUNCEMENT_TITLE: Release v${{ steps.version.outputs.version }}
+          ANNOUNCEMENT_BODY: Automated release created by GitHub Actions.
+          RELEASE_COMMIT: ${{ github.sha }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          STEPS_VERSION_OUTPUTS_VERSION: ${{ steps.version.outputs.version }}
         run: |
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
-          gh release create "v${{ steps.version.outputs.version }}" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" target/distrib/*
+          gh release create "v${STEPS_VERSION_OUTPUTS_VERSION}" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" target/distrib/*
   s3-upload:
     needs: release
     runs-on: ubuntu-latest
@@ -107,7 +113,10 @@ jobs:
       - name: Upload to S3
         working-directory: target/distrib
         run: |
-          aws s3 cp --recursive . ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}/${{ needs.release.outputs.tag }}/
+          aws s3 cp --recursive . ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/${NEEDS_RELEASE_OUTPUTS_TAG}/
+        env:
+          VARS_QLTY_RELEASE_AWS_S3_DESTINATION: ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}
+          NEEDS_RELEASE_OUTPUTS_TAG: ${{ needs.release.outputs.tag }}
   promote:
     needs: [release, s3-upload]
     uses: ./.github/workflows/release_promote.yml

--- a/.github/workflows/release_installer.yml
+++ b/.github/workflows/release_installer.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Generate attestations for installer scripts
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a
         with:
@@ -37,5 +38,7 @@ jobs:
       - name: Upload to S3
         working-directory: installer
         run: |
-          aws s3 cp install.ps1 ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}/installer/
-          aws s3 cp install.sh ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}/installer/
+          aws s3 cp install.ps1 ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/installer/
+          aws s3 cp install.sh ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/installer/
+        env:
+          VARS_QLTY_RELEASE_AWS_S3_DESTINATION: ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Upload to S3
         run: |
           VERSION="${INPUTS_VERSION}"
-          aws s3 cp --recursive ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}/v${VERSION#v}/ ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}/latest/
+          aws s3 cp --recursive ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/v${VERSION#v}/ ${VARS_QLTY_RELEASE_AWS_S3_DESTINATION}/latest/
         env:
           INPUTS_VERSION: ${{ inputs.version }}
+          VARS_QLTY_RELEASE_AWS_S3_DESTINATION: ${{ vars.QLTY_RELEASE_AWS_S3_DESTINATION }}

--- a/.github/workflows/update_linter_versions.yml
+++ b/.github/workflows/update_linter_versions.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
 
       - name: 📦 Use Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to all `actions/checkout` usages across workflow files
- Use environment variables for shell variable interpolation in several workflows (continuing work from #2652)

## Test plan
- [ ] Verify workflows run successfully after merge
- [ ] Check that checkout actions no longer persist credentials in git config

🤖 Generated with [Claude Code](https://claude.com/claude-code)