### PR TITLE
fix(coverage): detect branch on Travis CI push builds

### DIFF
--- a/qlty-coverage/src/ci/travisci.rs
+++ b/qlty-coverage/src/ci/travisci.rs
@@ -30,6 +30,7 @@ impl CI for TravisCI {
     fn branch(&self) -> String {
         self.env
             .var("TRAVIS_PULL_REQUEST_BRANCH")
+            .filter(|b| !b.is_empty())
             .or_else(|| self.env.var("TRAVIS_BRANCH"))
             .unwrap_or_default()
     }
@@ -149,6 +150,19 @@ mod test {
             env: Box::new(HashMapEnv::new(env)),
         };
         assert_eq!(&ci.branch(), "feature-branch");
+    }
+
+    #[test]
+    fn branch_push_build_with_empty_pr_branch() {
+        let mut env: HashMap<String, String> = HashMap::default();
+        env.insert("TRAVIS_BRANCH".to_string(), "main".to_string());
+        env.insert("TRAVIS_PULL_REQUEST_BRANCH".to_string(), "".to_string());
+        env.insert("TRAVIS_PULL_REQUEST".to_string(), "false".to_string());
+
+        let ci = TravisCI {
+            env: Box::new(HashMapEnv::new(env)),
+        };
+        assert_eq!(&ci.branch(), "main");
     }
 
     #[test]


### PR DESCRIPTION
Fixes qltysh/cloud#8231.

## Summary

Fix `qlty coverage publish` failing on Travis CI push builds (merge commits, direct pushes to a branch) with:

```
ERROR
> A branch, tag, or pull request must be specified.
> Please provide it using a supported CI provider or with one of
> --override-branch, --override-git-tag, or --override-pr-number
```

PR builds were unaffected — only push builds hit this.

## The bug

`TravisCI::branch()` in `qlty-coverage/src/ci/travisci.rs` reads:

```rust
self.env
    .var("TRAVIS_PULL_REQUEST_BRANCH")
    .or_else(|| self.env.var("TRAVIS_BRANCH"))
    .unwrap_or_default()
```

On a Travis **push build**, `TRAVIS_PULL_REQUEST_BRANCH` is exported as an *empty string*, not unset. `SystemEnv::var()` is `std::env::var(name).ok()`, which returns `Some("")` for set-but-empty vars — so the `Option` is `Some("")`, `.or_else(...)` never fires, the `TRAVIS_BRANCH` fallback is skipped, and `branch()` returns `""`.

With an empty branch, empty `pull_number()` (it's `"false"` on push builds), and empty `git_tag()`, `reference_type` resolves to `Unspecified` and validation at `qlty-cli/src/commands/coverage/utils.rs` aborts the upload.

PR builds work because `TRAVIS_PULL_REQUEST_BRANCH` is populated with the source branch, so the `Some("<branch>")` path returns a valid value.

Reference: [Travis default environment variables](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables).

## The fix

One-line change: filter out the empty string before falling through to `TRAVIS_BRANCH`.

```diff
 fn branch(&self) -> String {
     self.env
         .var("TRAVIS_PULL_REQUEST_BRANCH")
+        .filter(|b| !b.is_empty())
         .or_else(|| self.env.var("TRAVIS_BRANCH"))
         .unwrap_or_default()
 }
```

This mirrors the pattern the same file already uses in `git_tag()` for `TRAVIS_TAG`. PR builds keep working: `TRAVIS_PULL_REQUEST_BRANCH` is non-empty, the filter passes it through unchanged.

## Testing

- Added `branch_push_build_with_empty_pr_branch` — sets `TRAVIS_BRANCH=main`, `TRAVIS_PULL_REQUEST_BRANCH=""`, `TRAVIS_PULL_REQUEST=false` (exactly what Travis exports on a push build) and asserts `branch() == "main"`.
- **Reproduced the bug first**: ran the new test against the *unfixed* code and confirmed it failed with `left: "" right: "main"` — matching the real-world error.
- Applied the fix, new test passes.
- Full `qlty-coverage` suite passes: **255/255 tests, 0 failures**.
- Existing `branch` and `branch_pull_request` tests continue to pass, confirming no regression in the push-without-PR-var and PR-build codepaths.
