### PR TITLE
fix(docker): disable buildx provenance/sbom for push-by-digest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,6 +71,8 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
 
       - name: Generate Artifact Attestation
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a


### PR DESCRIPTION
## Summary

- Fixes Docker workflow failure in "Create Manifests and Push" step where digests are not found in registry
- When buildx provenance is enabled (default), the output digest is a manifest list wrapping both the platform image and attestation manifests
- This manifest list isn't directly accessible in the registry, causing the merge step to fail with "not found"
- Disabling `provenance` and `sbom` ensures the output digest is the actual platform manifest
- Provenance is already handled separately by the `actions/attest-build-provenance` step

## Error

```
ERROR: ghcr.io/qltysh/qlty@sha256:d55dc8a875052a351b9603c40e52214436da67101737752c547949b81838b3d1: not found
```

## Test plan

- [ ] Verify Docker workflow passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)