### PR TITLE
fix(config): update OpenAPI globs to support nested paths

### DIFF
--- a/qlty-config/default.toml
+++ b/qlty-config/default.toml
@@ -310,7 +310,7 @@ globs = ["*.coffee"]
 globs = ["*.swift"]
 
 [file_types.openapi]
-globs = ["openapi.yaml", "openapi.*.yaml"]
+globs = ["**/openapi.yaml", "**/openapi.*.yaml"]
 
 [file_types.scala]
 globs = ["*.scala"]


### PR DESCRIPTION
Fix OpenAPI file type configuration to support `openapi.yaml` and `openapi.*.yaml` anywhere.

- [x] Plugin tests passed with snapshot created (`npm test spectral`).
- [x] Manual testing with a project using Spectral.
