### PR TITLE
feat(cli): add --skip-source-fetch flag to fmt command

### DIFF
--- a/qlty-cli/src/commands/fmt.rs
+++ b/qlty-cli/src/commands/fmt.rs
@@ -54,6 +54,10 @@ pub struct Fmt {
 
     /// Files to analyze
     pub paths: Vec<PathBuf>,
+
+    /// Skip fetching sources before formatting
+    #[arg(long)]
+    skip_source_fetch: bool,
 }
 
 impl Fmt {
@@ -61,7 +65,10 @@ impl Fmt {
         self.validate_options()?;
 
         let workspace = Workspace::require_initialized()?;
-        workspace.fetch_sources()?;
+
+        if !self.skip_source_fetch {
+            workspace.fetch_sources()?;
+        }
 
         let settings = self.build_settings()?;
         let plan = Planner::new(ExecutionVerb::Fmt, &settings)?.compute()?;


### PR DESCRIPTION
## Summary
- Adds a new `--skip-source-fetch` flag to the `fmt` command
- When passed, skips the source fetching step before formatting
- Consistent with the same flag on the `check` command

## Test plan
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)