### PR TITLE
fix(trivy): remove suggested arg from drivers

### DIFF
--- a/qlty-plugins/plugins/linters/trivy/plugin.toml
+++ b/qlty-plugins/plugins/linters/trivy/plugin.toml
@@ -26,7 +26,6 @@ output = "stdout"
 output_format = "trivy_sarif"
 cache_results = true
 batch = false
-suggested = "targets"
 output_missing = "parse"
 
 [plugins.definitions.trivy.drivers.fs-secret]
@@ -54,7 +53,6 @@ output = "stdout"
 output_format = "trivy_sarif"
 cache_results = true
 batch = false
-suggested = "targets"
 output_missing = "parse"
 
 [[plugins.definitions.trivy.environment]]


### PR DESCRIPTION
## Summary

- Removes `suggested = "targets"` from `fs-vuln` and `config` drivers in `plugin.toml`

## Motivation

The `suggested` field causes trivy to be automatically enabled in auto-generated configs. There is no workaround for users who don't want it enabled, so removing it prevents unexpected opt-in behavior.

## Test plan

- [ ] Verify trivy is no longer included in auto-generated configs by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)