### PR TITLE
Skip structure analysis for languages with disabled smells mode

### DIFF
--- a/qlty-smells/src/structure/planner.rs
+++ b/qlty-smells/src/structure/planner.rs
@@ -214,6 +214,10 @@ impl Planner {
                 ),
             };
 
+            if language_plan.issue_mode == IssueMode::Disabled {
+                continue;
+            }
+
             languages.insert(name.to_string(), language_plan);
         }
 


### PR DESCRIPTION
## Summary
- Fixes #2719
- The structure smell planner was not checking whether a language's smells mode was set to `Disabled` before including it in the analysis plan. This meant languages with `mode: disabled` in their smells config were still being analyzed for structure smells.
- Added a check after `language_plan` creation to `continue` (skip the language) when `issue_mode == IssueMode::Disabled`, matching the existing pattern in the duplication planner (`qlty-smells/src/duplication/planner.rs`).

## Test plan
- [ ] Verify that setting `smells.mode: disabled` for a language in `qlty.toml` causes the structure planner to skip that language
- [ ] Verify that languages without disabled mode are still analyzed as before
- [ ] Confirm duplication planner behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)