### PR TITLE
feat(cli): add `qlty sources fetch` command

### DIFF
--- a/qlty-cli/src/arguments.rs
+++ b/qlty-cli/src/arguments.rs
@@ -1,5 +1,5 @@
 use crate::commands::*;
-use crate::commands::{auth, cache, config, plugins};
+use crate::commands::{auth, cache, config, plugins, sources};
 use crate::{CommandError, CommandSuccess};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -92,6 +92,9 @@ pub enum Commands {
     /// Find code smells like duplication and complexity
     Smells(Smells),
 
+    /// Manage plugin sources
+    Sources(sources::Arguments),
+
     /// Send telemetry
     #[command(hide = true)]
     Telemetry(Telemetry),
@@ -136,6 +139,7 @@ impl Arguments {
             Commands::Patch(command) => command.execute(self),
             Commands::Plugins(command) => command.execute(self),
             Commands::Smells(command) => command.execute(self),
+            Commands::Sources(command) => command.execute(self),
             Commands::Telemetry(command) => command.execute(self),
             Commands::Upgrade(command) => command.execute(self),
             Commands::Validate(command) => command.execute(self),

--- a/qlty-cli/src/commands.rs
+++ b/qlty-cli/src/commands.rs
@@ -19,6 +19,7 @@ mod parse;
 mod patch;
 pub mod plugins;
 mod smells;
+pub mod sources;
 mod telemetry;
 mod upgrade;
 mod validate;

--- a/qlty-cli/src/commands/sources.rs
+++ b/qlty-cli/src/commands/sources.rs
@@ -1,0 +1,27 @@
+use crate::{CommandError, CommandSuccess};
+use anyhow::Result;
+use clap::{Args, Subcommand};
+
+mod fetch;
+
+pub use fetch::Fetch;
+
+#[derive(Debug, Args)]
+pub struct Arguments {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Fetch plugin sources
+    Fetch(Fetch),
+}
+
+impl Arguments {
+    pub fn execute(&self, args: &crate::Arguments) -> Result<CommandSuccess, CommandError> {
+        match &self.command {
+            Commands::Fetch(command) => command.execute(args),
+        }
+    }
+}

--- a/qlty-cli/src/commands/sources/fetch.rs
+++ b/qlty-cli/src/commands/sources/fetch.rs
@@ -1,0 +1,15 @@
+use crate::{Arguments, CommandError, CommandSuccess};
+use anyhow::Result;
+use clap::Args;
+use qlty_config::Workspace;
+
+#[derive(Args, Debug, Clone)]
+pub struct Fetch {}
+
+impl Fetch {
+    pub fn execute(&self, _args: &Arguments) -> Result<CommandSuccess, CommandError> {
+        let workspace = Workspace::require_initialized()?;
+        workspace.fetch_sources()?;
+        CommandSuccess::ok()
+    }
+}

--- a/qlty-cli/tests/cmd.rs
+++ b/qlty-cli/tests/cmd.rs
@@ -49,6 +49,11 @@ fn smells_tests() {
 }
 
 #[test]
+fn sources_tests() {
+    setup_and_run_test_cases("tests/cmd/sources/**/*.toml");
+}
+
+#[test]
 fn coverage_tests() {
     setup_and_run_test_cases("tests/cmd/coverage/**/*.toml");
 }

--- a/qlty-cli/tests/cmd/sources/fetch.in/.gitignore
+++ b/qlty-cli/tests/cmd/sources/fetch.in/.gitignore
@@ -1,0 +1,1 @@
+.qlty/sources

--- a/qlty-cli/tests/cmd/sources/fetch.in/.qlty/qlty.toml
+++ b/qlty-cli/tests/cmd/sources/fetch.in/.qlty/qlty.toml
@@ -1,0 +1,5 @@
+config_version = "0"
+
+[[source]]
+name = "default"
+default = true

--- a/qlty-cli/tests/cmd/sources/fetch.toml
+++ b/qlty-cli/tests/cmd/sources/fetch.toml
@@ -1,0 +1,5 @@
+bin.name = "qlty"
+args = ["sources", "fetch", "--no-upgrade-check"]
+stdout = ""
+stderr = ""
+status.code = 0


### PR DESCRIPTION
## Summary

- Adds a new `qlty sources fetch` command to fetch plugin sources
- Minimal implementation that only requires an initialized workspace and fetches sources
- Useful for CI/CD pipelines or pre-fetching sources before running other commands

## Test plan

- [x] `cargo check` passes
- [x] `qlty sources --help` shows the new command
- [x] `qlty sources fetch --help` shows the fetch subcommand
- [x] `qlty sources fetch` executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)