### PR TITLE
fix(config): include underlying error in symlink failure log messages

### DIFF
--- a/qlty-config/src/library.rs
+++ b/qlty-config/src/library.rs
@@ -257,22 +257,24 @@ impl Library {
         if !link.exists() {
             #[cfg(unix)]
             {
-                if std::os::unix::fs::symlink(target, link).is_err() {
+                if let Err(err) = std::os::unix::fs::symlink(target, link) {
                     error!(
-                        "Failed to create symlink from {} to {}",
+                        "Failed to create symlink from {} to {}: {}",
                         target.display(),
-                        link.display()
+                        link.display(),
+                        err
                     );
                 }
             }
 
             #[cfg(windows)]
             {
-                if std::os::windows::fs::symlink_dir(target, link).is_err() {
+                if let Err(err) = std::os::windows::fs::symlink_dir(target, link) {
                     error!(
-                        "Failed to create symlink from {} to {}",
+                        "Failed to create symlink from {} to {}: {}",
                         target.display(),
-                        link.display()
+                        link.display(),
+                        err
                     );
                 }
             }


### PR DESCRIPTION
## Summary
- Symlink failure log messages in `Library::try_symlink_if_missing` were discarding the original OS error (e.g., "Permission denied", "File exists")
- Changed `.is_err()` to `if let Err(err)` and appended the error to the log message on both Unix and Windows paths
- No behavior change — failures are still logged and execution continues

## Test plan
- [x] `cargo check` passes
- [x] `cargo test -p qlty-config` — all 97 tests pass
- [x] `qlty fmt` and `qlty check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)