### PR TITLE
fix(check): skip unmatched driver versions instead of failing

### DIFF
--- a/qlty-check/src/planner/config.rs
+++ b/qlty-check/src/planner/config.rs
@@ -123,6 +123,12 @@ fn configure_plugin(
 
         plugin_def.version = Some(enabled_plugin.version.clone());
 
+        if !enabled_plugin.drivers.contains(&ALL.to_string()) {
+            plugin_def
+                .drivers
+                .retain(|driver_name, _| enabled_plugin.drivers.contains(driver_name));
+        }
+
         let mut unmatched_drivers = vec![];
 
         for (driver_name, driver) in plugin_def.drivers.iter_mut() {
@@ -200,11 +206,6 @@ fn configure_plugin(
             .affects_cache
             .extend(enabled_plugin.affects_cache.clone());
 
-        if !enabled_plugin.drivers.contains(&ALL.to_string()) {
-            plugin_def
-                .drivers
-                .retain(|driver_name, _| enabled_plugin.drivers.contains(driver_name));
-        }
         if let Some(TargetMode::UpstreamDiff(_)) = &planner.target_mode {
             if enabled_plugin.skip_upstream.is_none() || enabled_plugin.skip_upstream.unwrap() {
                 plugin_def.drivers.retain(|driver_name, driver| {


### PR DESCRIPTION
## Summary
- When a plugin driver has versioned entries and the enabled plugin version doesn't match any, warn and skip the driver instead of bailing with an error
- This prevents hard failures when a plugin adds new drivers (e.g., a format driver for v2+) while existing users on older versions have all drivers enabled by default

## Test plan
- [x] Added `test_unmatched_driver_version_is_skipped` — verifies matched lint driver is kept while unmatched format driver is removed
- [x] Added `test_matched_driver_version_is_kept` — verifies matched driver is resolved correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)