### PR TITLE
docs: clarify that existing comments should not be removed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@
 - Comprehensive error handling with proper context using `context()` or `with_context()`
 - Use descriptive variable names that clearly express intent
 - Do not add low value comments, let the code speak for itself unless there is something non-obvious
+- Do not remove or modify existing comments unless explicitly asked to
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Add guidance to CLAUDE.md that existing comments should be left untouched unless explicitly asked to remove them
- This is distinct from the existing rule to not add low value comments to new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)