### PR TITLE
fix: use push-by-digest for multi-platform Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,9 +76,8 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           platforms: ${{ matrix.platform }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
The current workflow pushes each platform build with tags, causing a race
  condition where the last completing build overwrites the previous one.
  This results in single-architecture manifests instead of multi-arch.

  For example, inspecting current tags shows:
  - main: only arm64
  - latest: only amd64
  - v0.609.0: only arm64

  The fix removes `tags` and `push` from the build job and uses
  `push-by-digest=true` instead. This ensures each platform only pushes
  its digest, and tags are only applied by the merge job when creating
  the unified multi-platform manifest.