### PR TITLE
feat(cli): add --skip-source-fetch flag to check command

### DIFF
--- a/qlty-cli/src/commands/check.rs
+++ b/qlty-cli/src/commands/check.rs
@@ -139,6 +139,10 @@ pub struct Check {
     /// Install tools only, do not run checks
     #[arg(long)]
     install_only: bool,
+
+    /// Skip fetching sources before running checks
+    #[arg(long)]
+    skip_source_fetch: bool,
 }
 
 impl Check {
@@ -146,7 +150,10 @@ impl Check {
         self.validate_options()?;
 
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
+
+        if !self.skip_source_fetch {
+            workspace.fetch_sources()?;
+        }
 
         let git_hook_stdin = if self.upstream_from_pre_push {
             match Self::read_pre_push_stdin()? {


### PR DESCRIPTION
## Summary
- Adds a new `--skip-source-fetch` flag to the `check` command
- When passed, skips the source fetching step before running checks
- Useful when sources have already been fetched or in CI environments where source fetching is not needed

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `qlty fmt` passes
- [x] `qlty check --level=low` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)