### PR TITLE
fix(ci): scope workflow permissions to job level

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,12 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  attestations: write
-  id-token: write
 jobs:
   compile:
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
     if: github.event.commits && github.event.commits[0] && github.event.commits[0].author.name == 'qlty-releases[bot]' && startsWith(github.event.commits[0].message, 'Release ')
     strategy:
       fail-fast: false

--- a/.github/workflows/cli_integration.yml
+++ b/.github/workflows/cli_integration.yml
@@ -15,9 +15,7 @@ on:
       - .github/workflows/cli_integration.yml
 
 permissions:
-  actions: write
   contents: read
-  id-token: write
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,12 +20,14 @@ env:
 
 permissions:
   contents: read
-  packages: write
-  attestations: write
-  id-token: write
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +109,10 @@ jobs:
           retention-days: 1
 
   merge:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' }}
     needs:

--- a/.github/workflows/release_installer.yml
+++ b/.github/workflows/release_installer.yml
@@ -7,14 +7,15 @@ on:
     paths:
       - installer/install.*
 permissions:
-  actions: write
-  attestations: write
   contents: read
-  id-token: write
 jobs:
   test:
     uses: ./.github/workflows/installer_test.yml
   release:
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -13,7 +13,6 @@ on:
         type: string
 permissions:
   contents: read
-  "id-token": "write"
 jobs:
   test:
     name: ${{ matrix.runner }}
@@ -35,6 +34,9 @@ jobs:
         run: ${{ matrix.command }} && ~/.qlty/bin/qlty version --no-upgrade-check
         shell: sh
   promote:
+    permissions:
+      contents: read
+      id-token: write
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Move write permissions from workflow level to job level following least privilege principle
- Fixes zizmor `excessive-permissions` audit findings across 5 workflow files
- Removes unused `actions: write` and `id-token: write` from `cli_integration.yml`

## Test plan
- [ ] Verify Build workflow runs correctly on release commits
- [ ] Verify Docker workflow builds and pushes images correctly
- [ ] Verify Release Installer workflow attests and uploads correctly
- [ ] Verify Release Promote workflow can authenticate to AWS

🤖 Generated with [Claude Code](https://claude.com/claude-code)