### PR TITLE
fix(ci): replace secrets inherit with explicit secret forwarding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,4 +189,6 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       workflow_run_id: ${{ github.event.workflow_run.id }}
-    secrets: inherit
+    secrets:
+      QLTY_APP_PRIVATE_KEY: ${{ secrets.QLTY_APP_PRIVATE_KEY }}
+      QLTY_RELEASE_AWS_ROLE_ARN: ${{ secrets.QLTY_RELEASE_AWS_ROLE_ARN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
       workflow_run_id:
         required: true
         type: string
+    secrets:
+      QLTY_APP_PRIVATE_KEY:
+        required: true
+      QLTY_RELEASE_AWS_ROLE_ARN:
+        required: true
 permissions:
   contents: read
   "id-token": "write"
@@ -122,4 +127,5 @@ jobs:
     uses: ./.github/workflows/release_promote.yml
     with:
       version: ${{ needs.release.outputs.tag }}
-    secrets: inherit
+    secrets:
+      QLTY_RELEASE_AWS_ROLE_ARN: ${{ secrets.QLTY_RELEASE_AWS_ROLE_ARN }}

--- a/.github/workflows/release_promote.yml
+++ b/.github/workflows/release_promote.yml
@@ -11,6 +11,9 @@ on:
       version:
         required: true
         type: string
+    secrets:
+      QLTY_RELEASE_AWS_ROLE_ARN:
+        required: true
 permissions:
   contents: read
   "id-token": "write"


### PR DESCRIPTION
## Summary
- Replace `secrets: inherit` with explicit secret declarations in reusable workflows
- Add `secrets:` section to `workflow_call` in release.yml and release_promote.yml
- Forward only the specific secrets each workflow needs (QLTY_APP_PRIVATE_KEY, QLTY_RELEASE_AWS_ROLE_ARN)

This addresses zizmor's `secrets-inherit` audit findings by following the Principle of Least Authority.

## Test plan
- [ ] Verify zizmor no longer reports secrets-inherit warnings
- [ ] Trigger a release workflow to confirm secrets are passed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)