### PR TITLE
fix(docker): add push=true to outputs for push-by-digest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false


### PR DESCRIPTION
## Summary

- Fixes Docker workflow failure where digests are "not found" in the registry
- Without `push=true` in the `outputs` parameter, `type=image` only exports locally and doesn't push to the container registry
- The merge step then fails because it can't find the digests in the registry
- Matches the [canonical Docker multi-platform workflow](https://docs.docker.com/build/ci/github-actions/multi-platform/)

## Error

```
ERROR: ghcr.io/qltysh/qlty@sha256:...: not found
```

## Test plan

- [ ] Verify Docker workflow passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)