### PR TITLE
fix(ci): add id-token permission to release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,9 @@ jobs:
   release:
     needs: [compile, extra]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.commits[0].author.name == 'qlty-releases[bot]' && startsWith(github.event.commits[0].message, 'Release ') }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/release.yml
     with:
       workflow_run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Seems like we introduced a regression in https://github.com/qltysh/qlty/pull/2654
Example https://github.com/qltysh/qlty/actions/runs/21718820289

## Summary
- Adds `id-token: write` permission to the `release` job in `build.yml`
- Fixes workflow validation error: "The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'"
- The permission is required because `release.yml` uses AWS OIDC authentication via `configure-aws-credentials`

## Test plan
- [ ] Verify the workflow passes GitHub's validation
- [ ] Confirm release workflow can authenticate with AWS when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)