### PR TITLE
fix(php): isolate composer cache per tool to prevent race conditions

### DIFF
--- a/qlty-check/src/tool/php.rs
+++ b/qlty-check/src/tool/php.rs
@@ -204,6 +204,17 @@ impl Tool for PhpPackage {
             "COMPOSER_VENDOR_DIR".to_string(),
             path_to_native_string(PathBuf::from(format!("{}/vendor", self.directory()))),
         );
+        env.insert(
+            "COMPOSER_HOME".to_string(),
+            path_to_native_string(PathBuf::from(format!("{}/.composer", self.directory()))),
+        );
+        env.insert(
+            "COMPOSER_CACHE_DIR".to_string(),
+            path_to_native_string(PathBuf::from(format!(
+                "{}/.composer-cache",
+                self.directory()
+            ))),
+        );
         Ok(env)
     }
 }

--- a/qlty-check/src/tool/php/composer.rs
+++ b/qlty-check/src/tool/php/composer.rs
@@ -94,7 +94,7 @@ impl Composer {
                 ],
             )
             .dir(php_package.directory())
-            .full_env(self.env()?)
+            .full_env(php_package.env()?)
             .stderr_capture()
             .stdout_capture()
             .unchecked(); // Capture output for debugging


### PR DESCRIPTION
## Summary
- Adds `COMPOSER_HOME` and `COMPOSER_CACHE_DIR` env vars to `PhpPackage` to isolate each tool's composer cache in its own directory
- Changes `install_package_file()` to use `php_package.env()` instead of `self.env()` so the composer update command runs with the isolated cache directories

## Problem
When multiple PHP tools (phpstan, php-codesniffer, etc.) are installed in parallel, they all run composer which tries to clone repositories to the shared global cache at `~/.composer/cache/vcs/`. This causes intermittent failures due to race conditions when multiple processes try to clone the same repository simultaneously.

## Test plan
- [x] Existing tests pass
- [ ] Test with parallel PHP tool installation in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)