### PR TITLE
feat(plugins): add ultracite linter plugin

### DIFF
--- a/qlty-plugins/plugins/linters/ultracite/README.md
+++ b/qlty-plugins/plugins/linters/ultracite/README.md
@@ -1,0 +1,36 @@
+# Ultracite
+
+[Ultracite](https://github.com/haydenbleasel/ultracite) is a highly opinionated, zero-configuration linter and formatter for JavaScript and TypeScript projects. It's built on top of Biome, providing instant code analysis with hundreds of preconfigured rules.
+
+## Enabling Ultracite
+
+Enabling with the `qlty` CLI:
+
+```bash
+qlty plugins enable ultracite
+```
+
+Or by editing `qlty.toml`:
+
+```toml
+[plugins.enabled]
+ultracite = "latest"
+```
+
+## Configuration files
+
+- [`biome.json`](https://biomejs.dev/reference/configuration/)
+- [`biome.jsonc`](https://biomejs.dev/reference/configuration/)
+- [`eslint.config.js`](https://eslint.org/docs/latest/use/configure/configuration-files)
+- [`eslint.config.mjs`](https://eslint.org/docs/latest/use/configure/configuration-files)
+- [`eslint.config.ts`](https://eslint.org/docs/latest/use/configure/configuration-files)
+
+## Links
+
+- [Ultracite on GitHub](https://github.com/haydenbleasel/ultracite)
+- [Ultracite documentation](https://docs.ultracite.ai/)
+- [Ultracite plugin definition](https://github.com/qltysh/qlty/tree/main/plugins/linters/ultracite)
+
+## License
+
+Ultracite is licensed under the [MIT License](https://github.com/haydenbleasel/ultracite/blob/main/license.md).

--- a/qlty-plugins/plugins/linters/ultracite/fixtures/__snapshots__/basic_v7.1.3.shot
+++ b/qlty-plugins/plugins/linters/ultracite/fixtures/__snapshots__/basic_v7.1.3.shot
@@ -1,0 +1,471 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`linter=ultracite fixture=basic version=7.1.3 1`] = `
+{
+  "issues": [
+    {
+      "category": "CATEGORY_STYLE",
+      "level": "LEVEL_FMT",
+      "location": {
+        "path": "basic.in.ts",
+      },
+      "message": "Incorrect formatting, autoformat by running \`qlty fmt\`.",
+      "mode": "MODE_BLOCK",
+      "onAddedLine": true,
+      "ruleKey": "fmt",
+      "tool": "ultracite",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_HIGH",
+      "location": {
+        "path": "basic.in.ts",
+        "range": {},
+      },
+      "message": "Formatter would have printed the following content:",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "format",
+      "suggestions": [
+        {
+          "patch": "--- original
++++ modified
+@@ -1,16 +1,20 @@
+-const foobar = () => { }
+-const barfoo = () => { }
++const foobar = () => {;;nst barfoo = () => { }
+
+ enum Bar { Baz };
++,
++  
+
+ const foo = (bar: Bar) => {
+   switch (bar) {
+     case Bar.Baz:
+-      foobar();
+-      barfoo();
++ ,
++     foobar();
++  barfoo();
+       break;
+   }
++    
++ ;
++  ; 
+   { !foo ? null : 1 }
+ }
+-
+ enum Foo { Bae };
+",
+          "replacements": [
+            {
+              "location": {
+                "range": {
+                  "endColumn": 24,
+                  "endLine": 1,
+                  "startColumn": 23,
+                  "startLine": 1,
+                },
+              },
+            },
+            {
+              "data": ";",
+              "location": {
+                "range": {
+                  "endColumn": 25,
+                  "endLine": 1,
+                  "startColumn": 25,
+                  "startLine": 1,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 24,
+                  "endLine": 1,
+                  "startColumn": 23,
+                  "startLine": 1,
+                },
+              },
+            },
+            {
+              "data": ";",
+              "location": {
+                "range": {
+                  "endColumn": 25,
+                  "endLine": 1,
+                  "startColumn": 25,
+                  "startLine": 1,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 24,
+                  "endLine": 1,
+                  "startColumn": 23,
+                  "startLine": 1,
+                },
+              },
+            },
+            {
+              "data": "
+  ",
+              "location": {
+                "range": {
+                  "endColumn": 10,
+                  "endLine": 4,
+                  "startColumn": 10,
+                  "startLine": 4,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 24,
+                  "endLine": 1,
+                  "startColumn": 23,
+                  "startLine": 1,
+                },
+              },
+            },
+            {
+              "data": ",
+",
+              "location": {
+                "range": {
+                  "endColumn": 16,
+                  "endLine": 4,
+                  "startColumn": 16,
+                  "startLine": 4,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 1,
+                  "endLine": 2,
+                  "startColumn": 25,
+                  "startLine": 1,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 2,
+                  "endLine": 11,
+                  "startColumn": 1,
+                  "startLine": 11,
+                },
+              },
+            },
+            {
+              "data": "
+    ",
+              "location": {
+                "range": {
+                  "endColumn": 4,
+                  "endLine": 13,
+                  "startColumn": 4,
+                  "startLine": 13,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 2,
+                  "endLine": 11,
+                  "startColumn": 1,
+                  "startLine": 11,
+                },
+              },
+            },
+            {
+              "data": ";
+  ",
+              "location": {
+                "range": {
+                  "endColumn": 2,
+                  "endLine": 14,
+                  "startColumn": 2,
+                  "startLine": 14,
+                },
+              },
+            },
+            {
+              "data": ";",
+              "location": {
+                "range": {
+                  "endColumn": 2,
+                  "endLine": 14,
+                  "startColumn": 2,
+                  "startLine": 14,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 2,
+                  "endLine": 11,
+                  "startColumn": 1,
+                  "startLine": 11,
+                },
+              },
+            },
+            {
+              "data": "
+  ",
+              "location": {
+                "range": {
+                  "endColumn": 4,
+                  "endLine": 13,
+                  "startColumn": 4,
+                  "startLine": 13,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 2,
+                  "endLine": 11,
+                  "startColumn": 1,
+                  "startLine": 11,
+                },
+              },
+            },
+            {
+              "data": ",
+",
+              "location": {
+                "range": {
+                  "endColumn": 2,
+                  "endLine": 9,
+                  "startColumn": 2,
+                  "startLine": 9,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 1,
+                  "endLine": 15,
+                  "startColumn": 2,
+                  "startLine": 14,
+                },
+              },
+            },
+          ],
+          "source": "SUGGESTION_SOURCE_TOOL",
+        },
+      ],
+      "tool": "ultracite",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "basic.in.ts",
+        "range": {
+          "endColumn": 22,
+          "endLine": 13,
+          "startColumn": 3,
+          "startLine": 13,
+        },
+      },
+      "message": "This block statement doesn't serve any purpose and can be safely removed.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "lint/complexity/noUselessLoneBlockStatements",
+      "snippet": "  { !foo ? null : 1 }",
+      "snippetWithContext": "
+enum Bar { Baz };
+
+const foo = (bar: Bar) => {
+  switch (bar) {
+    case Bar.Baz:
+      foobar();
+      barfoo();
+      break;
+  }
+  { !foo ? null : 1 }
+}
+
+enum Foo { Bae };",
+      "suggestions": [
+        {
+          "patch": "--- original
++++ modified
+@@ -9,8 +9,7 @@
+       foobar();
+       barfoo();
+       break;
+-  }
+-  { !foo ? null : 1 }
++  }!foo ? null : 1 
+ }
+
+ enum Foo { Bae };
+",
+          "replacements": [
+            {
+              "location": {
+                "range": {
+                  "endColumn": 5,
+                  "endLine": 13,
+                  "startColumn": 4,
+                  "startLine": 12,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 22,
+                  "endLine": 13,
+                  "startColumn": 21,
+                  "startLine": 13,
+                },
+              },
+            },
+          ],
+          "source": "SUGGESTION_SOURCE_TOOL",
+        },
+      ],
+      "tool": "ultracite",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "basic.in.ts",
+        "range": {
+          "endColumn": 9,
+          "endLine": 16,
+          "startColumn": 6,
+          "startLine": 16,
+        },
+      },
+      "message": "This variable Foo is unused.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "lint/correctness/noUnusedVariables",
+      "snippet": "enum Foo { Bae };",
+      "snippetWithContext": "const foo = (bar: Bar) => {
+  switch (bar) {
+    case Bar.Baz:
+      foobar();
+      barfoo();
+      break;
+  }
+  { !foo ? null : 1 }
+}
+
+enum Foo { Bae };",
+      "tool": "ultracite",
+    },
+    {
+      "category": "CATEGORY_LINT",
+      "level": "LEVEL_MEDIUM",
+      "location": {
+        "path": "basic.in.ts",
+        "range": {
+          "endColumn": 10,
+          "endLine": 6,
+          "startColumn": 7,
+          "startLine": 6,
+        },
+      },
+      "message": "This variable foo is unused.",
+      "mode": "MODE_BLOCK",
+      "ruleKey": "lint/correctness/noUnusedVariables",
+      "snippet": "const foo = (bar: Bar) => {",
+      "snippetWithContext": "const foobar = () => { }
+const barfoo = () => { }
+
+enum Bar { Baz };
+
+const foo = (bar: Bar) => {
+  switch (bar) {
+    case Bar.Baz:
+      foobar();
+      barfoo();
+      break;
+  }
+  { !foo ? null : 1 }
+}
+
+enum Foo { Bae };",
+      "suggestions": [
+        {
+          "patch": "--- original
++++ modified
+@@ -3,8 +3,8 @@
+
+ enum Bar { Baz };
+
+-const foo = (bar: Bar) => {
+-  switch (bar) {
++const _foo = (bar: Bar) => {
++  switch_fooar) {
+     case Bar.Baz:
+       foobar();
+       barfoo();
+",
+          "replacements": [
+            {
+              "location": {
+                "range": {
+                  "endColumn": 10,
+                  "endLine": 6,
+                  "startColumn": 7,
+                  "startLine": 6,
+                },
+              },
+            },
+            {
+              "data": "_foo",
+              "location": {
+                "range": {
+                  "endColumn": 10,
+                  "endLine": 6,
+                  "startColumn": 10,
+                  "startLine": 6,
+                },
+              },
+            },
+            {
+              "location": {
+                "range": {
+                  "endColumn": 12,
+                  "endLine": 7,
+                  "startColumn": 9,
+                  "startLine": 7,
+                },
+              },
+            },
+            {
+              "data": "_foo",
+              "location": {
+                "range": {
+                  "endColumn": 12,
+                  "endLine": 7,
+                  "startColumn": 12,
+                  "startLine": 7,
+                },
+              },
+            },
+          ],
+          "source": "SUGGESTION_SOURCE_TOOL",
+        },
+      ],
+      "tool": "ultracite",
+    },
+  ],
+}
+`;

--- a/qlty-plugins/plugins/linters/ultracite/fixtures/basic.in.ts
+++ b/qlty-plugins/plugins/linters/ultracite/fixtures/basic.in.ts
@@ -1,0 +1,16 @@
+const foobar = () => { }
+const barfoo = () => { }
+
+enum Bar { Baz };
+
+const foo = (bar: Bar) => {
+  switch (bar) {
+    case Bar.Baz:
+      foobar();
+      barfoo();
+      break;
+  }
+  { !foo ? null : 1 }
+}
+
+enum Foo { Bae };

--- a/qlty-plugins/plugins/linters/ultracite/fixtures/biome.jsonc
+++ b/qlty-plugins/plugins/linters/ultracite/fixtures/biome.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  }
+}

--- a/qlty-plugins/plugins/linters/ultracite/plugin.toml
+++ b/qlty-plugins/plugins/linters/ultracite/plugin.toml
@@ -1,0 +1,33 @@
+config_version = "0"
+
+[plugins.definitions.ultracite]
+runtime = "node"
+package = "ultracite"
+file_types = ["typescript", "javascript", "jsx", "tsx"]
+config_files = ["biome.json", "biome.jsonc", "eslint.config.js", "eslint.config.mjs", "eslint.config.ts"]
+affects_cache = ["package.json"]
+latest_version = "7.1.3"
+known_good_version = "7.1.3"
+version_command = "ultracite --version"
+description = "A highly opinionated, zero-configuration linter and formatter"
+package_file_candidate = "package.json"
+package_file_candidate_filters = ["ultracite"]
+
+[plugins.definitions.ultracite.drivers.lint]
+script = "ultracite check --reporter=json ${target}"
+success_codes = [0, 1]
+output = "stdout"
+output_format = "biome"
+batch = true
+cache_results = true
+suggested = "config"
+output_missing = "parse"
+
+[plugins.definitions.ultracite.drivers.format]
+script = "ultracite fix ${target}"
+success_codes = [0, 1]
+output = "rewrite"
+batch = true
+cache_results = true
+driver_type = "formatter"
+suggested = "config"

--- a/qlty-plugins/plugins/linters/ultracite/ultracite.test.ts
+++ b/qlty-plugins/plugins/linters/ultracite/ultracite.test.ts
@@ -1,0 +1,3 @@
+import { linterCheckTest } from "tests";
+
+linterCheckTest("ultracite", __dirname);


### PR DESCRIPTION
## Summary

- Add support for Ultracite, a highly opinionated, zero-configuration linter and formatter for JavaScript/TypeScript projects
- Ultracite is built on top of Biome and provides instant code analysis with hundreds of preconfigured rules
- Plugin includes both lint and format drivers

## Test plan

- [x] Plugin tests pass (`npm test -- --testNamePattern="ultracite"`)
- [ ] Manual testing with a project using ultracite

🤖 Generated with [Claude Code](https://claude.com/claude-code)