### PR TITLE
fix(docker): use GitHub Actions variable for IMAGE_NAME in manifest step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -135,7 +135,7 @@ jobs:
         working-directory: ${{ runner.temp }}/digests
         run: |-
           tags=($(jq -cr '[.tags[] | "-t \(.)"] | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON"))
-          images=($(printf '${{ env.REGISTRY }}/${IMAGE_NAME}@sha256:%s ' *))
+          images=($(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *))
           echo tags: "${tags[@]}"
           echo images: "${images[@]}" 
           docker buildx imagetools create "${tags[@]}" "${images[@]}"
@@ -146,8 +146,6 @@ jobs:
 
           echo "Image digest: $DIGEST"
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
-        env:
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
 
       # confirm merged image manifests
       - name: Inspect Image Manifests


### PR DESCRIPTION
## Summary

- Fixes Docker workflow failure in "Create Manifests and Push" step
- The shell variable `${IMAGE_NAME}` was inside single quotes, so bash did not expand it
- Changed to use `${{ env.IMAGE_NAME }}` GitHub Actions syntax for proper variable expansion

## Error

```
images: ghcr.io/${IMAGE_NAME}@sha256:...
ERROR: failed to parse source "ghcr.io/${IMAGE_NAME}@sha256:...", valid sources are digests, references and descriptors: invalid reference format: repository name (${IMAGE_NAME}@sha256) must be lowercase
```

## Test plan

- [ ] Verify Docker workflow passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)