### PR TITLE
fix(ci): use env var for shell variable interpolation in prepare_release

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -49,9 +49,11 @@ jobs:
           cargo release version \
             --execute \
             --no-confirm \
-            ${{ inputs.increment == 'version' && inputs.version || inputs.increment || 'minor' }}
+            "${RELEASE_VERSION}"
 
           echo "version=$(cargo metadata --format-version 1 | jq -r ".workspace_members[0]" | cut -d# -f2)" >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE_VERSION: ${{ inputs.increment == 'version' && inputs.version || inputs.increment || 'minor' }}
       - name: Commit changes
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         with:


### PR DESCRIPTION
## Summary

- Fixes template-injection vulnerability in `prepare_release.yml` detected by zizmor
- Moves `inputs.version` from direct template expansion to environment variable
- Uses shell variable expansion (`${RELEASE_VERSION}`) instead of GitHub Actions template expansion to properly handle quoting

## Test plan

- [x] Verify zizmor passes with no template-injection findings
- [ ] Manually trigger prepare_release workflow to verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)