### PR TITLE
fix(coverage): fetch sources before loading config in coverage publish

### DIFF
--- a/qlty-cli/src/commands/coverage/utils.rs
+++ b/qlty-cli/src/commands/coverage/utils.rs
@@ -13,7 +13,10 @@ const OIDC_REGEX: &str = r"^([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_]+)\.([a-zA-Z0-9\-_
 
 pub fn load_config() -> QltyConfig {
     Workspace::new()
-        .and_then(|workspace| workspace.config())
+        .and_then(|workspace| {
+            workspace.fetch_sources()?;
+            workspace.config()
+        })
         .unwrap_or_default()
 }
 


### PR DESCRIPTION
## Summary

- `qlty coverage publish` was not calling `fetch_sources()` before loading the config, unlike every other config-consuming command (`check`, `fmt`, `smells`, `metrics`, `install`, etc.)
- This meant that coverage ignore patterns defined in a shared source's `source.toml` were silently dropped because the source was never fetched to disk
- Since `.qlty/sources/` is gitignored, a fresh CI clone has no sources available, so `load_config()` would fall through to `QltyConfig::default()` via `unwrap_or_default()`, losing all coverage exclusion patterns from shared sources

## Test plan

- [x] All 247 `qlty-coverage` unit tests pass
- [x] All 12 coverage integration tests pass (`cmd::coverage_tests`)
- [x] `cargo check` passes
- [x] `qlty fmt` — no changes needed
- [x] `qlty check --level=low` — no issues
- [ ] Verify with project that coverage ignores from their shared `source.toml` are now applied during `qlty coverage publish` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)