### PR TITLE
fix(docker): remove push-to-registry for attestation with push-by-digest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,7 +77,6 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
 
       - name: Export digest
         run: |


### PR DESCRIPTION
## Summary

- Fixes Docker build workflow failing at "Generate Artifact Attestation" step
- When using `push-by-digest=true`, the image manifest is only accessible by its content-addressable digest
- The attestation action's `push-to-registry` option fails because it cannot find the manifest at that digest in the expected format (returns 404)

## Changes

- Remove `push-to-registry: true` from the attestation step in the build job
- Attestations are still created in GitHub's attestation store and can be verified via `gh attestation verify`

## Test plan

- [ ] Verify Docker workflow passes on this branch
- [ ] Verify attestations are still created in GitHub's attestation store

🤖 Generated with [Claude Code](https://claude.com/claude-code)